### PR TITLE
Add group all, listing changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ refs:
     stage: benchmark
     script:
       - ./tools/sbt/bin/sbt assembly
-      - 'java -jar ./target/renaissance-0.1.jar --raw-list | tr -d , >list.txt'
+      - 'java -jar ./target/renaissance-0.1.jar --raw-list >list.txt'
       - 'for BENCH in `cat list.txt`; do echo "====> $BENCH"; java -Xms2500M -Xmx2500M -jar ./target/renaissance-0.1.jar -r 1 "$BENCH" || exit 1; done'
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Usage: renaissance [options] [benchmark-specification]
   --json <value>           Output results to JSON file.
   --readme                 Regenerates the README file, and does not run anything.
   --list                   Print list of benchmarks with their description.
-  --raw-list               Print list of benchmarks, each benchmark name on separate line.
-  --group-list             Print list of benchmark groups.
+  --raw-list               Print list of benchmarks (each benchmark name on separate line).
+  --group-list             Print list of benchmark groups (each group name on separate line).
   benchmark-specification  Comma-separated list of benchmarks (or groups) that must be executed (or all).
 ```
 

--- a/renaissance-harness/src/main/scala/org/renaissance/renaissance-suite.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/renaissance-suite.scala
@@ -247,10 +247,10 @@ object RenaissanceSuite {
         .text("Print list of benchmarks with their description.")
         .action((_, c) => c.withList())
       opt[Unit]("raw-list")
-        .text("Print list of benchmarks, each benchmark name on separate line.")
+        .text("Print list of benchmarks (each benchmark name on separate line).")
         .action((_, c) => c.withRawList())
       opt[Unit]("group-list")
-        .text("Print list of benchmark groups.")
+        .text("Print list of benchmark groups (each group name on separate line).")
         .action((_, c) => c.withGroupList())
       arg[String]("benchmark-specification")
         .text("Comma-separated list of benchmarks (or groups) that must be executed (or all).")
@@ -290,7 +290,7 @@ object RenaissanceSuite {
     } else if (config.printList) {
       print(formatBenchmarkList)
     } else if (config.printRawList) {
-      print(formatRawBenchmarkList)
+      println(formatRawBenchmarkList)
     } else if (config.printGroupList) {
       println(formatGroupList)
     } else if (config.benchmarkSpecifiers.isEmpty) {
@@ -382,7 +382,7 @@ object RenaissanceSuite {
     return result.asInstanceOf[RenaissanceBenchmark]
   }
 
-  private def formatRawBenchmarkList(): String = benchmarks.toSeq.sorted.mkString(", ")
+  private def formatRawBenchmarkList(): String = benchmarks.toSeq.sorted.mkString("\n")
 
   private def formatBenchmarkList(): String = {
     val indent = "    "
@@ -400,7 +400,7 @@ object RenaissanceSuite {
     return result.toString
   }
 
-  private def formatGroupList(): String = groupBenchmarks.keys.toSeq.sorted.mkString(", ")
+  private def formatGroupList(): String = groupBenchmarks.keys.toSeq.sorted.mkString("\n")
 
   private def generateBenchmarkDescription(name: String): String = {
     val bench = benchmarkDetails(name)


### PR DESCRIPTION
Added special group `all' to run all benchmarks. As noted in discussion to #42, we should somewhere specify that valid runs should run only single benchmark.

Also reverted to one item per line in `--*-list` commands a it is much easire to (a) use it in shell scripts and (b) find specific name in the list (also updated help text).
