### PR TITLE
Fix for finagle-chirper locking problem

### DIFF
--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleChirper.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleChirper.scala
@@ -225,7 +225,6 @@ class FinagleChirper extends RenaissanceBenchmark {
 
   class Cache(val index: Int, val service: Service[Request, Response])
     extends Service[Request, Response] {
-    val lock = new AnyRef
     val cache = new concurrent.TrieMap[String, Buf]
     val count = new AtomicInteger
 


### PR DESCRIPTION
This solves #164. Throughput is fairly close to the previous version, but seems to be slightly better on all VMs I tested.