### PR TITLE
Travis: switch to OpenJDK for Java 11 (fixes #167)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,8 @@ jobs:
     - <<: *bundle
       jdk: oraclejdk9
     - <<: *bundle
-      jdk: oraclejdk11
+      env:
+       - USE_JDK=openjdk11
     - <<: *bundle
       env:
         - USE_JDK=OpenJ9
@@ -66,7 +67,8 @@ jobs:
     - <<: *bench
       jdk: oraclejdk9
     - <<: *bench
-      jdk: oraclejdk11
+      env:
+       - USE_JDK=openjdk11
     # Disabled because of #131
     #- <<: *bench
     #  env:
@@ -85,6 +87,7 @@ before_script:
   - 'if [ -n "$USE_JDK" ]; then wget "https://github.com/sormuras/bach/raw/master/install-jdk.sh" && chmod +x install-jdk.sh; fi'
   - 'if [ -n "$USE_JDK" ]; then export JAVA_HOME="$HOME/$USE_JDK"; fi'
   - 'if [ "$USE_JDK" = "OpenJ9" ]; then ./install-jdk.sh --url "https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=linux&arch=x64&release=latest&heap_size=normal&type=jdk" --target "$JAVA_HOME"; fi'
+  - 'if [ "$USE_JDK" = "openjdk11" ]; then ./install-jdk.sh -f 11 --target "$JAVA_HOME"; fi'
   - 'if [ -n "$USE_JDK" ]; then export PATH="$JAVA_HOME/bin:$PATH"; fi'
 
 cache:


### PR DESCRIPTION
After this change, we compile & run on (`java -version`):

```
openjdk version "11.0.3" 2019-04-16
OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.3+7)
OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.3+7, mixed mode)
```
