### PR TITLE
finagle-http bugfixes (fixes #148, fixes #149)

### DIFF
--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
@@ -132,6 +132,7 @@ class FinagleHttp extends RenaissanceBenchmark {
     threadBarrier = new CountDownLatch(NUM_CLIENTS + 1)
     for (i <- 0 until NUM_CLIENTS) {
       threads(i) = new WorkerThread(port, threadBarrier, NUM_REQUESTS)
+      threads(i).setName(s"finagle-http-worker-$i")
       threads(i).start()
     }
   }

--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
@@ -46,7 +46,9 @@ class FinagleHttp extends RenaissanceBenchmark {
         val request = http.Request(http.Method.Get, "/json")
         request.host = s"localhost:$port"
         val response: Future[http.Response] = client(request)
-        Await.result(response.onSuccess { rep: http.Response =>
+        // Need to use map() instead of onSuccess() as we actually need to
+        // wait for the side-effect, not the original response
+        Await.result(response.map { rep: http.Response =>
           totalContentLength += rep.content.length
         })
       }

--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
@@ -2,6 +2,7 @@ package org.renaissance.twitter.finagle
 
 import java.net.InetSocketAddress
 import java.util.Date
+import java.util.concurrent.CountDownLatch
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
@@ -31,16 +32,38 @@ import org.renaissance.SimpleResult
 @Repetitions(12)
 class FinagleHttp extends RenaissanceBenchmark {
 
+  class WorkerThread(port: Int, barrier: CountDownLatch, requestCount: Int) extends Thread {
+    var totalContentLength = 0L
+
+    override def run(): Unit = {
+      val client: Service[http.Request, http.Response] =
+        com.twitter.finagle.Http.newService(s"localhost:$port")
+
+      barrier.countDown
+      barrier.await
+
+      for (i <- 0 until requestCount) {
+        val request = http.Request(http.Method.Get, "/json")
+        request.host = s"localhost:$port"
+        val response: Future[http.Response] = client(request)
+        Await.result(response.onSuccess { rep: http.Response =>
+          totalContentLength += rep.content.length
+        })
+      }
+      client.close()
+    }
+  }
+
   // TODO: Consolidate benchmark parameters across the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/27
 
   /** Number of requests sent during the execution of the benchmark.
    */
-  var NUM_REQUESTS = 2000000
+  var NUM_REQUESTS = 12000
 
   /** Number of clients that are simultaneously sending the requests.
    */
-  var NUM_CLIENTS = 20
+  var NUM_CLIENTS = 8
 
   /** Manually computed length of one request (see /json handler).
    */
@@ -50,10 +73,13 @@ class FinagleHttp extends RenaissanceBenchmark {
 
   var port: Int = -1
 
+  var threads: Array[WorkerThread] = null
+  var threadBarrier: CountDownLatch = null
+
   override def setUpBeforeAll(c: Config): Unit = {
     if (c.functionalTest) {
-      NUM_REQUESTS = 1000
-      NUM_CLIENTS = 5
+      NUM_REQUESTS = 150
+      NUM_CLIENTS = 2
     }
     val mapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
     val helloWorld: Buf = Buf.Utf8("Hello, World!")
@@ -99,27 +125,27 @@ class FinagleHttp extends RenaissanceBenchmark {
     server.close()
   }
 
+  // Start the threads outside of the measured loop (use count-down latch
+  // to start the work simultaneously)
+  override def beforeIteration(c: Config): Unit = {
+    threads = new Array[WorkerThread](NUM_CLIENTS)
+    threadBarrier = new CountDownLatch(NUM_CLIENTS + 1)
+    for (i <- 0 until NUM_CLIENTS) {
+      threads(i) = new WorkerThread(port, threadBarrier, NUM_REQUESTS)
+      threads(i).start()
+    }
+  }
+
   override def runIteration(c: Config): BenchmarkResult = {
+    // This actually starts the threads (see beforeIteration)
+    threadBarrier.countDown
+
     var totalLength = 0L
     for (i <- 0 until NUM_CLIENTS) {
-      val clientThread = new Thread {
-        override def run(): Unit = {
-          val client: Service[http.Request, http.Response] =
-            com.twitter.finagle.Http.newService(s"localhost:$port")
-          val request = http.Request(http.Method.Get, "/json")
-          request.host = s"localhost:$port"
-          val response: Future[http.Response] = client(request)
-          for (i <- 0 until NUM_REQUESTS) {
-            Await.result(response.onSuccess { rep: http.Response =>
-              totalLength += rep.content.length
-            })
-          }
-          client.close()
-        }
-      }
-      clientThread.start()
-      clientThread.join()
+      threads(i).join()
+      totalLength += threads(i).totalContentLength
     }
+
     return new SimpleResult(
       "total request length",
       NUM_CLIENTS * NUM_REQUESTS * REQUEST_CONTENT_SIZE,

--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
@@ -119,6 +119,13 @@ class FinagleHttp extends RenaissanceBenchmark {
       .withTracer(NullTracer)
       .serve(s":0", serverAndDate.andThen(muxer))
     port = server.boundAddress.asInstanceOf[InetSocketAddress].getPort
+    println(
+      "finagle-http on :%d spawning %d client and %s server workers.".format(
+        port,
+        NUM_CLIENTS,
+        System.getProperty("com.twitter.finagle.netty4.numWorkers", "default number of")
+      )
+    )
   }
 
   override def tearDownAfterAll(c: Config): Unit = {

--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
@@ -63,7 +63,7 @@ class FinagleHttp extends RenaissanceBenchmark {
 
   /** Number of clients that are simultaneously sending the requests.
    */
-  var NUM_CLIENTS = 8
+  var NUM_CLIENTS = Runtime.getRuntime.availableProcessors
 
   /** Manually computed length of one request (see /json handler).
    */


### PR DESCRIPTION
finagle-http is now sending requests in parallel. Also, the measured part of the benchmark now excludes starting of the threads (there is a barrier to start all the work at once).

Note that the parameters (number of clients and number of requests) were changed to roughly correspond to the previous performance (same order of magnitude).

Also note that this commit changes the performance of the finagle-http benchmark drastically.

This closes #148 and #149 but there still seems to be some other bug as sometimes exactly one request is lost (see Travis links in #151).