### PR TITLE
Travis: limit Java memory (workaround #96)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ refs:
     script:
       - ./tools/sbt/bin/sbt assembly
       - 'java -jar ./target/renaissance-0.1.jar --raw-list | tr -d , >list.txt'
-      - 'for BENCH in `cat list.txt`; do echo "====> $BENCH"; java -jar ./target/renaissance-0.1.jar -r 1 "$BENCH" || exit 1; done'
+      - 'for BENCH in `cat list.txt`; do echo "====> $BENCH"; java -Xms2500M -Xmx2500M -jar ./target/renaissance-0.1.jar -r 1 "$BENCH" || exit 1; done'
 
 jobs:
   include:


### PR DESCRIPTION
With this setting, all benchmarks should pass even on Travis.