### PR TITLE
Travis: force older JDK on MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,8 @@ jobs:
 
     - <<: *bundle
       os: osx
+      osx_image: xcode9.3
+      jdk: oraclejdk9
     - <<: *bundle
       jdk: openjdk8
     - <<: *bundle
@@ -81,6 +83,8 @@ jobs:
 
     - <<: *bench
       os: osx
+      osx_image: xcode9.3
+      jdk: oraclejdk9
     - <<: *bench
       jdk: openjdk8
     - <<: *bench


### PR DESCRIPTION
By default, MacOS on Travis now uses JDK 13 which fails the build (because of SBT, probably). So let's use JDK 9 for now there.