### PR TITLE
Issue #185 - Use SingleShotTime in JMH wrappers

### DIFF
--- a/project/jmh.scala
+++ b/project/jmh.scala
@@ -21,8 +21,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @State(Scope.Benchmark)
 @OutputTimeUnit(MILLISECONDS)
-@Warmup(iterations = ${info.repetitions}, time = 1, timeUnit = MILLISECONDS)
-@Measurement(iterations = ${info.repetitions / 4 + 1}, time = 1, timeUnit = MILLISECONDS)
+@Warmup(iterations = ${info.repetitions})
+@Measurement(iterations = ${info.repetitions / 4 + 1})
 public class ${jmhClassName} extends JmhRenaissanceBenchmark {
   public ${jmhClassName}() { super("${info.name}"); }
 }

--- a/renaissance-jmh/src/main/java/org/renaissance/jmh/JmhRenaissanceBenchmark.java
+++ b/renaissance-jmh/src/main/java/org/renaissance/jmh/JmhRenaissanceBenchmark.java
@@ -32,7 +32,7 @@ public abstract class JmhRenaissanceBenchmark {
   }
 
   @org.openjdk.jmh.annotations.Benchmark
-  @BenchmarkMode(Mode.AverageTime)
+  @BenchmarkMode(Mode.SingleShotTime)
   @OutputTimeUnit(MILLISECONDS)
   @Measurement(timeUnit = MILLISECONDS)
   public final void runOperation() {


### PR DESCRIPTION
Switch  @BenchmarkMode to Mode.SingleShotTime and remove unneeded timing parameters from @Warmup and @Measurement as a result of that.