### PR TITLE
delete temporary directories

### DIFF
--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
@@ -90,6 +90,7 @@ class Als extends RenaissanceBenchmark {
       .saveAsTextFile(outputPath.toString)
 
     sc.stop()
+    RenaissanceBenchmark.deleteTempDir(tempDirPath)
   }
 
   def runIteration(c: Config): Unit = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/NaiveBayes.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/NaiveBayes.scala
@@ -103,6 +103,7 @@ class NaiveBayes extends RenaissanceBenchmark {
     )
 
     sc.stop()
+    RenaissanceBenchmark.deleteTempDir(tempDirPath)
   }
 
   def runIteration(c: Config): Unit = {


### PR DESCRIPTION
Added call `deleteTempDir` at the end, for missing ones (`als` and `naive-bayes`).