### PR TITLE
Reduce the default number of iterations in als

### DIFF
--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
@@ -21,7 +21,7 @@ import scala.util.Random
 @Group("apache-spark")
 @Summary("Runs the ALS algorithm from the Spark MLlib.")
 @Licenses(Array(License.APACHE2))
-@Repetitions(60)
+@Repetitions(30)
 class Als extends RenaissanceBenchmark with SparkUtil {
 
   // TODO: Consolidate benchmark parameters across the suite.


### PR DESCRIPTION
Reported by @tkrodriguez - the default number of iterations in `als` might be set too high.

As far as I can tell, a default of 30 would be sufficient. My run on `Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz`:

```
====== als (apache-spark), iteration 0 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 0 completed (6136.922 ms) ======
====== als (apache-spark), iteration 1 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 1 completed (2745.996 ms) ======
====== als (apache-spark), iteration 2 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 2 completed (2559.419 ms) ======
====== als (apache-spark), iteration 3 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 3 completed (2519.642 ms) ======
====== als (apache-spark), iteration 4 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 4 completed (2771.04 ms) ======
====== als (apache-spark), iteration 5 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 5 completed (2416.153 ms) ======
====== als (apache-spark), iteration 6 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 6 completed (2348.959 ms) ======
====== als (apache-spark), iteration 7 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 7 completed (2254.184 ms) ======
====== als (apache-spark), iteration 8 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 8 completed (2334.291 ms) ======
====== als (apache-spark), iteration 9 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 9 completed (2659.207 ms) ======
====== als (apache-spark), iteration 10 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 10 completed (2607.233 ms) ======
====== als (apache-spark), iteration 11 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 11 completed (2269.047 ms) ======
====== als (apache-spark), iteration 12 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 12 completed (2230.565 ms) ======
====== als (apache-spark), iteration 13 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 13 completed (2240.726 ms) ======
====== als (apache-spark), iteration 14 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 14 completed (2368.87 ms) ======
====== als (apache-spark), iteration 15 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 15 completed (2298.611 ms) ======
====== als (apache-spark), iteration 16 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 16 completed (2503.21 ms) ======
====== als (apache-spark), iteration 17 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 17 completed (2334.358 ms) ======
====== als (apache-spark), iteration 18 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 18 completed (2248.512 ms) ======
====== als (apache-spark), iteration 19 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 19 completed (2251.141 ms) ======
====== als (apache-spark), iteration 20 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 20 completed (2211.475 ms) ======
====== als (apache-spark), iteration 21 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 21 completed (2353.797 ms) ======
====== als (apache-spark), iteration 22 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 22 completed (2304.881 ms) ======
====== als (apache-spark), iteration 23 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 23 completed (2213.912 ms) ======
====== als (apache-spark), iteration 24 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 24 completed (2271.989 ms) ======
====== als (apache-spark), iteration 25 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 25 completed (2288.094 ms) ======
====== als (apache-spark), iteration 26 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 26 completed (2227.659 ms) ======
====== als (apache-spark), iteration 27 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 27 completed (2272.091 ms) ======
====== als (apache-spark), iteration 28 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 28 completed (2232.327 ms) ======
====== als (apache-spark), iteration 29 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 29 completed (2231.661 ms) ======
====== als (apache-spark), iteration 30 started ======
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== als (apache-spark), iteration 30 completed (2232.971 ms) ======
```