### PR TITLE
Avoid creating thousands of response handler objects in finagle-http

### DIFF
--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
@@ -68,17 +68,17 @@ final class FinagleHttp extends Benchmark {
         val responseHandler = (response: Response) =>
           totalContentLength += response.content.length
 
-        barrier.countDown
-        barrier.await
+        barrier.countDown()
+        barrier.await()
 
-        for (i <- 0 until requestCount) {
+        for (_ <- 0 until requestCount) {
           val request = http.Request(http.Method.Get, "/json")
           request.host = serviceHost
 
           val response: Future[http.Response] = client(request)
 
-          // Need to use map() instead of onSuccess() as we actually need to
-          // wait for the side-effect, not the original response
+          // Use map() instead of onSuccess() because we need to
+          // wait for the side-effect, not the original response.
           Await.result(response.map(responseHandler))
         }
 
@@ -107,8 +107,8 @@ final class FinagleHttp extends Benchmark {
 
   var port: Int = -1
 
-  var threads: Array[WorkerThread] = null
-  var threadBarrier: CountDownLatch = null
+  var threads: Array[WorkerThread] = _
+  var threadBarrier: CountDownLatch = _
 
   override def setUpBeforeAll(c: BenchmarkContext): Unit = {
     requestCountParam = c.intParameter("request_count")
@@ -119,7 +119,7 @@ final class FinagleHttp extends Benchmark {
     val muxer: HttpMuxer = new HttpMuxer()
       .withHandler(
         "/json",
-        Service.mk { req: Request =>
+        Service.mk { _: Request =>
           val rep = Response()
           rep.content =
             Buf.ByteArray.Owned(mapper.writeValueAsBytes(Map("message" -> "Hello, World!")))
@@ -127,7 +127,7 @@ final class FinagleHttp extends Benchmark {
           Future.value(rep)
         }
       )
-      .withHandler("/plaintext", Service.mk { req: Request =>
+      .withHandler("/plaintext", Service.mk { _: Request =>
         val rep = Response()
         rep.content = helloWorld
         rep.contentType = "text/plain"
@@ -168,10 +168,10 @@ final class FinagleHttp extends Benchmark {
   override def setUpBeforeEach(c: BenchmarkContext): Unit = {
     //
     // Use a CountDownLatch initialized to (clientCount + 1) to start the
-    // threads (outside the measured loop) and make them block until the
-    // measured operation is executed. In the measured operation, we provide
-    // the one last countDown() invocation which unblocks all the threads
-    // and lets the start working simultaneously.
+    // threads (outside the measured operation) and make them block until the
+    // measured operation is executed. The measured operation provides the
+    // last countDown() invocation which unblocks all the threads so that
+    // they start working simultaneously.
     //
     threadBarrier = new CountDownLatch(clientCountParam + 1)
 
@@ -184,8 +184,8 @@ final class FinagleHttp extends Benchmark {
   }
 
   override def run(c: BenchmarkContext): BenchmarkResult = {
-    // Let the threads do the work (see beforeIteration)
-    threadBarrier.countDown
+    // Unleash the threads (see beforeOperationSetUp).
+    threadBarrier.countDown()
 
     var totalLength = 0L
     for (thread <- threads) {

--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
@@ -65,6 +65,9 @@ final class FinagleHttp extends Benchmark {
         com.twitter.finagle.Http.newService(serviceHost)
 
       try {
+        val responseHandler = (response: Response) =>
+          totalContentLength += response.content.length
+
         barrier.countDown
         barrier.await
 
@@ -76,9 +79,7 @@ final class FinagleHttp extends Benchmark {
 
           // Need to use map() instead of onSuccess() as we actually need to
           // wait for the side-effect, not the original response
-          Await.result(response.map { rep: http.Response =>
-            totalContentLength += rep.content.length
-          })
+          Await.result(response.map(responseHandler))
         }
 
       } finally {

--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
@@ -60,8 +60,9 @@ final class FinagleHttp extends Benchmark {
     var totalContentLength = 0L
 
     override def run(): Unit = {
+      val serviceHost = s"localhost:$port"
       val client: Service[http.Request, http.Response] =
-        com.twitter.finagle.Http.newService(s"localhost:$port")
+        com.twitter.finagle.Http.newService(serviceHost)
 
       try {
         barrier.countDown
@@ -69,7 +70,7 @@ final class FinagleHttp extends Benchmark {
 
         for (i <- 0 until requestCount) {
           val request = http.Request(http.Method.Get, "/json")
-          request.host = s"localhost:$port"
+          request.host = serviceHost
 
           val response: Future[http.Response] = client(request)
 


### PR DESCRIPTION
The `finagle-http` benchmark creates a new (anonymous) response handler for each HTTP request, eventually creating thousands (`$requestCount$`) of them in the benchmark loop. This has been pointed out in _Detection of Suspicious Time Windows in Memory Monitoring_ by Markus Weninger et al. published at MPLR'19, see https://dx.doi.org/10.1145/3357390.3361025

This has been on the back burner for some time (I forgot about it), but I would generally consider creating such instances in a loop a bad practice, so the code in this PR manually hoists the response handler creation out of the loop and uses just one handler for all HTTP requests.

However, I'm also willing to accept an argument (if anyone is willing to play the devil's advocate) that it's either a non-problem or that a normal (non-benchmark) application code might actually need to have a per-request response handler with some per-request state (which we don't have here).

Is it actually something that could be optimized away automatically? My guess is that no, because the response handler is a lambda passed to a future, so it's probably pretty opaque to the compiler.