### PR TITLE
WiP: Force GC before measured operation by default

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -31,10 +31,10 @@ import org.renaissance.Benchmark._
 
 @Summary("Runs some performance-critical Java code.")
 final class MyJavaBenchmark extends Benchmark {
-  override def runIteration(config: Config): BenchmarkResult = {
+  override def run(context: BenchmarkContext): BenchmarkResult = {
     // This is the benchmark body, which in this case calls some Java code.
     JavaCode.runSomeJavaCode()
-    // Return object for later validation of the iteration.
+    // Return object for later validation of the operation result.
     return new MyJavaBenchmarkResult()
   }
 }

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Usage: renaissance [options] [benchmark-specification]
   --json <file-path>       Output results to JSON file.
   -c, --configuration <name>
                            Run benchmarks with given named configuration.
-  --force-gc <when>        Force garbage collection 'before', 'after', or 'around' measured operation.
+  --no-forced-gc           Do not force garbage collection before each measured operation.
   --list                   Print list of benchmarks with their description.
   --raw-list               Print list of benchmarks (each benchmark name on separate line).
   --group-list             Print list of benchmark groups (each group name on separate line).
@@ -207,9 +207,10 @@ to provide. This is demonstrated in the following example:
 
 ```scala
 class SimplePlugin extends Plugin
-  with HarnessInitListener
-  with OperationSetUpListener
-  with OperationTearDownListener {
+  with AfterHarnessInitListener
+  with AfterOperationSetUpListener
+  with BeforeOperationTearDownListener {
+
   override def afterHarnessInit() = {
     // Initialize the plugin after the harness finished initializing
   }
@@ -226,13 +227,14 @@ class SimplePlugin extends Plugin
 
 The following interfaces provide common (paired) event types which allow a plugin to hook
 into a specific point in the benchmark execution sequence. They are analogous to common
-annotations known from testing frameworks such as JUnit.
-- `HarnessInitListener`
-- `HarnessShutdownListener`
-- `BenchmarkSetUpListener`
-- `BenchmarkTearDownListener`
-- `OperationSetUpListener`
-- `OperationTearDownListener`
+annotations known from testing frameworks such as JUnit. Harness-level events occur only
+once per the whole execution, benchmark-level events occur once for each benchmark
+executed, and operation-level events occur once for each execution of the measured
+operation.
+- `AfterHarnessInitListener`, `BeforeHarnessShutdownListener`
+- `BeforeBenchmarkSetUpListener`, `AfterBenchmarkTearDownListener`
+- `AfterBenchmarkSetUpListener`, `BeforeBenchmarkTearDownListener`
+- `AfterOperationSetUpListener`, `BeforeOperationTearDownListener`
 
 The following interfaces provide special non-paired event types:
 - `MeasurementResultListener`, intended for plugins that want to receive
@@ -244,7 +246,7 @@ has either failed in some way (the benchmark triggered an exception), or that th
 operation produced a result which failed validation. This means that no measurements results
 will be received.
 
-And finally the following interface are used by the harness to request
+And finally the following interfaces are used by the harness to request
 services from plugins:
 - `MeasurementResultPublisher`, intended for plugins that want to collect
 values of additional metrics around the execution of the benchmark operation. The harness
@@ -254,7 +256,7 @@ the plugin is supposed to use to notify other result listeners about custom meas
 of the benchmark's measured operation. Such a plugin should implement other interfaces to
 get enough information to determine, per-benchmark, whether to execute the measured operation
 or not. The harness calls the `canExecute` method before executing the benchmark's measured
-operation, and will pass the result of `isLast` method to some other events.
+operation, and will pass the result of the `isLast` method to some other events.
 
 To make the harness use an external plugin, it needs to be specified on the command line.
 The harness can load multiple plugins, and each must be enabled using the
@@ -267,10 +269,11 @@ plugin to control benchmark execution. Other than that, policy is treated the sa
 plugin.
 
 When registering plugins for pair events (harness init/shutdown, benchmark set up/tear down,
-operation set up/tear down), the plugins specified earlier "wrap" plugins specified later.
-This means that plugins that need to be the closest to the measured operation need to be
-specified last. Note that this also applies to the execution policy, which would be generally
-specified first, but any order is possible.
+operation set up/tear down), the plugins specified earlier will "wrap" plugins specified later.
+This means that for example plugins that want to collect additional measurements and need to
+invoked as close as possible to the measured operation need to be specified last. Note that
+this also applies to an external execution policy, which would be generally specified first,
+but any order is possible.
 
 Plugins (and policies) can receive additional command line arguments. Each argument must be
 given using the `--with-arg <arg>` option, which appends `<arg>` to the list of arguments for
@@ -418,6 +421,5 @@ We need to do this to, e.g., avoid accidentally resolving the wrong class
 by going through the system class loader (this can easily happen with,
 e.g. Apache Spark and Scala, due to the way that Spark internally resolves some classes).
 
-You can see the further details of the build system in the top-level `build.sbt` file,
-and in the source code of the `RenaissanceSuite` and
-`ModuleLoader` classes.
+You can find further details in the top-level `build.sbt` file, and in the source code of
+the `RenaissanceSuite` and `ModuleLoader` classes.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Usage: renaissance [options] [benchmark-specification]
   --json <file-path>       Output results to JSON file.
   -c, --configuration <name>
                            Run benchmarks with given named configuration.
+  --force-gc <when>        Force garbage collection 'before', 'after', or 'around' measured operation.
   --list                   Print list of benchmarks with their description.
   --raw-list               Print list of benchmarks (each benchmark name on separate line).
   --group-list             Print list of benchmark groups (each group name on separate line).

--- a/renaissance-harness/src/main/java/org/renaissance/harness/EventDispatcher.java
+++ b/renaissance-harness/src/main/java/org/renaissance/harness/EventDispatcher.java
@@ -14,26 +14,39 @@ import java.util.List;
  */
 final class EventDispatcher {
 
-  private final HarnessInitListener[] harnessInitListeners;
-  private final HarnessShutdownListener[] harnessShutdownListeners;
-  private final BenchmarkSetUpListener[] benchmarkSetUpListeners;
-  private final BenchmarkTearDownListener[] benchmarkTearDownListeners;
-  private final OperationSetUpListener[] operationSetUpListeners;
-  private final OperationTearDownListener[] operationTearDownListeners;
+  private final AfterHarnessInitListener[] afterHarnessInitListeners;
+  private final BeforeHarnessShutdownListener[] beforeHarnessShutdownListeners;
+
+  private final BeforeBenchmarkSetUpListener[] beforeBenchmarkSetUpListeners;
+  private final AfterBenchmarkTearDownListener[] afterBenchmarkTearDownListeners;
+
+  private final AfterBenchmarkSetUpListener[] afterBenchmarkSetUpListeners;
+  private final BeforeBenchmarkTearDownListener[] beforeBenchmarkTearDownListeners;
+
+  private final AfterOperationSetUpListener[] afterOperationSetUpListeners;
+  private final BeforeOperationTearDownListener[] beforeOperationTearDownListeners;
+
   private final MeasurementResultListener[] measurementResultListeners;
   private final BenchmarkFailureListener[] benchmarkFailureListeners;
   private final MeasurementResultPublisher[] measurementResultPublishers;
 
 
   private EventDispatcher(Builder builder) {
-    harnessInitListeners = builder.harnessInitListeners.toArray(new HarnessInitListener[0]);
-    harnessShutdownListeners = builder.harnessShutdownListeners.toArray(new HarnessShutdownListener[0]);
-    benchmarkSetUpListeners = builder.benchmarkSetUpListeners.toArray(new BenchmarkSetUpListener[0]);
-    benchmarkTearDownListeners = builder.benchmarkTearDownListeners.toArray(new BenchmarkTearDownListener[0]);
-    operationSetUpListeners = builder.operationSetUpListeners.toArray(new OperationSetUpListener[0]);
-    operationTearDownListeners = builder.operationTearDownListeners.toArray(new OperationTearDownListener[0]);
+    afterHarnessInitListeners = builder.afterHarnessInitListeners.toArray(new AfterHarnessInitListener[0]);
+    beforeHarnessShutdownListeners = builder.beforeHarnessShutdownListeners.toArray(new BeforeHarnessShutdownListener[0]);
+
+    beforeBenchmarkSetUpListeners = builder.beforeBenchmarkSetUpListeners.toArray(new BeforeBenchmarkSetUpListener[0]);
+    afterBenchmarkTearDownListeners = builder.afterBenchmarkTearDownListeners.toArray(new AfterBenchmarkTearDownListener[0]);
+
+    afterBenchmarkSetUpListeners = builder.afterBenchmarkSetUpListeners.toArray(new AfterBenchmarkSetUpListener[0]);
+    beforeBenchmarkTearDownListeners = builder.beforeBenchmarkTearDownListeners.toArray(new BeforeBenchmarkTearDownListener[0]);
+
+    afterOperationSetUpListeners = builder.afterOperationSetUpListeners.toArray(new AfterOperationSetUpListener[0]);
+    beforeOperationTearDownListeners = builder.beforeOperationTearDownListeners.toArray(new BeforeOperationTearDownListener[0]);
+
     measurementResultListeners = builder.measurementResultListeners.toArray(new MeasurementResultListener[0]);
     measurementResultPublishers = builder.measurementResultPublishers.toArray(new MeasurementResultPublisher[0]);
+
     benchmarkFailureListeners = builder.benchmarkFailureListeners.toArray(new BenchmarkFailureListener[0]);
   }
 
@@ -42,28 +55,39 @@ final class EventDispatcher {
   //
 
   void notifyAfterHarnessInit() {
-    for (final HarnessInitListener l : harnessInitListeners) {
+    for (final AfterHarnessInitListener l : afterHarnessInitListeners) {
       l.afterHarnessInit();
     }
   }
 
-
   void notifyBeforeHarnessShutdown() {
-    for (final HarnessShutdownListener l : harnessShutdownListeners) {
+    for (final BeforeHarnessShutdownListener l : beforeHarnessShutdownListeners) {
       l.beforeHarnessShutdown();
     }
   }
 
 
-  void notifyAfterBenchmarkSetUp(final String benchName) {
-    for (final BenchmarkSetUpListener l : benchmarkSetUpListeners) {
-      l.afterBenchmarkSetUp(benchName);
+  void notifyBeforeBenchmarkSetUp(final String benchName) {
+    for (final BeforeBenchmarkSetUpListener l : beforeBenchmarkSetUpListeners) {
+      l.beforeBenchmarkSetUp(benchName);
+    }
+  }
+
+  void notifyAfterBenchmarkTearDown(final String benchName) {
+    for (final AfterBenchmarkTearDownListener l : afterBenchmarkTearDownListeners) {
+      l.afterBenchmarkTearDown(benchName);
     }
   }
 
 
+  void notifyAfterBenchmarkSetUp(final String benchName) {
+    for (final AfterBenchmarkSetUpListener l : afterBenchmarkSetUpListeners) {
+      l.afterBenchmarkSetUp(benchName);
+    }
+  }
+
   void notifyBeforeBenchmarkTearDown(final String benchName) {
-    for (final BenchmarkTearDownListener l : benchmarkTearDownListeners) {
+    for (final BeforeBenchmarkTearDownListener l : beforeBenchmarkTearDownListeners) {
       l.beforeBenchmarkTearDown(benchName);
     }
   }
@@ -72,16 +96,15 @@ final class EventDispatcher {
   void notifyAfterOperationSetUp(
     final String benchName, final int opIndex, final boolean isLastOp
   ) {
-    for (final OperationSetUpListener l : operationSetUpListeners) {
+    for (final AfterOperationSetUpListener l : afterOperationSetUpListeners) {
       l.afterOperationSetUp(benchName, opIndex, isLastOp);
     }
   }
 
-
   void notifyBeforeOperationTearDown(
     final String benchName, final int opIndex, final long durationNanos
   ) {
-    for (final OperationTearDownListener l : operationTearDownListeners) {
+    for (final BeforeOperationTearDownListener l : beforeOperationTearDownListeners) {
       l.beforeOperationTearDown(benchName, opIndex, durationNanos);
     }
   }
@@ -113,14 +136,21 @@ final class EventDispatcher {
   //
 
   static final class Builder {
-    private final List<HarnessInitListener> harnessInitListeners = new ArrayList<>();
-    private final List<HarnessShutdownListener> harnessShutdownListeners = new ArrayList<>();
-    private final List<BenchmarkSetUpListener> benchmarkSetUpListeners = new ArrayList<>();
-    private final List<BenchmarkTearDownListener> benchmarkTearDownListeners = new ArrayList<>();
-    private final List<OperationSetUpListener> operationSetUpListeners = new ArrayList<>();
-    private final List<OperationTearDownListener> operationTearDownListeners = new ArrayList<>();
+    private final List<AfterHarnessInitListener> afterHarnessInitListeners = new ArrayList<>();
+    private final List<BeforeHarnessShutdownListener> beforeHarnessShutdownListeners = new ArrayList<>();
+
+    private final List<BeforeBenchmarkSetUpListener> beforeBenchmarkSetUpListeners = new ArrayList<>();
+    private final List<AfterBenchmarkTearDownListener> afterBenchmarkTearDownListeners = new ArrayList<>();
+
+    private final List<AfterBenchmarkSetUpListener> afterBenchmarkSetUpListeners = new ArrayList<>();
+    private final List<BeforeBenchmarkTearDownListener> beforeBenchmarkTearDownListeners = new ArrayList<>();
+
+    private final List<AfterOperationSetUpListener> afterOperationSetUpListeners = new ArrayList<>();
+    private final List<BeforeOperationTearDownListener> beforeOperationTearDownListeners = new ArrayList<>();
+
     private final List<MeasurementResultListener> measurementResultListeners = new ArrayList<>();
     private final List<MeasurementResultPublisher> measurementResultPublishers = new ArrayList<>();
+
     private final List<BenchmarkFailureListener> benchmarkFailureListeners = new ArrayList<>();
 
     /**
@@ -135,41 +165,40 @@ final class EventDispatcher {
      * @return This {@link Builder}.
      */
     public Builder withPlugin(Plugin plugin) {
-      if (plugin instanceof HarnessInitListener) {
-        harnessInitListeners.add((HarnessInitListener) plugin);
-      }
-      if (plugin instanceof HarnessShutdownListener) {
-        harnessShutdownListeners.add(0, (HarnessShutdownListener) plugin);
-      }
+      appendInstanceOf(plugin, AfterHarnessInitListener.class, afterHarnessInitListeners);
+      prependInstanceOf(plugin, BeforeHarnessShutdownListener.class, beforeHarnessShutdownListeners);
 
-      if (plugin instanceof BenchmarkSetUpListener) {
-        benchmarkSetUpListeners.add((BenchmarkSetUpListener) plugin);
-      }
-      if (plugin instanceof BenchmarkTearDownListener) {
-        benchmarkTearDownListeners.add(0, (BenchmarkTearDownListener) plugin);
-      }
+      appendInstanceOf(plugin, BeforeBenchmarkSetUpListener.class, beforeBenchmarkSetUpListeners);
+      prependInstanceOf(plugin, AfterBenchmarkTearDownListener.class, afterBenchmarkTearDownListeners);
 
-      if (plugin instanceof OperationSetUpListener) {
-        operationSetUpListeners.add((OperationSetUpListener) plugin);
-      }
-      if (plugin instanceof OperationTearDownListener) {
-        operationTearDownListeners.add(0, (OperationTearDownListener) plugin);
-      }
+      appendInstanceOf(plugin, AfterBenchmarkSetUpListener.class, afterBenchmarkSetUpListeners);
+      prependInstanceOf(plugin, BeforeBenchmarkTearDownListener.class, beforeBenchmarkTearDownListeners);
 
-      if (plugin instanceof MeasurementResultListener) {
-        measurementResultListeners.add((MeasurementResultListener) plugin);
-      }
-      if (plugin instanceof MeasurementResultPublisher) {
-        measurementResultPublishers.add((MeasurementResultPublisher) plugin);
-      }
+      appendInstanceOf(plugin, AfterOperationSetUpListener.class, afterOperationSetUpListeners);
+      prependInstanceOf(plugin, BeforeOperationTearDownListener.class, beforeOperationTearDownListeners);
 
-      if (plugin instanceof BenchmarkFailureListener) {
-        benchmarkFailureListeners.add((BenchmarkFailureListener) plugin);
-      }
+      appendInstanceOf(plugin, MeasurementResultListener.class, measurementResultListeners);
+      appendInstanceOf(plugin, MeasurementResultPublisher.class, measurementResultPublishers);
 
+      appendInstanceOf(plugin, BenchmarkFailureListener.class, benchmarkFailureListeners);
       return this;
     }
 
+    private static <T extends Plugin> void prependInstanceOf(
+      Plugin plugin, Class<T> listenerType, List<T> listeners
+    ) {
+      if (listenerType.isInstance(plugin)) {
+        listeners.add(0, listenerType.cast(plugin));
+      }
+    }
+
+    private static <T extends Plugin> void appendInstanceOf(
+      Plugin plugin, Class<T> listenerType, List<T> listeners
+    ) {
+      if (listenerType.isInstance(plugin)) {
+        listeners.add(listenerType.cast(plugin));
+      }
+    }
 
     /**
      * Registers a {@link ResultWriter} into respective listener lists.
@@ -178,7 +207,7 @@ final class EventDispatcher {
      * @return This {@link Builder}.
      */
     public Builder withResultWriter(ResultWriter writer) {
-      harnessShutdownListeners.add(writer);
+      beforeHarnessShutdownListeners.add(writer);
       measurementResultListeners.add(writer);
       benchmarkFailureListeners.add(writer);
       return this;

--- a/renaissance-harness/src/main/java/org/renaissance/harness/ExecutionPlugins.java
+++ b/renaissance-harness/src/main/java/org/renaissance/harness/ExecutionPlugins.java
@@ -1,0 +1,66 @@
+package org.renaissance.harness;
+
+import org.renaissance.Plugin.OperationSetUpListener;
+import org.renaissance.Plugin.OperationTearDownListener;
+
+import java.util.concurrent.TimeUnit;
+
+final class ExecutionPlugins {
+
+  static OperationSetUpListener forceGcBeforeOperationPlugin() {
+    return (benchmark, opIndex, isLastOp) -> {
+      System.out.println("Forcing GC before measured operation.");
+      RuntimeHelper.singleton.collectGarbage();
+    };
+  }
+
+
+  static OperationTearDownListener forceGcAfterOperationPlugin() {
+    return (benchmark, opIndex, isLastOp) -> {
+      System.out.println("Forcing GC after measured operation.");
+      RuntimeHelper.singleton.collectGarbage();
+    };
+  }
+
+
+  private static final class RuntimeHelper {
+    private static final RuntimeHelper singleton = new RuntimeHelper();
+
+    private static final int FORCED_GC_LOOPS_LIMIT = 10;
+    private static final int FORCED_GC_DELAY_SECONDS = 1;
+
+    private final Runtime runtime = Runtime.getRuntime();
+
+    private long getHeapSize() {
+      return runtime.totalMemory() - runtime.freeMemory();
+    }
+
+    private void triggerCollection() {
+      runtime.runFinalization();
+      runtime.gc();
+    }
+
+    long collectGarbage() {
+      final long initialSize = getHeapSize();
+
+      try {
+        GC_LOOP: for (int i = 0; i < FORCED_GC_LOOPS_LIMIT; i++) {
+          final long sizeBefore = getHeapSize();
+          triggerCollection();
+
+          TimeUnit.SECONDS.sleep(FORCED_GC_DELAY_SECONDS);
+
+          if (getHeapSize() >= sizeBefore) {
+            break GC_LOOP;
+          }
+        }
+
+      } catch (InterruptedException e) {
+        // Stop trying to shrink the heap.
+      }
+
+      return initialSize - getHeapSize();
+    }
+  }
+
+}

--- a/renaissance-harness/src/main/java/org/renaissance/harness/ExecutionPolicies.java
+++ b/renaissance-harness/src/main/java/org/renaissance/harness/ExecutionPolicies.java
@@ -16,7 +16,7 @@ final class ExecutionPolicies {
    * of repetitions for a given benchmark.
    */
   static final class FixedOpCount implements ExecutionPolicy,
-    BenchmarkSetUpListener {
+    AfterBenchmarkSetUpListener {
 
     private final ToIntFunction<String> countLimitProvider;
 
@@ -53,7 +53,7 @@ final class ExecutionPolicies {
    * plugins and event listeners.
    */
   static final class FixedTime implements ExecutionPolicy,
-    BenchmarkSetUpListener, OperationTearDownListener {
+    AfterBenchmarkSetUpListener, BeforeOperationTearDownListener {
 
     private final long runTimeNanos;
 
@@ -95,7 +95,7 @@ final class ExecutionPolicies {
    * time of other plugins and event listeners.
    */
   static final class FixedOpTime implements ExecutionPolicy,
-    BenchmarkSetUpListener, OperationTearDownListener {
+    AfterBenchmarkSetUpListener, BeforeOperationTearDownListener {
 
     private final long operationRunTimeNanos;
 

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/Config.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/Config.scala
@@ -28,6 +28,9 @@ private final class Config {
 
   var configuration = "default"
 
+  var forceGcBefore = false
+  var forceGcAfter = false
+
   def withBenchmarkSpecification(v: String) = {
     benchmarkSpecifiers ++= v.split(",").map(_.trim)
     this
@@ -98,6 +101,18 @@ private final class Config {
     this
   }
 
+  def withForcedGc(when: String) = {
+    val lcWhen = when.toLowerCase()
+    if (List("before", "around").contains(lcWhen)) {
+      forceGcBefore = true
+    }
+
+    if (List("after", "around").contains(lcWhen)) {
+      forceGcAfter = true
+    }
+
+    this
+  }
 }
 
 private object PolicyType extends Enumeration {

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/Config.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/Config.scala
@@ -28,8 +28,12 @@ private final class Config {
 
   var configuration = "default"
 
-  var forceGcBefore = false
-  var forceGcAfter = false
+  /**
+   * Force garbage collection before executing the measured operation. This is
+   * enabled by default to avoid accumulating garbage between operations which
+   * can then trigger GC during operation.
+   */
+  var forceGc = true
 
   def withBenchmarkSpecification(v: String) = {
     benchmarkSpecifiers ++= v.split(",").map(_.trim)
@@ -101,16 +105,8 @@ private final class Config {
     this
   }
 
-  def withForcedGc(when: String) = {
-    val lcWhen = when.toLowerCase()
-    if (List("before", "around").contains(lcWhen)) {
-      forceGcBefore = true
-    }
-
-    if (List("after", "around").contains(lcWhen)) {
-      forceGcAfter = true
-    }
-
+  def withoutForcedGc() = {
+    forceGc = false
     this
   }
 }

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ConfigParser.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ConfigParser.scala
@@ -87,16 +87,9 @@ private final class ConfigParser(tags: Map[String, String]) {
         .action((v, c) => c.withConfiguration(v))
         .maxOccurs(1)
 
-      opt[String]("force-gc")
-        .valueName("<when>")
-        .text("Force garbage collection 'before', 'after', or 'around' measured operation.")
-        .validate(v => {
-          val options = List("before", "after", "around")
-          if (options.contains(v.toLowerCase)) success
-          else failure("expected 'before', 'after', or 'around' when forcing GC")
-        })
-        .action((v, c) => c.withForcedGc(v))
-        .unbounded()
+      opt[Unit]("no-forced-gc")
+        .text("Do not force garbage collection before each measured operation.")
+        .action((_, c) => c.withoutForcedGc())
 
       opt[Unit]("list")
         .text("Print list of benchmarks with their description.")

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ConfigParser.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ConfigParser.scala
@@ -87,6 +87,17 @@ private final class ConfigParser(tags: Map[String, String]) {
         .action((v, c) => c.withConfiguration(v))
         .maxOccurs(1)
 
+      opt[String]("force-gc")
+        .valueName("<when>")
+        .text("Force garbage collection 'before', 'after', or 'around' measured operation.")
+        .validate(v => {
+          val options = List("before", "after", "around")
+          if (options.contains(v.toLowerCase)) success
+          else failure("expected 'before', 'after', or 'around' when forcing GC")
+        })
+        .action((v, c) => c.withForcedGc(v))
+        .unbounded()
+
       opt[Unit]("list")
         .text("Print list of benchmarks with their description.")
         .action((_, c) => c.withList)

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
@@ -66,17 +66,13 @@ object RenaissanceSuite {
       }
 
       //
-      // (Optionally) register built-in plugins to force GC before and/or
-      // after execution of the measured operation. These plugins have the
-      // lowest priority and are therefore positioned the farthest from the
-      // measured operation (before/after built-in policies).
+      // (Optionally) register the built-in plugin to force GC before each
+      // measured operation. The plugin has the lowest priority and is the
+      // first to be executed 'before operation', preceding the built-in
+      // policies.
       //
-      if (config.forceGcBefore) {
-        plugins = ExecutionPlugins.forceGcBeforeOperationPlugin() +: plugins
-      }
-
-      if (config.forceGcAfter) {
-        plugins = ExecutionPlugins.forceGcAfterOperationPlugin() +: plugins
+      if (config.forceGc) {
+        plugins = new ExecutionPlugins.ForceGcPlugin() +: plugins
       }
 
       // Initialize result writers (if any).

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
@@ -34,7 +34,7 @@ object RenaissanceSuite {
       case None    => sys.exit(1)
     }
 
-    // Load info on available benchmarks
+    // Load information about available benchmarks.
     val allBenchmarks = BenchmarkRegistry.createDefault()
 
     if (config.printList) {
@@ -48,30 +48,47 @@ object RenaissanceSuite {
     } else {
       val benchmarks = selectBenchmarks(allBenchmarks, config.benchmarkSpecifiers)
 
-      // Load all plugins in given order (including external policy)
-      val plugins = for ((specifier, args) <- config.pluginsWithArgs) yield {
+      // Load all plugins in given order (including external policy).
+      val externalPlugins = for ((specifier, args) <- config.pluginsWithArgs) yield {
         specifier -> createExtension(specifier, args)
       }
 
-      // Get effective execution policy (built-in or external)
-      val policy = getPolicy(config, benchmarks, plugins)
+      //
+      // Get effective execution policy (built-in or external) and if using
+      // a built-in policy, prepend it to list of plugins (external policy
+      // will be among the external plugins specified on the command line).
+      //
+      var plugins = externalPlugins.values.toSeq
 
-      // If using built-in policy, prepend it to list of plugins
-      var pluginsWithPolicy = plugins.values.toSeq
+      val policy = getPolicy(config, benchmarks, externalPlugins)
       if (config.policyType != PolicyType.EXTERNAL) {
-        pluginsWithPolicy = policy +: pluginsWithPolicy
+        plugins = policy +: plugins
       }
 
-      // Initialize result writers (if any)
+      //
+      // (Optionally) register built-in plugins to force GC before and/or
+      // after execution of the measured operation. These plugins have the
+      // lowest priority and are therefore positioned the farthest from the
+      // measured operation (before/after built-in policies).
+      //
+      if (config.forceGcBefore) {
+        plugins = ExecutionPlugins.forceGcBeforeOperationPlugin() +: plugins
+      }
+
+      if (config.forceGcAfter) {
+        plugins = ExecutionPlugins.forceGcAfterOperationPlugin() +: plugins
+      }
+
+      // Initialize result writers (if any).
       val writers = Seq(
         config.csvOutput.map(f => new CsvWriter(f)),
         config.jsonOutput.map(f => new JsonWriter(f))
       ).flatten
 
-      // Register plugins (including policy) and result writers for harness events
-      val dispatcher = createEventDispatcher(pluginsWithPolicy, writers)
+      // Register plugins and result writers for harness events.
+      val dispatcher = createEventDispatcher(plugins, writers)
 
-      // Note: no access to Config beyond this call
+      // Note: no access to Config beyond this point.
       runBenchmarks(benchmarks, config.configuration, policy, dispatcher)
     }
   }

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -5,8 +5,8 @@ import java.nio.charset.StandardCharsets
 
 import org.apache.commons.io.FileUtils
 import org.renaissance.Benchmark
+import org.renaissance.Plugin.BeforeHarnessShutdownListener
 import org.renaissance.Plugin.BenchmarkFailureListener
-import org.renaissance.Plugin.HarnessShutdownListener
 import org.renaissance.Plugin.MeasurementResultListener
 import spray.json._
 import spray.json.DefaultJsonProtocol._
@@ -23,7 +23,7 @@ import scala.collection.mutable
  * actually stores the collected data.
  */
 private abstract class ResultWriter
-  extends HarnessShutdownListener
+  extends BeforeHarnessShutdownListener
   with MeasurementResultListener
   with BenchmarkFailureListener {
 


### PR DESCRIPTION
This provides initial support for forced GC mentioned in #193.

The CLI provides a `--force-gc <when>` option which allows specifying `before`, `after` or `around` in place of `<where>`. The option can be used multiple times, so using `--force-gc before` and `--force-gc after` at the same time has cumulative effect. 

While this is a simple feature, there are a couple of things that should be decided explicitly and which may trigger some other changes -- feedback is therefore welcome.

It is internally implemented as a built-in, lowest-priority plugin (executes first/last in paired notifications) hooked either into the `afterOperationSetUp` (i.e. before operation) or the `beforeOperationTearDown` (i.e. after operation) notification slots. It is also inside the unix-timestamped phase covering operation set up, plugin invocation, the actual operation, plugin invocation (again), and operation tear down. Currently it also currently prints a message *inside* the measured operation bracket (delimited by `=====`). 

Anything described above can be challenged and changed. I would bring your attention to the following:

+ Are we fine the before/after semantics and the position in the execution sequence? 
  - The *before operation* GC executes after operation setup and before operation, so that it can potentially clean garbage produced during operation setup, along with garbage from the previous operation and operation tear down.
  - The *after operation* GC raises a few more questions. If enabled, it executes after operation and before operation tear down, so it may trigger clean up of the "operation garbage" but not "operation tear down garbage".  If used alone, it will also not clean the "operation set up" garbage. 

+ Do we actually need the "force GC after operation" mode?
  - If yes, should it be moved after benchmark tear down? This may require creating an "after operation tear down" notification slot and move it there, or special case it in some other way.

+ Do we want the forced GC to print any message? If yes, when and with what content?

+ Should the forced GC be part of the unix-stamped phase of the execution sequence?

To make the discussion a bit easier, here's the execution sequence for each benchmark after it is instantiated (for reference):

1. call `setUpBeforeAll()` on the benchmark
2. notify plugins in the `afterBenchmarkSetUp` slot
3. repeat executing the measured operation while execution policy says so

    3.1 print `=====` bracket with operation started information

    3.2 take `currentTimeMillis()` (unix) timestamp of the start of the operation-related activities

    3.3 call `setUpBeforeEach()` on the benchmark

    3.4 notify plugins in the `afterOperationSetUp` slot

    - This is where forced GC and built-in policy plugins get executed, *before* all other plugins. 

    3.5 execute the measured operation

      - take `nanoTime()` timestamp of the start of the actual operation  
      - call `run()` on the benchmark
      - take `nanoTime()` timestamp of the end of the actual operation

    3.6 notify plugins in the `beforeOperationTearDown` slot

    - This is where forced GC and built-in policy plugins get executed, *after* all other plugins.

    3.7 call `tearDownAfterEach()` on the benchmark

    3.8 take `currentTimeMillis()` (unix) timestamp of the end of the operation-related activities

    3.9 validate benchmark result

    3.10 publish measured values
    - operation duration (difference between `nanoTime()` timestamps)
    - both phase start and phase end `currentTimeMillis()` (unix) timestamps

    3.11 request measurements from plugins in the `measurementResultsRequested` slot

    3.12 print `=====` bracket with operation completed information

4. notify plugins in the `beforeBenchmarkTearDown` slot
5. call `tearDownAfterAll()` on the benchmark
