### PR TITLE
[finagle-chirper] Fix for #73 for JDK9+

### DIFF
--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleChirper.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleChirper.scala
@@ -97,17 +97,17 @@ class FinagleChirper extends RenaissanceBenchmark {
 
       val compInt = new Comparator[Integer] {
         override def compare(c1: Integer, c2: Integer): Int = {
-            c1.compareTo(c2);
+          c1.compareTo(c2);
         }
         def naturalOrder(): Comparator[Integer] =
-        return new Comparator[Integer] {
+          return new Comparator[Integer] {
             override def compare(c1: Integer, c2: Integer): Int = {
-                c1.compareTo(c2);
+              c1.compareTo(c2);
             }
             override def reversed(): Comparator[Integer] = {
-                Comparator.reverseOrder[Integer];
+              Comparator.reverseOrder[Integer];
             }
-        }
+          }
       }
 
       counts


### PR DESCRIPTION
Fixed issue #73 throwing `IncompatibleClassChangeError` on finagle-chirper on JDK9+. 

The problem seems to come in JDK9 with the use of static methods in interfaces. 

As for neo4j, I provided a concrete implementation specific to `[Integer]` by reimplementing some methods from `java.lang.Comparator` interface and `java.util.Comparators` class, in Scala.
``` 
// FROM java.util.Comparator interface
 public static <T extends Comparable<? super T>> Comparator<T> naturalOrder() {
          return (Comparator<T>) Comparators.NaturalOrderComparator.INSTANCE;
      }
```
```
// FROM java.util.Comparators class
         enum NaturalOrderComparator implements Comparator<Comparable<Object>> {
               INSTANCE;
               @Override
               public int compare(Comparable<Object> c1, Comparable<Object> c2) {
                   return c1.compareTo(c2);
              }
              @Override
              public Comparator<Comparable<Object>> reversed() {
                  return Comparator.reverseOrder();
               }
           }
```
This results in the following Scala code:
```
val compInt = new Comparator[Integer] {
        override def compare(c1: Integer, c2: Integer): Int = {
            c1.compareTo(c2);
        }
        def naturalOrder(): Comparator[Integer] =
        return new Comparator[Integer] {
            override def compare(c1: Integer, c2: Integer): Int = {
                c1.compareTo(c2);
            }
            override def reversed(): Comparator[Integer] = {
                Comparator.reverseOrder[Integer];
            }
        }
      }
```
and replacing
```
       .max(Comparator.naturalOrder[Integer])
```
with
```
        .max(compInt.naturalOrder())
```

Please review it, as I'm newbie in Scala! Probably it's naively implemented... 