### PR TITLE
fix OutOfMemoryError : MetaSpace #49

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,1 @@
+-J-XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
Added `.sbtopts` to solve #49 containing
```
-J-XX:MaxMetaspaceSize=512m
```
