### PR TITLE
Travis: check *.java are in pure ASCII

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,11 @@ jobs:
         - ./tools/sbt/bin/sbt assembly
         - java -jar ./target/renaissance-gpl-$RENAISSANCE_VERSION.jar --readme && git diff --exit-code -- README.md CONTRIBUTION.md
 
+    - stage: "Basic checks"
+      name: "Content encoding of Java sources"
+      script:
+        - "! grep --color -P -n -r '--include=*.java' -e '[^\x00-\x7F]' ."
+
     - <<: *bundle
       os: osx
     - <<: *bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
     - stage: "Basic checks"
       name: "Content encoding of Java sources"
       script:
-        - "! grep --color -P -n -r '--include=*.java' -e '[^\x00-\x7F]' ."
+        - "! grep -P -nH -r '--include=*.java' -e '[^\x00-\x7F]' ."
 
     - <<: *bundle
       os: osx


### PR DESCRIPTION
This should fix #43 where non-ASCII characters caused compilation problems on Mac.