### PR TITLE
Travis speedup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ jobs:
       script:
         - ./tools/sbt/bin/sbt renaissanceFormatCheck
 
-    #- stage: "Basic checks"
-    #  name: "README.md is up to date"
-    #  script:
-    #    - ./tools/sbt/bin/sbt assembly
-    #    - java -jar ./target/renaissance-0.1.jar --readme && git diff --quiet --exit-code -- README.md CONTRIBUTION.md
+    - stage: "Basic checks"
+      name: "README.md is up to date"
+      script:
+        - ./tools/sbt/bin/sbt assembly
+        - java -jar ./target/renaissance-0.1.jar --readme && git diff --exit-code -- README.md CONTRIBUTION.md
 
     - <<: *bundle
       os: osx


### PR DESCRIPTION
Current Travis setup takes literally hours to complete as we compile the suite for each benchmark separately.

The new configuration is split into the following stages:

* basic checks (formatting and eventually README check - see #33)
* compilation on various JDKs (eventually we might want to add JDK11 and Windows too)
* benchmark execution
    * all benchmarks are run inside one job

The new setup prevents quickly seeing which benchmark failed but it should cut the total build time by 6minutes per each benchmark which I believe is worth it.

I have also added caches as suggested in #68.