### PR TITLE
Keep version at one place only

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For example, you can specify `scala-kmeans` as the benchmark.
 The following is a complete list of command-line options.
 
 ```
-Renaissance Benchmark Suite 0.1
+Renaissance Benchmark Suite 0.9.0
 Usage: renaissance [options] [benchmark-specification]
 
   --help                   Prints this usage text.

--- a/build.sbt
+++ b/build.sbt
@@ -234,6 +234,11 @@ lazy val renaissance: Project = {
       remoteDebug := false,
       nonGplOnly := false,
       setupPrePush := addLink(file("tools") / "pre-push", file(".git") / "hooks" / "pre-push"),
+      packageOptions := Seq(
+        sbt.Package.ManifestAttributes(
+          ("Renaissance-Version", renaissanceVersion)
+        )
+      ),
       // Configure fat JAR: specify its name, main(), do not run tests when
       // building it and raise error on file conflicts.
       assemblyJarName in assembly := "renaissance-" + renaissanceVersion + ".jar",

--- a/renaissance-core/src/main/java/org/renaissance/MetaInfo.java
+++ b/renaissance-core/src/main/java/org/renaissance/MetaInfo.java
@@ -1,0 +1,31 @@
+package org.renaissance;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.jar.Manifest;
+import java.util.jar.Attributes;
+
+public class MetaInfo {
+  private static final String UNKNOWN_VERSION = "?.?.?";
+
+  public static String getRenaissanceVersion() {
+    InputStream manifestStream = MetaInfo.class.getResourceAsStream("/META-INF/MANIFEST.MF");
+    if (manifestStream == null) {
+      return UNKNOWN_VERSION;
+    }
+
+    try {
+      Manifest manifest = new Manifest(manifestStream);
+      Attributes mainAttributes = manifest.getMainAttributes();
+      String version = mainAttributes.getValue("Renaissance-Version");
+      manifestStream.close();
+
+      if (version == null) {
+        return UNKNOWN_VERSION;
+      }
+      return version;
+    } catch (IOException e) {
+      return UNKNOWN_VERSION;
+    }
+  }
+}

--- a/renaissance-harness/src/main/scala/org/renaissance/renaissance-suite.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/renaissance-suite.scala
@@ -212,7 +212,7 @@ object RenaissanceSuite {
 
   private val parser: OptionParser[Config] =
     new OptionParser[Config]("renaissance") {
-      head("Renaissance Benchmark Suite", "0.1")
+      head("Renaissance Benchmark Suite", MetaInfo.getRenaissanceVersion)
 
       help("help")
         .text("Prints this usage text.")


### PR DESCRIPTION
Currently, there are plenty of spaces where version information is kept. This PR tries to at least keep in sync version printed by harness and version as determined by the main.sbt.

I am not sure this is the cleanest solution but we have to somehow keep the individual places in sync.

Btw, it also means that the released JARs contain invalid version :-(.