### PR TITLE
ubench-agent plugin [WiP]

### DIFF
--- a/plugins/ubench-agent/.gitignore
+++ b/plugins/ubench-agent/.gitignore
@@ -1,0 +1,2 @@
+/ubench-agent-repo/
+libubench-agent.so

--- a/plugins/ubench-agent/.gitignore
+++ b/plugins/ubench-agent/.gitignore
@@ -1,2 +1,3 @@
-/ubench-agent-repo/
 libubench-agent.so
+/java-ubench-agent-*/
+/java-ubench-agent-*.tar.gz

--- a/plugins/ubench-agent/build-ubench-agent.sh
+++ b/plugins/ubench-agent/build-ubench-agent.sh
@@ -6,13 +6,16 @@ msg() {
     echo "[build-ubench-agent]:" "$@" >&2
 }
 
-UBENCH_AGENT_DIR="ubench-agent-repo"
+UBENCH_AGENT_COMMIT="5e8473dbc4d38948dc2d680b5fdf0775824ad40f"
+UBENCH_AGENT_TARBALL="java-ubench-agent-$UBENCH_AGENT_COMMIT.tar.gz"
+UBENCH_AGENT_TARBALL_URL="https://github.com/D-iii-S/java-ubench-agent/archive/$UBENCH_AGENT_COMMIT.tar.gz"
+UBENCH_AGENT_DIR="java-ubench-agent-$UBENCH_AGENT_COMMIT"
 
 msg "Fetching sources..."
+wget --continue -O "$UBENCH_AGENT_TARBALL" "$UBENCH_AGENT_TARBALL_URL"
 if ! [ -d "$UBENCH_AGENT_DIR" ]; then
-    git clone https://github.com/D-iii-S/java-ubench-agent.git "$UBENCH_AGENT_DIR"
-else
-    ( cd "$UBENCH_AGENT_DIR"; git pull )
+    msg "Unpacking the tarball..."
+    tar xzf "$UBENCH_AGENT_TARBALL"
 fi
 
 msg "Building agent..."

--- a/plugins/ubench-agent/build-ubench-agent.sh
+++ b/plugins/ubench-agent/build-ubench-agent.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -ueo pipefail
+
+msg() {
+    echo "[build-ubench-agent]:" "$@" >&2
+}
+
+UBENCH_AGENT_DIR="ubench-agent-repo"
+
+msg "Fetching sources..."
+if ! [ -d "$UBENCH_AGENT_DIR" ]; then
+    git clone https://github.com/D-iii-S/java-ubench-agent.git "$UBENCH_AGENT_DIR"
+else
+    ( cd "$UBENCH_AGENT_DIR"; git pull )
+fi
+
+msg "Building agent..."
+pushd "$UBENCH_AGENT_DIR"
+ant lib
+msg "Build succeeded."
+popd
+
+AGENT_NATIVE_FILE=`find $UBENCH_AGENT_DIR/out/lib -name '*agent*' | grep -v '\.jar$'`
+
+msg "Copying agent files..."
+cp -f "$AGENT_NATIVE_FILE" .
+cp -f "$UBENCH_AGENT_DIR/out/lib/ubench-agent.jar" lib
+
+AGENT_NATIVE_FILE=$( realpath $( basename $AGENT_NATIVE_FILE ) )
+
+msg "Add the following to Java command line when starting the suite:"
+msg "  -agentpath:$AGENT_NATIVE_FILE"

--- a/plugins/ubench-agent/build.sbt
+++ b/plugins/ubench-agent/build.sbt
@@ -1,0 +1,19 @@
+lazy val renaissanceCore = RootProject(uri("../../renaissance-core"))
+
+lazy val pluginUbenchAgent = (project in file("."))
+  .settings(
+    name := "plugin-ubenchagent",
+    version := "0.0.1",
+    crossPaths := false,
+    autoScalaLibrary := false,
+    organization := (organization in renaissanceCore).value,
+    assemblyMergeStrategy in assembly := {
+      case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
+      case PathList("org", "renaissance", "plugins", _*) => MergeStrategy.first
+      case PathList("org", "renaissance", _*) => MergeStrategy.discard
+      case _ => MergeStrategy.singleOrError
+    },
+  )
+  .dependsOn(
+    renaissanceCore
+  )

--- a/plugins/ubench-agent/lib/.gitignore
+++ b/plugins/ubench-agent/lib/.gitignore
@@ -1,0 +1,1 @@
+ubench-agent.jar

--- a/plugins/ubench-agent/project/build.properties
+++ b/plugins/ubench-agent/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/plugins/ubench-agent/project/plugins.sbt
+++ b/plugins/ubench-agent/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")

