### PR TITLE
Reset locale to Locale.ROOT

### DIFF
--- a/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
@@ -2,6 +2,7 @@ package org.renaissance.harness
 
 import java.util.concurrent.TimeUnit.SECONDS
 import java.util.function.ToIntFunction
+import java.util.Locale
 
 import org.renaissance.Benchmark
 import org.renaissance.BenchmarkResult.ValidationException
@@ -21,6 +22,10 @@ import scala.collection._
 object RenaissanceSuite {
 
   def main(args: Array[String]): Unit = {
+    // Reset locale to have repeatable output across
+    // different environments.
+    Locale.setDefault(Locale.ROOT)
+
     val benchmarkPkg = classOf[Benchmark].getPackage
     val parser = new ConfigParser(
       immutable.Map(


### PR DESCRIPTION
This is to improve output stability/repeatability across different environments. For example, even simple `%8.5f` can change based on user/OS settings.

This is most important for validation where hashes are computed but it also makes any output diffing simpler in general (noticed because of PR #197).