### PR TITLE
Store benchmark failure into JSON (issue #162)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ refs:
       - CACHED_JAR_NAME="$HOME/.prebuilt/"`git rev-parse HEAD`.jar; if [ -e "$CACHED_JAR_NAME" ]; then cp "$CACHED_JAR_NAME" target/renaissance-gpl-$RENAISSANCE_VERSION.jar; else ./tools/sbt/bin/sbt assembly; fi
       - CACHED_JMH_JAR_NAME="$HOME/.prebuilt/"`git rev-parse HEAD`-jmh-assembly.jar; if [ -e "$CACHED_JMH_JAR_NAME" ]; then cp "$CACHED_JMH_JAR_NAME" renaissance-jmh/target/scala-2.12/renaissance-jmh-assembly-$RENAISSANCE_VERSION.jar; else ./tools/sbt/bin/sbt renaissanceJmh/jmh:assembly; fi
       - 'java -version'
-      - 'java -jar ./target/renaissance-gpl-$RENAISSANCE_VERSION.jar --raw-list >list.txt'
+      - 'java -jar ./target/renaissance-gpl-$RENAISSANCE_VERSION.jar --raw-list | grep -v '^dummy' >list.txt'
       - 'for BENCH in `cat list.txt`; do echo "====> $BENCH"; java -Xms2500M -Xmx2500M -jar ./target/renaissance-gpl-$RENAISSANCE_VERSION.jar --functional-test -r 1 "$BENCH" || exit 1; done'
       - 'java -Xms2500M -Xmx2500M -jar ./renaissance-jmh/target/scala-2.12/renaissance-jmh-assembly-$RENAISSANCE_VERSION.jar -wi 0 -i 1 -f 1'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ refs:
       - CACHED_JAR_NAME="$HOME/.prebuilt/"`git rev-parse HEAD`.jar; if [ -e "$CACHED_JAR_NAME" ]; then cp "$CACHED_JAR_NAME" target/renaissance-gpl-$RENAISSANCE_VERSION.jar; else ./tools/sbt/bin/sbt assembly; fi
       - CACHED_JMH_JAR_NAME="$HOME/.prebuilt/"`git rev-parse HEAD`-jmh-assembly.jar; if [ -e "$CACHED_JMH_JAR_NAME" ]; then cp "$CACHED_JMH_JAR_NAME" renaissance-jmh/target/scala-2.12/renaissance-jmh-assembly-$RENAISSANCE_VERSION.jar; else ./tools/sbt/bin/sbt renaissanceJmh/jmh:assembly; fi
       - 'java -version'
-      - 'java -jar ./target/renaissance-gpl-$RENAISSANCE_VERSION.jar --raw-list | grep -v '^dummy' >list.txt'
+      - 'java -jar ./target/renaissance-gpl-$RENAISSANCE_VERSION.jar --raw-list | grep -v "^dummy" >list.txt'
       - 'for BENCH in `cat list.txt`; do echo "====> $BENCH"; java -Xms2500M -Xmx2500M -jar ./target/renaissance-gpl-$RENAISSANCE_VERSION.jar --functional-test -r 1 "$BENCH" || exit 1; done'
       - 'java -Xms2500M -Xmx2500M -jar ./renaissance-jmh/target/scala-2.12/renaissance-jmh-assembly-$RENAISSANCE_VERSION.jar -wi 0 -i 1 -f 1'
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ The following is the complete list of benchmarks, separated into groups.
 
 - `dummy-failing` - A dummy benchmark for testing the harness (fails during iteration). (default repetitions: 20)
 
+- `dummy-setup-failing` - A dummy benchmark for testing the harness (fails during setup). (default repetitions: 20)
+
+- `dummy-teardown-failing` - A dummy benchmark for testing the harness (fails during teardown). (default repetitions: 20)
+
 - `dummy-validation-failing` - A dummy benchmark for testing the harness (fails during validation). (default repetitions: 20)
 
 #### jdk-concurrent
@@ -237,6 +241,8 @@ The following table contains the licensing information of all the benchmarks:
 | dotty | BSD3 | MIT |
 | dummy-empty | MIT | MIT |
 | dummy-failing | MIT | MIT |
+| dummy-setup-failing | MIT | MIT |
+| dummy-teardown-failing | MIT | MIT |
 | dummy-validation-failing | MIT | MIT |
 | finagle-chirper | APACHE2 | MIT |
 | finagle-http | APACHE2 | MIT |

--- a/README.md
+++ b/README.md
@@ -104,7 +104,11 @@ The following is the complete list of benchmarks, separated into groups.
 
 #### dummy
 
-- `dummy` - A dummy benchmark which only serves to test the harness. (default repetitions: 20)
+- `dummy-empty` - A dummy benchmark which only serves to test the harness. (default repetitions: 20)
+
+- `dummy-failing` - A dummy benchmark for testing the harness (fails during iteration). (default repetitions: 20)
+
+- `dummy-validation-failing` - A dummy benchmark for testing the harness (fails during validation). (default repetitions: 20)
 
 #### jdk-concurrent
 
@@ -231,7 +235,9 @@ The following table contains the licensing information of all the benchmarks:
 | db-shootout | APACHE2 | MIT |
 | dec-tree | APACHE2 | MIT |
 | dotty | BSD3 | MIT |
-| dummy | MIT | MIT |
+| dummy-empty | MIT | MIT |
+| dummy-failing | MIT | MIT |
+| dummy-validation-failing | MIT | MIT |
 | finagle-chirper | APACHE2 | MIT |
 | finagle-http | APACHE2 | MIT |
 | fj-kmeans | APACHE2 | MIT |

--- a/benchmarks/dummy/src/main/java/org/renaissance/dummy/DummyEmpty.java
+++ b/benchmarks/dummy/src/main/java/org/renaissance/dummy/DummyEmpty.java
@@ -8,11 +8,11 @@ import org.renaissance.SimpleResult;
 
 import static org.renaissance.Benchmark.*;
 
-@Name("dummy")
+@Name("dummy-empty")
 @Group("dummy")
 @Summary("A dummy benchmark which only serves to test the harness.")
 @Licenses(License.MIT)
-public final class Dummy extends RenaissanceBenchmark {
+public final class DummyEmpty extends RenaissanceBenchmark {
   @Override
   protected BenchmarkResult runIteration(Config config) {
     return new SimpleResult("nothing", 0, 0);

--- a/benchmarks/dummy/src/main/java/org/renaissance/dummy/DummyFailing.java
+++ b/benchmarks/dummy/src/main/java/org/renaissance/dummy/DummyFailing.java
@@ -1,0 +1,27 @@
+package org.renaissance.dummy;
+
+import org.renaissance.Config;
+import org.renaissance.License;
+import org.renaissance.RenaissanceBenchmark;
+import org.renaissance.BenchmarkResult;
+import org.renaissance.SimpleResult;
+
+import static org.renaissance.Benchmark.*;
+
+@Name("dummy-failing")
+@Group("dummy")
+@Summary("A dummy benchmark for testing the harness (fails during iteration).")
+@Licenses(License.MIT)
+public final class DummyFailing extends RenaissanceBenchmark {
+  private int counter = 0;
+
+  @Override
+  protected BenchmarkResult runIteration(Config config) {
+    counter++;
+    if (counter > 1) {
+      throw new AssertionError("Intentionally failing");
+    } else {
+      return new SimpleResult("nothing", 0, 0);
+    }
+  }
+}

--- a/benchmarks/dummy/src/main/java/org/renaissance/dummy/DummySetupFailing.java
+++ b/benchmarks/dummy/src/main/java/org/renaissance/dummy/DummySetupFailing.java
@@ -1,0 +1,25 @@
+package org.renaissance.dummy;
+
+import org.renaissance.Config;
+import org.renaissance.License;
+import org.renaissance.RenaissanceBenchmark;
+import org.renaissance.BenchmarkResult;
+import org.renaissance.SimpleResult;
+
+import static org.renaissance.Benchmark.*;
+
+@Name("dummy-setup-failing")
+@Group("dummy")
+@Summary("A dummy benchmark for testing the harness (fails during setup).")
+@Licenses(License.MIT)
+public final class DummySetupFailing extends RenaissanceBenchmark {
+  @Override
+  public void setUpBeforeAll(Config config) {
+    throw new AssertionError("Intentionally failing");
+  }
+
+  @Override
+  protected BenchmarkResult runIteration(Config config) {
+    return new SimpleResult("nothing", 0, 0);
+  }
+}

--- a/benchmarks/dummy/src/main/java/org/renaissance/dummy/DummyTeardownFailing.java
+++ b/benchmarks/dummy/src/main/java/org/renaissance/dummy/DummyTeardownFailing.java
@@ -1,0 +1,25 @@
+package org.renaissance.dummy;
+
+import org.renaissance.Config;
+import org.renaissance.License;
+import org.renaissance.RenaissanceBenchmark;
+import org.renaissance.BenchmarkResult;
+import org.renaissance.SimpleResult;
+
+import static org.renaissance.Benchmark.*;
+
+@Name("dummy-teardown-failing")
+@Group("dummy")
+@Summary("A dummy benchmark for testing the harness (fails during teardown).")
+@Licenses(License.MIT)
+public final class DummyTeardownFailing extends RenaissanceBenchmark {
+  @Override
+  public void tearDownAfterAll(Config config) {
+    throw new AssertionError("Intentionally failing");
+  }
+
+  @Override
+  protected BenchmarkResult runIteration(Config config) {
+    return new SimpleResult("nothing", 0, 0);
+  }
+}

--- a/benchmarks/dummy/src/main/java/org/renaissance/dummy/DummyValidationFailing.java
+++ b/benchmarks/dummy/src/main/java/org/renaissance/dummy/DummyValidationFailing.java
@@ -1,0 +1,35 @@
+package org.renaissance.dummy;
+
+import org.renaissance.Config;
+import org.renaissance.License;
+import org.renaissance.RenaissanceBenchmark;
+import org.renaissance.BenchmarkResult;
+import org.renaissance.SimpleResult;
+import org.renaissance.ValidationException;
+
+import static org.renaissance.Benchmark.*;
+
+@Name("dummy-validation-failing")
+@Group("dummy")
+@Summary("A dummy benchmark for testing the harness (fails during validation).")
+@Licenses(License.MIT)
+public final class DummyValidationFailing extends RenaissanceBenchmark {
+  private static class FailingValidator implements BenchmarkResult {
+    @Override
+    public void validate() {
+      throw new ValidationException("Intentionally failing");
+    }
+  }
+
+  private int counter = 0;
+
+  @Override
+  protected BenchmarkResult runIteration(Config config) {
+    counter++;
+    if (counter > 1) {
+      return new FailingValidator();
+    } else {
+      return new SimpleResult("nothing", 0, 0);
+    }
+  }
+}

--- a/renaissance-core/src/main/java/org/renaissance/RenaissanceBenchmark.java
+++ b/renaissance-core/src/main/java/org/renaissance/RenaissanceBenchmark.java
@@ -109,6 +109,7 @@ public abstract class RenaissanceBenchmark {
         for (ResultObserver observer : config.resultObservers()) {
           observer.onFailure(name());
         }
+        return t;
       }
     }
   }

--- a/renaissance-core/src/main/java/org/renaissance/RenaissanceBenchmark.java
+++ b/renaissance-core/src/main/java/org/renaissance/RenaissanceBenchmark.java
@@ -96,6 +96,9 @@ public abstract class RenaissanceBenchmark {
       }
       return null;
     } catch (Throwable t) {
+      for (ResultObserver observer : config.resultObservers()) {
+        observer.onFailure(name());
+      }
       return t;
     } finally {
       try {

--- a/renaissance-core/src/main/java/org/renaissance/RenaissanceBenchmark.java
+++ b/renaissance-core/src/main/java/org/renaissance/RenaissanceBenchmark.java
@@ -106,6 +106,9 @@ public abstract class RenaissanceBenchmark {
       } catch (Throwable t) {
         System.err.println("Error during tear-down: " + t.getMessage());
         t.printStackTrace();
+        for (ResultObserver observer : config.resultObservers()) {
+          observer.onFailure(name());
+        }
       }
     }
   }

--- a/renaissance-core/src/main/java/org/renaissance/ResultObserver.java
+++ b/renaissance-core/src/main/java/org/renaissance/ResultObserver.java
@@ -11,5 +11,13 @@ public interface ResultObserver {
    * @param value Actual value.
    */
   public void onNewResult(String benchmark, String metric, long value);
+
+  /** Callback when benchmark fails.
+   *
+   * Serves to e.g. invalidate previous results or marking the run as failed.
+   *
+   * @param benchmark Name of the benchmark.
+   */
+  public void onFailure(String benchmark);
   public void onExit();
 }

--- a/renaissance-core/src/main/java/org/renaissance/ResultObserver.java
+++ b/renaissance-core/src/main/java/org/renaissance/ResultObserver.java
@@ -19,5 +19,6 @@ public interface ResultObserver {
    * @param benchmark Name of the benchmark.
    */
   public void onFailure(String benchmark);
+
   public void onExit();
 }

--- a/renaissance-harness/src/main/scala/org/renaissance/renaissance-suite.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/renaissance-suite.scala
@@ -30,6 +30,7 @@ object RenaissanceSuite {
    */
   abstract class ResultWriter extends ResultObserver {
     val allResults = new mutable.HashMap[String, mutable.Map[String, mutable.ArrayBuffer[Long]]]
+    val failedBenchmarks = new mutable.ArrayBuffer[String]
     val storeHook = new FlushOnShutdownThread(this)
 
     Runtime.getRuntime.addShutdownHook(storeHook)
@@ -57,6 +58,10 @@ object RenaissanceSuite {
       metricStorage += value
     }
 
+    def onFailure(benchmark: String): Unit = {
+      failedBenchmarks += benchmark
+    }
+
     def getBenchmarks: Iterable[String] = {
       allResults.keys
     }
@@ -66,7 +71,7 @@ object RenaissanceSuite {
     }
 
     def getResults()
-      : Iterable[(String, Map[String, mutable.ArrayBuffer[Long]], Iterable[Int])] =
+      : Iterable[(String, Boolean, Map[String, mutable.ArrayBuffer[Long]], Iterable[Int])] =
       for {
         benchName <- getBenchmarks
         benchResults = allResults(benchName)
@@ -74,6 +79,7 @@ object RenaissanceSuite {
       } yield
         (
           benchName,
+          !failedBenchmarks.contains(benchName),
           benchResults.toMap.asInstanceOf[Map[String, mutable.ArrayBuffer[Long]]],
           (0 to maxIndex)
         )
@@ -91,7 +97,7 @@ object RenaissanceSuite {
       }
       csv.append("\n")
 
-      for ((benchmark, results, repetitions) <- getResults) {
+      for ((benchmark, goodRuns, results, repetitions) <- getResults) {
         for (i <- repetitions) {
           val line = new StringBuffer
           line.append(benchmark)
@@ -142,12 +148,12 @@ object RenaissanceSuite {
       val columns = getColumns
 
       val tree = new mutable.HashMap[String, JsValue]
-      tree.update("format_version", 2.toJson)
+      tree.update("format_version", 3.toJson)
       tree.update("benchmarks", getBenchmarks.toList.toJson)
       tree.update("environment", getEnvironment(if (normalTermination) "normal" else "forced"))
 
-      val resultTree = new mutable.HashMap[String, JsValue]
-      for ((benchmark, results, repetitions) <- getResults) {
+      val dataTree = new mutable.HashMap[String, JsValue]
+      for ((benchmark, goodRuns, results, repetitions) <- getResults) {
         val subtree = new mutable.ArrayBuffer[JsValue]
         for (i <- repetitions) {
           val scores = new mutable.HashMap[String, JsValue]
@@ -159,10 +165,13 @@ object RenaissanceSuite {
           }
           subtree += scores.toMap.toJson
         }
-        resultTree.update(benchmark, subtree.toList.toJson)
+        val resultsTree = new mutable.HashMap[String, JsValue]
+        resultsTree.update("results", subtree.toList.toJson)
+        resultsTree.update("termination", (if (goodRuns) "normal" else "failure").toJson)
+        dataTree.update(benchmark, resultsTree.toMap.toJson)
       }
 
-      tree.update("results", resultTree.toMap.toJson)
+      tree.update("data", dataTree.toMap.toJson)
 
       FileUtils.write(
         new File(filename),

--- a/renaissance-harness/src/main/scala/org/renaissance/renaissance-suite.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/renaissance-suite.scala
@@ -148,7 +148,7 @@ object RenaissanceSuite {
       val columns = getColumns
 
       val tree = new mutable.HashMap[String, JsValue]
-      tree.update("format_version", 3.toJson)
+      tree.update("format_version", 4.toJson)
       tree.update("benchmarks", getBenchmarks.toList.toJson)
       tree.update("environment", getEnvironment(if (normalTermination) "normal" else "forced"))
 


### PR DESCRIPTION
This is an attempt to fix #162 (JSON and CSV do not report in any way whether the benchmark failed).

In this PR the information about benchmark outcome is added to JSON. I have not added it to CSV as I see no reasonable way to store it there.

For the purposes of testing, this PR also extends the dummy benchmarks with two failing ones.

The downside is that the code for the output writers is growing in complexity. Hopefully with #81 this functionality could be moved to separate plugins.
