### PR TITLE
Avoid unnecessary disk IO and add hash-based validation in page-rank

### DIFF
--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
@@ -138,10 +138,10 @@ final class PageRank extends Benchmark with SparkUtil {
 
         val rankLines = ranks
           .sortByKey()
+          .collect
           .map {
             case (url, rank) => f"$url $rank%.8f"
           }
-          .collect
           .toList
 
         Validators.hashing(expectedRankHashParam, rankLines.asJava).validate()

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
@@ -140,7 +140,7 @@ final class PageRank extends Benchmark with SparkUtil {
           .sortByKey()
           .collect
           .map {
-            case (url, rank) => f"$url $rank%.8f"
+            case (url, rank) => f"$url $rank%.7f"
           }
           .toList
 

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
@@ -1,18 +1,19 @@
 package org.renaissance.apache.spark
 
-import java.nio.charset.StandardCharsets
 import java.nio.file.Path
-import java.nio.file.Paths
+import java.util.regex.Pattern
 
-import org.apache.commons.io.FileUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.renaissance.Benchmark
 import org.renaissance.Benchmark._
 import org.renaissance.BenchmarkContext
 import org.renaissance.BenchmarkResult
+import org.renaissance.BenchmarkResult.Assert
 import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
+
+import scala.collection.JavaConverters._
 
 @Name("page-rank")
 @Group("apache-spark")
@@ -24,14 +25,19 @@ import org.renaissance.License
   Array(
     new Parameter(name = "thread_count", defaultValue = "$cpu.count"),
     new Parameter(name = "input_line_count", defaultValue = "-1"),
-    new Parameter(name = "expected_rank_count", defaultValue = "598652")
+    new Parameter(name = "expected_rank_count", defaultValue = "598652"),
+    new Parameter(name = "expected_rank_hash", defaultValue = "d8bf7171feef1b87")
   )
 )
 @Configurations(
   Array(
     new Configuration(
       name = "test",
-      settings = Array("input_line_count = 5000", "expected_rank_count = 1661")
+      settings = Array(
+        "input_line_count = 5000",
+        "expected_rank_count = 1661",
+        "expected_rank_hash=7ca80582125b8ca7"
+      )
     ),
     new Configuration(name = "jmh")
   )
@@ -47,65 +53,63 @@ final class PageRank extends Benchmark with SparkUtil {
 
   private var expectedRankCountParam: Int = _
 
+  private var expectedRankHashParam: String = _
+
   private val ITERATIONS = 2
 
   // TODO: Unify handling of scratch directories throughout the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/13
 
-  val pageRankPath = Paths.get("target", "page-rank")
-
-  val outputPath = pageRankPath.resolve("output")
-
   val inputZipFile = "web-berkstan.txt.zip"
-
-  val bigInputFile = pageRankPath.resolve("bigfile.txt")
+  val inputFile = "web-BerkStan.txt"
 
   var sc: SparkContext = _
 
   var links: RDD[(String, Iterable[String])] = _
 
-  var ranks: RDD[(String, Double)] = _
-
   var tempDirPath: Path = _
 
-  def prepareInput(c: BenchmarkContext) = {
-    FileUtils.deleteDirectory(pageRankPath.toFile)
-    var inputText = ZipResourceUtil.readZipFromResourceToText(inputZipFile)
-    if (inputLineCountParam >= 0) {
-      inputText = inputText.linesWithSeparators.take(inputLineCountParam).mkString
-    }
-
-    FileUtils.write(bigInputFile.toFile, inputText, StandardCharsets.UTF_8, true)
-  }
-
-  def loadData() = {
-    val lines = sc.textFile(bigInputFile.toString)
-    links = lines
-      .map { line =>
-        val parts = line.split("\\s+")
-        (parts(0), parts(1))
+  def loadData(
+    zipName: String,
+    entryName: String,
+    lineCount: Int
+  ): RDD[(String, Iterable[String])] = {
+    val inputSource = ZipResourceUtil.sourceFromZipResource(entryName, zipName)
+    try {
+      var inputLines = inputSource.getLines()
+      if (lineCount >= 0) {
+        inputLines = inputLines.take(lineCount)
       }
-      .distinct()
-      .groupByKey()
-      .cache()
 
-//    ranks = links.mapValues(v => 1.0)
+      val splitter = Pattern.compile("\\s+")
+      sc.parallelize(inputLines.toSeq)
+        .map { line =>
+          val parts = splitter.split(line)
+          parts(0) -> parts(1)
+        }
+        .distinct()
+        .groupByKey()
+        .cache()
+    } finally {
+      inputSource.close()
+    }
   }
 
   override def setUpBeforeAll(c: BenchmarkContext): Unit = {
     threadCountParam = c.intParameter("thread_count")
-    expectedRankCountParam = c.intParameter("expected_rank_count")
     inputLineCountParam = c.intParameter("input_line_count")
+    expectedRankCountParam = c.intParameter("expected_rank_count")
+    expectedRankHashParam = c.stringParameter("expected_rank_hash")
 
     tempDirPath = c.generateTempDir("page_rank")
     sc = setUpSparkContext(tempDirPath, threadCountParam, "page-rank")
-    prepareInput(c)
-    loadData()
+    links = loadData(inputZipFile, inputFile, inputLineCountParam)
   }
 
   override def run(c: BenchmarkContext): BenchmarkResult = {
-    ranks = links.mapValues(v => 1.0)
-    for (i <- 0 until ITERATIONS) {
+    var ranks = links.mapValues(_ => 1.0)
+
+    for (_ <- 0 until ITERATIONS) {
       val contributions = links.join(ranks).values.flatMap {
         case (urls, rank) =>
           urls.map(url => (url, rank / urls.size))
@@ -113,19 +117,39 @@ final class PageRank extends Benchmark with SparkUtil {
       ranks = contributions.reduceByKey(_ + _).mapValues(0.15 + 0.85 * _)
     }
 
-    // TODO: add more sophisticated validation
-    Validators.simple("ranks count", expectedRankCountParam, ranks.count())
+    //
+    // Trigger the computation by counting the ranks. An alternative is to
+    // call collect(), which would also gather all the data into the driver
+    // as part of the measured operation. A typical application would probably
+    // iterate over a (potentially large) result (which is what count() will
+    // do) instead of collecting it into one place.
+    //
+    val rankCount: Int = ranks.count().toInt
+
+    new BenchmarkResult {
+      //
+      // Validate the result. Check the number of ranks first, and then the
+      // hash of the string representation of the ranks. Round the ranks to
+      // 8 decimal places and order them by the web site id to avoid numerical
+      // instability issues on different platforms.
+      //
+      override def validate() = {
+        Assert.assertEquals(expectedRankCountParam, rankCount, "ranks count")
+
+        val rankLines = ranks
+          .sortByKey()
+          .map {
+            case (url, rank) => f"$url $rank%.8f"
+          }
+          .collect
+          .toList
+
+        Validators.hashing(expectedRankHashParam, rankLines.asJava).validate()
+      }
+    }
   }
 
   override def tearDownAfterAll(c: BenchmarkContext): Unit = {
-    val output = ranks
-      .collect()
-      .map {
-        case (url, rank) => s"$url $rank"
-      }
-      .mkString("\n")
-    FileUtils.write(outputPath.toFile, output, StandardCharsets.UTF_8, true)
-
     tearDownSparkContext(sc)
     c.deleteTempDir(tempDirPath)
   }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
@@ -36,7 +36,7 @@ import scala.collection.JavaConverters._
       settings = Array(
         "input_line_count = 5000",
         "expected_rank_count = 1661",
-        "expected_rank_hash=7ca80582125b8ca7"
+        "expected_rank_hash = 7ca80582125b8ca7"
       )
     ),
     new Configuration(name = "jmh")
@@ -60,7 +60,7 @@ final class PageRank extends Benchmark with SparkUtil {
   // TODO: Unify handling of scratch directories throughout the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/13
 
-  val inputZipFile = "web-berkstan.txt.zip"
+  val inputZipResource = "/web-berkstan.txt.zip"
   val inputFile = "web-BerkStan.txt"
 
   var sc: SparkContext = _
@@ -103,7 +103,7 @@ final class PageRank extends Benchmark with SparkUtil {
 
     tempDirPath = c.generateTempDir("page_rank")
     sc = setUpSparkContext(tempDirPath, threadCountParam, "page-rank")
-    links = loadData(inputZipFile, inputFile, inputLineCountParam)
+    links = loadData(inputZipResource, inputFile, inputLineCountParam)
   }
 
   override def run(c: BenchmarkContext): BenchmarkResult = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConverters._
     new Parameter(name = "thread_count", defaultValue = "$cpu.count"),
     new Parameter(name = "input_line_count", defaultValue = "-1"),
     new Parameter(name = "expected_rank_count", defaultValue = "598652"),
-    new Parameter(name = "expected_rank_hash", defaultValue = "d8bf7171feef1b87")
+    new Parameter(name = "expected_rank_hash", defaultValue = "4704db55b9f60104")
   )
 )
 @Configurations(
@@ -36,7 +36,7 @@ import scala.collection.JavaConverters._
       settings = Array(
         "input_line_count = 5000",
         "expected_rank_count = 1661",
-        "expected_rank_hash = 7ca80582125b8ca7"
+        "expected_rank_hash = 9fd2e94dca375b4e"
       )
     ),
     new Configuration(name = "jmh")

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConverters._
     new Parameter(name = "thread_count", defaultValue = "$cpu.count"),
     new Parameter(name = "input_line_count", defaultValue = "-1"),
     new Parameter(name = "expected_rank_count", defaultValue = "598652"),
-    new Parameter(name = "expected_rank_hash", defaultValue = "4704db55b9f60104")
+    new Parameter(name = "expected_rank_hash", defaultValue = "9b39ddf5eaa8b3d2")
   )
 )
 @Configurations(
@@ -35,8 +35,8 @@ import scala.collection.JavaConverters._
       name = "test",
       settings = Array(
         "input_line_count = 5000",
-        "expected_rank_count = 1661",
-        "expected_rank_hash = 9fd2e94dca375b4e"
+        "expected_rank_count = 1664",
+        "expected_rank_hash = 797021674f62a217"
       )
     ),
     new Configuration(name = "jmh")
@@ -55,28 +55,34 @@ final class PageRank extends Benchmark with SparkUtil {
 
   private var expectedRankHashParam: String = _
 
-  private val ITERATIONS = 2
+  /** Number of iterations of the page rank algorithm. */
+  private val PAGE_RANK_ITERATIONS = 2
+
+  private val INPUT_ZIP_RESOURCE = "/web-berkstan.txt.zip"
+
+  private val INPUT_ZIP_ENTRY = "web-BerkStan.txt"
+
+  /**
+   * Maximum difference in neighboring ranks for web sites in the same class.
+   * The value is slightly lower but in the same order as 1/685230, which
+   * corresponds to the number of web sites in the input data set
+   */
+  private val RANK_DIFFERENCE_LIMIT = 1e-6
 
   // TODO: Unify handling of scratch directories throughout the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/13
 
-  val inputZipResource = "/web-berkstan.txt.zip"
-  val inputFile = "web-BerkStan.txt"
+  private var sc: SparkContext = _
 
-  var sc: SparkContext = _
+  private var links: RDD[(Int, Iterable[Int])] = _
 
-  var links: RDD[(String, Iterable[String])] = _
+  private var tempDirPath: Path = _
 
-  var tempDirPath: Path = _
-
-  def loadData(
-    zipName: String,
-    entryName: String,
-    lineCount: Int
-  ): RDD[(String, Iterable[String])] = {
+  private def loadData(zipName: String, entryName: String, lineCount: Int) = {
     val inputSource = ZipResourceUtil.sourceFromZipResource(entryName, zipName)
+
     try {
-      var inputLines = inputSource.getLines()
+      var inputLines = inputSource.getLines().dropWhile(_.startsWith("#"))
       if (lineCount >= 0) {
         inputLines = inputLines.take(lineCount)
       }
@@ -84,10 +90,9 @@ final class PageRank extends Benchmark with SparkUtil {
       val splitter = Pattern.compile("\\s+")
       sc.parallelize(inputLines.toSeq)
         .map { line =>
-          val parts = splitter.split(line)
-          parts(0) -> parts(1)
+          val parts = splitter.split(line, 2)
+          parts(0).toInt -> parts(1).toInt
         }
-        .distinct()
         .groupByKey()
         .cache()
     } finally {
@@ -103,16 +108,15 @@ final class PageRank extends Benchmark with SparkUtil {
 
     tempDirPath = c.generateTempDir("page_rank")
     sc = setUpSparkContext(tempDirPath, threadCountParam, "page-rank")
-    links = loadData(inputZipResource, inputFile, inputLineCountParam)
+    links = loadData(INPUT_ZIP_RESOURCE, INPUT_ZIP_ENTRY, inputLineCountParam)
+
   }
 
   override def run(c: BenchmarkContext): BenchmarkResult = {
     var ranks = links.mapValues(_ => 1.0)
-
-    for (_ <- 0 until ITERATIONS) {
+    for (_ <- 0 until PAGE_RANK_ITERATIONS) {
       val contributions = links.join(ranks).values.flatMap {
-        case (urls, rank) =>
-          urls.map(url => (url, rank / urls.size))
+        case (urls, rank) => urls.map(url => (url, rank / urls.size))
       }
       ranks = contributions.reduceByKey(_ + _).mapValues(0.15 + 0.85 * _)
     }
@@ -121,31 +125,48 @@ final class PageRank extends Benchmark with SparkUtil {
     // Trigger the computation by counting the ranks. An alternative is to
     // call collect(), which would also gather all the data into the driver
     // as part of the measured operation. A typical application would probably
-    // iterate over a (potentially large) result (which is what count() will
+    // iterate over a (potentially large) result (which is what count() may
     // do) instead of collecting it into one place.
     //
     val rankCount: Int = ranks.count().toInt
 
     new BenchmarkResult {
       //
-      // Validate the result. Check the number of ranks first, and then the
-      // hash of the string representation of the ranks. Round the ranks to
-      // 8 decimal places and order them by the web site id to avoid numerical
-      // instability issues on different platforms.
+      // Check the number of ranks and the string representation of the web site
+      // identifiers ordered by rank and web site id (for equivalent ranks). To
+      // work around numerical instability issues, the sites are first pre-sorted
+      // by rank, and the ordering is then relaxed so that neighboring ranks that
+      // differ only slightly are considered equal.
       //
       override def validate() = {
         Assert.assertEquals(expectedRankCountParam, rankCount, "ranks count")
 
-        val rankLines = ranks
-          .sortByKey()
-          .collect
-          .map {
-            case (url, rank) => f"$url $rank%.7f"
-          }
-          .toList
+        val preSortedEntries = ranks.sortBy { case (_, rank) => rank }.collect
+        val sortedEntries = relaxedRanks(preSortedEntries, RANK_DIFFERENCE_LIMIT).sortBy {
+          case (url, rank) => (rank, url)
+        }
 
+        val rankLines = sortedEntries.map { case (url, _) => url.toString }.toList
         Validators.hashing(expectedRankHashParam, rankLines.asJava).validate()
       }
+
+      private def relaxedRanks(entries: Seq[(Int, Double)], diffLimit: Double) = {
+        var prevRank = entries(0)._2
+        var groupRank = prevRank
+
+        entries
+          .map {
+            case (url, rank) =>
+              val diff = rank - prevRank
+              if (diff > diffLimit) {
+                groupRank = rank
+              }
+
+              prevRank = rank
+              (url, groupRank)
+          }
+      }
+
     }
   }
 

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ZipResourceUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ZipResourceUtil.scala
@@ -1,21 +1,40 @@
 package org.renaissance.apache.spark
 
+import java.io.FileNotFoundException
 import java.nio.charset.StandardCharsets
 import java.util.zip.ZipInputStream
 
-import org.apache.commons.io.IOUtils
+import scala.io.BufferedSource
+import scala.io.Source
 
 object ZipResourceUtil {
 
-  def readZipFromResourceToText(resourceName: String): String = {
-    val zis = new ZipInputStream(this.getClass.getResourceAsStream("/" + resourceName))
+  def sourceFromZipResource(entryName: String, resourceName: String): BufferedSource = {
+    val is = this.getClass.getResourceAsStream("/" + resourceName)
+    if (is == null) {
+      throw new FileNotFoundException(
+        s"resource '$resourceName' not found"
+      )
+    }
 
+    val zis = new ZipInputStream(is)
     try {
-      zis.getNextEntry()
-      IOUtils.toString(zis, StandardCharsets.UTF_8)
-
-    } finally {
-      zis.close()
+      Iterator
+        .continually(zis.getNextEntry)
+        .takeWhile(_ != null)
+        .filterNot(_.isDirectory)
+        .find(_.getName.equalsIgnoreCase(entryName))
+        .map(_ => Source.fromInputStream(zis, StandardCharsets.UTF_8.name))
+        .getOrElse {
+          throw new FileNotFoundException(
+            s"file '$entryName' not found in resource '$resourceName'"
+          )
+        }
+    } catch {
+      // Close the stream and propagate the exception
+      case e: Throwable =>
+        zis.close()
+        throw e
     }
   }
 

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ZipResourceUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ZipResourceUtil.scala
@@ -7,10 +7,18 @@ import java.util.zip.ZipInputStream
 import scala.io.BufferedSource
 import scala.io.Source
 
-object ZipResourceUtil {
+private object ZipResourceUtil {
 
+  /**
+   * Creates a {@link Source} from a file within a ZIP resource
+   * associated with the {@link ZipResourceUtil} class.
+   *
+   * @param entryName name of the ZIP entry
+   * @param resourceName path to the ZIP resource
+   * @return {@link Source} instance for the given file within a ZIP
+   */
   def sourceFromZipResource(entryName: String, resourceName: String): BufferedSource = {
-    val is = this.getClass.getResourceAsStream("/" + resourceName)
+    val is = this.getClass.getResourceAsStream(resourceName)
     if (is == null) {
       throw new FileNotFoundException(
         s"resource '$resourceName' not found"


### PR DESCRIPTION
This was triggered by @davleopo mentioning leftover code in `page-rank` in the API cleanup PR :-)

### Unnecessary disk IO

When making sure that it was indeed just leftover code, I realized that maybe the setup code is causing more disk IO than necessary, so I modified the code to get rid of it.

The code originally read the whole zipped file as a single String into memory, optionally reduced the number of lines (for the `test` configuration), and wrote it uncompressed to disk. Then it used the the `SparkContext.textFile()` method to create an RDD which was then processed into a map and cached.

This uses a lazy `Source` to read either all (or a subset of) lines from the zipped file into a collection, and uses the `SparkContext.parallelize()` method to create an RDD which is then processed the same way as above. It also avoids writing the ranks from the last executed operation to disk.

This step (creating an RDD) may be something to consider, because `SparkContext.textFile()` instantiates a different implementation (Hadoop-related) of `RDD` than `SparkContext.parallelize()`. I think that in a distributed scenario, the `SparkContext.textFile()` would cause the workers to read the input file on their own from a shared file system, while the new approach reads the file in the driver (once) and then distributes the RDD. 

In our use case, this might not be a bad thing, but it should probably be an explicit decision. The measured operation execution times do not appear to be influenced (I would be surprised if they were) even though the ranks were slightly (8th decimal place after floating point) different.

I think that avoiding unnecessary disk IO is generally a good thing if it can be done, so if we are fine with this, I think we can make the other Spark benchmarks follow suit.

### Validation with floating-point ranks

Because I already had my hands on the benchmark, I also added a hash-based validation of the results in addition to checking the expected number of ranks. Even though on my machine each operation produced *identical* results, the results produced on the Travis CI machines were slightly different. Because numerical instability across different machines is a real issue to deal with, the web sites are pre-sorted sorted by ranks. This ordering is then relaxed by making neighboring ranks that differ by only a small amount equivalent, and finally the web sites are ordered by web site id within the equivalence classes.

In addition to whatever systems Travis CI uses, the default configuration passed validation on KabyLake (i7-7700HQ, 32G RAM), SkyLake (i7-6700K, 32G RAM), Sandy Bridge Xeon (E3-1245, 16G RAM), Apollo Lake Celeron (J3455, 8G RAM, OpenJDK 11), Core 2 Quad (Q9550, 4G RAM), and AMD Barcelona (Opteron 2356, 16G RAM) systems running Linux and various builds of OpenJDK 8 (mostly).

### Web site identifiers as integers

Finally, instead of keeping the web graph as `RDD[String, Iterable[String]]`, I modified the code to keep it as `RDD[Int, Iterable[Int]]` (the strings were actually numbers anyway). This seems to consume less memory and make key lookups faster. As a result, where the first operation initially took around 30 seconds on my laptop, it now takes a bit below 13 seconds, and where the operation stabilized somewhere above 3 seconds by the 19th repetition, it now stabilizes around 2.6 seconds on JDK8 and around 2 seconds on Graal 1.0.0-rc6.