### PR TITLE
Run 1 iteration per iteration

### DIFF
--- a/benchmarks/actors/src/main/scala/org/renaissance/actors/AkkaUct.scala
+++ b/benchmarks/actors/src/main/scala/org/renaissance/actors/AkkaUct.scala
@@ -19,18 +19,12 @@ class AkkaUct extends RenaissanceBenchmark {
   // TODO: Consolidate benchmark parameters across the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/27
 
-  private var numIterations: Int = 10
-
   private var bench: UctAkkaActorBenchmark.UctAkkaActorBenchmark = null
 
   override def setUpBeforeAll(c: Config): Unit = {
     bench = new UctAkkaActorBenchmark.UctAkkaActorBenchmark
     bench.initialize(new Array[String](0))
     AkkaActorState.initialize()
-
-    if (c.functionalTest) {
-      numIterations = 2
-    }
   }
 
   override def tearDownAfterAll(c: Config): Unit = {
@@ -40,9 +34,7 @@ class AkkaUct extends RenaissanceBenchmark {
   }
 
   protected override def runIteration(config: Config): BenchmarkResult = {
-    for (i <- 0 until numIterations) {
-      bench.runIteration()
-    }
+    bench.runIteration()
     // TODO: add proper validation
     return new EmptyResult
   }


### PR DESCRIPTION
For this Akka test we would prefer to run 1 iteration per iteration, not 10, which seems arbitrary. With 1, the JMH version can work better as intended, for example the -w/-r run time options are more effective and help to shorten the overall run time while still reporting a stable score.

In the current JMH form the default run of -f 1 takes 7m20s on my WS. With 1 iteration, I get a stable score in less than 2 minutes on my WS with -w 5 -r 5 -wi 8 -i 8. 

Current default results (takes 7m20):
[
    {   
        "jmhVersion" : "1.21",
        "benchmark" : "org.renaissance.actors.Jmh_AkkaUct.run",
        "mode" : "avgt",
        "threads" : 1,
        "forks" : 1,
        "jvm" : "/opt/jdk-14-b5/bin/java",
        "jvmArgs" : [ 
        ],
        "jdkVersion" : "14-ea",
        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
        "vmVersion" : "14-ea+5-129",
        "warmupIterations" : 24, 
        "warmupTime" : "1 ms",
        "warmupBatchSize" : 1,
        "measurementIterations" : 7,
        "measurementTime" : "1 ms",
        "measurementBatchSize" : 1,
        "primaryMetric" : { 
            "score" : 14042.513736857141,
            "scoreError" : 570.9239920298696,
            "scoreConfidence" : [ 
                13471.589744827272,
                14613.437728887011
            ],
            "scorePercentiles" : { 
                "0.0" : 13578.494304,
                "50.0" : 14043.063298,
                "90.0" : 14362.295723,
                "95.0" : 14362.295723,
                "99.0" : 14362.295723,
                "99.9" : 14362.295723,
                "99.99" : 14362.295723,
                "99.999" : 14362.295723,
                "99.9999" : 14362.295723,
                "100.0" : 14362.295723
            },
            "scoreUnit" : "ms/op",
            "rawData" : [ 
                [
                    14362.295723,
                    14136.824942,
                    13977.926244,
                    13943.900688,
                    13578.494304,
                    14043.063298,
                    14255.090959
                ]
            ]
        },
        "secondaryMetrics" : { 
        }
    }   
]

Results with -w 5 -r 5 -wi 8 -i 8:
[
    {   
        "jmhVersion" : "1.21",
        "benchmark" : "org.renaissance.actors.Jmh_AkkaUct.run",
        "mode" : "avgt",
        "threads" : 1,
        "forks" : 1,
        "jvm" : "/opt/jdk-14-b5/bin/java",
        "jvmArgs" : [ 
        ],
        "jdkVersion" : "14-ea",
        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
        "vmVersion" : "14-ea+5-129",
        "warmupIterations" : 8,
        "warmupTime" : "5 s",
        "warmupBatchSize" : 1,
        "measurementIterations" : 8,
        "measurementTime" : "5 s",
        "measurementBatchSize" : 1,
        "primaryMetric" : { 
            "score" : 1335.19305690625,
            "scoreError" : 56.70632219472169,
            "scoreConfidence" : [ 
                1278.4867347115282,
                1391.8993791009716
            ],
            "scorePercentiles" : { 
                "0.0" : 1289.088368,
                "50.0" : 1330.37029375,
                "90.0" : 1379.36255725,
                "95.0" : 1379.36255725,
                "99.0" : 1379.36255725,
                "99.9" : 1379.36255725,
                "99.99" : 1379.36255725,
                "99.999" : 1379.36255725,
                "99.9999" : 1379.36255725,
                "100.0" : 1379.36255725
            },
            "scoreUnit" : "ms/op",
            "rawData" : [ 
                [
                    1321.01475675,
                    1330.72075725,
                    1368.5955805,
                    1379.36255725,
                    1312.82309025,
                    1289.088368,
                    1330.01983025,
                    1349.919515
                ]
            ]
        },
        "secondaryMetrics" : { 
        }
    }   
]

Thanks,
Eric
