### PR TITLE
Add Git revision information

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -167,7 +167,7 @@ lazy val renaissance: Project = {
           // Consider Specification-Version to mark sets of active benchmarks
           ("Git-Head-Commit", git.gitHeadCommit.value.get),
           ("Git-Head-Commit-Date", git.gitHeadCommitDate.value.get),
-          ("Git-Uncommitted-Changes", git.gitUncommittedChanges.value.toString),
+          ("Git-Uncommitted-Changes", git.gitUncommittedChanges.value.toString)
         )
       ),
       // Configure fat JAR: specify its name, main(), do not run tests when

--- a/build.sbt
+++ b/build.sbt
@@ -163,8 +163,11 @@ lazy val renaissance: Project = {
       setupPrePush := addLink(file("tools") / "pre-push", file(".git") / "hooks" / "pre-push"),
       packageOptions := Seq(
         sbt.Package.ManifestAttributes(
-          ("Specification-Title", "Renaissance Benchmark Suite")
+          ("Specification-Title", "Renaissance Benchmark Suite"),
           // Consider Specification-Version to mark sets of active benchmarks
+          ("Git-Head-Commit", git.gitHeadCommit.value.get),
+          ("Git-Head-Commit-Date", git.gitHeadCommitDate.value.get),
+          ("Git-Uncommitted-Changes", git.gitUncommittedChanges.value.toString),
         )
       ),
       // Configure fat JAR: specify its name, main(), do not run tests when

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.6.0-RC2")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.6")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")


### PR DESCRIPTION
Adds `sbt-git` plugin to retrieve Git revision hash and date and stores it into `MANIFEST.MF`. Quite useful when you run several experiments and you want to check which revision you actually used.

It also embeds this information into the JSON output.

After these changes, `MANIFEST-MF` contains also following information:

```ini
Git-Head-Commit: hash-of-the-commit
Git-Head-Commit-Date: 2019-07-04T16:06:00+0200
Git-Uncommitted-Changes: true
```

And the JSON is extended with this fragment:

```json
"suite": {
    "name": "Renaissance Benchmark Suite",
    "git": {
      "commit_hash": "0767866594a84584aa0e1e3859ac0344c86436bf",
      "dirty": "true",
      "commit_date": "2019-07-10T11:02:56+0200"
    },
    "version": "0.10.0"
  }
```