### PR TITLE
Website: display page title

### DIFF
--- a/website/_layouts/headers.html
+++ b/website/_layouts/headers.html
@@ -4,6 +4,7 @@
 
 <head>
   <meta charset=utf-8 />
+  <title>{{ page.title }}{% if page.url != "/index.html" %} | Renaissance Suite{% endif %}</title>
   <meta name="keywords" content="benchmarks, JVM, benchmarking suite, concurrency, parallelism, modern" />
   <meta name="description" content="The next-generation benchmarking suite for the JVM." />
   <link rel="icon" type="image/png" href="/favicon.ico?v=4"/>

--- a/website/docs.md
+++ b/website/docs.md
@@ -2,7 +2,7 @@
 layout: mainpage
 projectname: Renaissance Suite
 logoname: mona-lisa-round.png
-title: Renaissance
+title: Documentation
 permalink: /docs.html
 ---
 


### PR DESCRIPTION
Because the page has no `<title>` element now.