### PR TITLE
Fix broken Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
     - stage: "Basic checks"
       name: "Content encoding of Java sources"
       script:
-        - "if grep -P -nH -r '--include=*.java' -e '[^\x00-\x7F]' .; then false; else true; fi"
+        - ./tools/check-encoding.sh
 
     - <<: *bundle
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
     - stage: "Basic checks"
       name: "Content encoding of Java sources"
       script:
-        - "! grep -P -nH -r '--include=*.java' -e '[^\x00-\x7F]' ."
+        - "if grep -P -nH -r '--include=*.java' -e '[^\x00-\x7F]' .; then false; else true; fi"
 
     - <<: *bundle
       os: osx

--- a/tools/check-encoding.sh
+++ b/tools/check-encoding.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if grep -P -nH -r '--include=*.java' -e '[^\x00-\x7F]' .; then
+    exit 1;
+fi
+


### PR DESCRIPTION
Seems that Travis is not able to parse such easy command as `! grep -P -nH -r '--include=*.java' -e '[^\x00-\x7F]' .` ;-).

Opening this PR to ensure we run Travis again.