--- a/plugins/ubench-agent/src/main/java/org/renaissance/plugins/ubenchagent/Main.java
+++ b/plugins/ubench-agent/src/main/java/org/renaissance/plugins/ubenchagent/Main.java
@@ -1,0 +1,68 @@
+package org.renaissance.plugins.ubenchagent;
+
+import org.renaissance.Plugin;
+
+import java.util.List;
+
+import cz.cuni.mff.d3s.perf.Measurement;
+import cz.cuni.mff.d3s.perf.BenchmarkResults;
+
+public class Main implements Plugin,
+    Plugin.BenchmarkSetUpListener,
+    Plugin.OperationSetUpListener,
+    Plugin.OperationTearDownListener,
+    Plugin.MeasurementResultPublisher {
+
+  final int eventSet;
+
+  public Main(String[] args) {
+    if (args.length != 1) {
+      warn("One argument should have been provided to the constructor.");
+      eventSet = -1;
+      return;
+    }
+    String[] events = args[0].split(",");
+
+    eventSet = Measurement.createEventSet(1, events);
+  }
+
+  @Override
+  public void afterBenchmarkSetUp(String benchmark) {
+    Measurement.start(eventSet);
+    Measurement.stop(eventSet);
+  }
+
+  @Override
+  public void afterOperationSetUp(String benchmark, int opIndex, boolean isLastOp) {
+    Measurement.start(eventSet);
+  }
+
+  @Override
+  public void beforeOperationTearDown(String benchmark, int opIndex, long harnessDuration) {
+    Measurement.stop(eventSet);
+  }
+
+  @Override
+  public void onMeasurementResultsRequested(String benchmark, int opIndex, Plugin.MeasurementResultListener dispatcher) {
+    BenchmarkResults results = Measurement.getResults(eventSet);
+    String[] events = results.getEventNames();
+    List<long[]> data = results.getData();
+    if (data.size() != 1) {
+      warn("Ignoring invalid data from this loop.");
+      return;
+    }
+    long[] values = data.get(0);
+    if (values.length != events.length) {
+      warn("Ignoring invalid data from this loop.");
+      return;
+    }
+    for (int i = 0; i < values.length; i++) {
+      dispatcher.onMeasurementResult(benchmark, "ubench_agent_" + events[i], values[i]);
+    }
+  }
+
+  private void warn(String msg, Object... args) {
+    System.out.printf("[ubench plugin] WARNING: " + msg + "\n", args);
+  }
+}
+

--- a/plugins/ubench-agent/src/main/java/org/renaissance/plugins/ubenchagent/Main.java
+++ b/plugins/ubench-agent/src/main/java/org/renaissance/plugins/ubenchagent/Main.java
@@ -2,7 +2,9 @@ package org.renaissance.plugins.ubenchagent;
 
 import org.renaissance.Plugin;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import cz.cuni.mff.d3s.perf.Measurement;
 import cz.cuni.mff.d3s.perf.BenchmarkResults;
@@ -16,12 +18,15 @@ public class Main implements Plugin,
   final int eventSet;
 
   public Main(String[] args) {
-    if (args.length != 1) {
-      warn("One argument should have been provided to the constructor.");
+    String[] events = Arrays.stream(args)
+        .flatMap(a -> Arrays.stream(a.split(",")))
+        .collect(Collectors.toList())
+        .toArray(new String[0]);
+    if (events.length == 0) {
+      warn("No events specified, are you sure about this?");
       eventSet = -1;
       return;
     }
-    String[] events = args[0].split(",");
 
     eventSet = Measurement.createEventSet(1, events);
   }

--- a/plugins/ubench-agent/src/main/java/org/renaissance/plugins/ubenchagent/Main.java
+++ b/plugins/ubench-agent/src/main/java/org/renaissance/plugins/ubenchagent/Main.java
@@ -28,7 +28,7 @@ public class Main implements Plugin,
       return;
     }
 
-    eventSet = Measurement.createEventSet(1, events);
+    eventSet = Measurement.createEventSet(1, events, Measurement.THREAD_INHERIT);
   }
 
   @Override

--- a/plugins/ubench-agent/src/main/java/org/renaissance/plugins/ubenchagent/Main.java
+++ b/plugins/ubench-agent/src/main/java/org/renaissance/plugins/ubenchagent/Main.java
@@ -10,9 +10,9 @@ import cz.cuni.mff.d3s.perf.Measurement;
 import cz.cuni.mff.d3s.perf.BenchmarkResults;
 
 public class Main implements Plugin,
-    Plugin.BenchmarkSetUpListener,
-    Plugin.OperationSetUpListener,
-    Plugin.OperationTearDownListener,
+    Plugin.AfterBenchmarkSetUpListener,
+    Plugin.AfterOperationSetUpListener,
+    Plugin.BeforeOperationTearDownListener,
     Plugin.MeasurementResultPublisher {
 
   final int eventSet;


### PR DESCRIPTION
This PR adds a new plugin to enable measurement of hardware counters via [ubench-agent](https://github.com/D-iii-S/java-ubench-agent). The code was originally mentioned in #191.

The plugin is compiled via SBT but user has to first compile the C agent.

After that, following spell runs Renaissance and collects L1 cache misses and wall-clock time.

```shell
java \
    -agentpath:plugins/ubench-agent/libubench-agent.so \
    -jar target/renaissance-gpl-0.10.0.jar \
    --csv output.csv  --json output.json \
    --plugin 'plugins/ubench-agent/target/plugin-ubenchagent-assembly-0.0.1.jar!org.renaissance.plugins.ubenchagent.Main' \
    --with-arg SYS:wallclock-time,PAPI_L1_DCM \
    finagle-http -r 50
```

There are few things to decide/discuss.

* Do we want the plugins in the same repository? Personally, I would prefer separate repositories as it seems cleaner (and more flexible wrt. to updates) but I have no strong opinion on this.
* How do we build dependencies for the plugins? For ubench-agent, we need to build the native agent (the JAR can be probably uploaded to Maven central or similar, but I doubt it would work well for the native libraries). Currently, there is a simple shell script that clones the repository. Not sure if Git submodule would help here.
* I have already opened #194 as the command-line is really long.
