### PR TITLE
Dotty: use OS-specific path separator

### DIFF
--- a/benchmarks/scala-dotty/src/main/scala/org/renaissance/scala/dotty/Dotty.scala
+++ b/benchmarks/scala-dotty/src/main/scala/org/renaissance/scala/dotty/Dotty.scala
@@ -83,7 +83,7 @@ class Dotty extends RenaissanceBenchmark {
       Thread.currentThread.getContextClassLoader
         .asInstanceOf[URLClassLoader]
         .getURLs
-        .mkString(":"),
+        .mkString(File.pathSeparator),
       DOTTY_ARG_TYPE_CONVERSION,
       DOTTY_ARG_CLASS_FILE_DESTINATION,
       outputPath.toString


### PR DESCRIPTION
This caused silent failures when run on Windows.
