### PR TITLE
Add VM uptime timestamps to repetitions and (much) more environmental info

### DIFF
--- a/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
@@ -158,14 +158,18 @@ object RenaissanceSuite {
       // Wait for the next reading.
     }
 
-    val currentNanosBefore = System.nanoTime()
-
+    // Wait for the next reading and get straddling nanoTime readings.
     val currentMillis = System.currentTimeMillis()
-    while (System.currentTimeMillis() == currentMillis) {
-      // Wait for the next reading.
+    var currentNanosBefore = System.nanoTime ()
+    var currentNanosAfter = 0L
+    var sameTick = true
+    while (sameTick) {
+      sameTick = (System.currentTimeMillis() == currentMillis)
+      currentNanosAfter = System.nanoTime()
+      if (sameTick) currentNanosBefore = currentNanosAfter
     }
 
-    val currentNanosAfter = System.nanoTime()
+    // The two straddling nanoTime readings should give us the best estimate.
     val currentNanos = (currentNanosBefore + currentNanosAfter) / 2
 
     //

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
@@ -1,10 +1,9 @@
 package org.renaissance.harness
 
+import java.util.Locale
+import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.TimeUnit.SECONDS
 import java.util.function.ToIntFunction
-import java.util.Locale
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeUnit.MILLISECONDS
 
 import org.renaissance.Benchmark
 import org.renaissance.BenchmarkResult.ValidationException
@@ -105,7 +104,7 @@ object RenaissanceSuite {
     // TODO: Why collect failing benchmarks instead of just quitting whenever one fails?
     val failedBenchmarks = new mutable.ArrayBuffer[BenchmarkInfo](benchmarks.length)
 
-    val vmStartNanos = getVmStartNanos()
+    val vmStartNanos = getVmStartNanos
 
     // Notify observers that the suite is set up.
     dispatcher.notifyAfterHarnessInit()
@@ -149,12 +148,12 @@ object RenaissanceSuite {
     }
   }
 
-  private def getVmStartNanos() = {
+  private def getVmStartNanos = {
     //
     // Get nanoTime() reading from between two
     // distinct currentTimeMillis() readings.
     //
-    val initMillis = System.currentTimeMillis();
+    val initMillis = System.currentTimeMillis()
     while (System.currentTimeMillis() == initMillis) {
       // Wait for the next reading.
     }
@@ -167,7 +166,7 @@ object RenaissanceSuite {
     }
 
     val currentNanosAfter = System.nanoTime()
-    val currentNanos = (currentNanosBefore + currentNanosAfter) / 2;
+    val currentNanos = (currentNanosBefore + currentNanosAfter) / 2
 
     //
     // Approximate nanoTime() value at VM start based on the millisecond

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -90,6 +90,11 @@ private abstract class ResultWriter
         benchResults.toMap,
         0 to maxIndex
       )
+
+  protected final def writeToFile(fileName: String, string: String): Unit = {
+    FileUtils.write(new File(fileName), string, StandardCharsets.UTF_8, false)
+  }
+
 }
 
 private final class CsvWriter(val filename: String) extends ResultWriter {
@@ -117,12 +122,7 @@ private final class CsvWriter(val filename: String) extends ResultWriter {
       }
     }
 
-    FileUtils.write(
-      new File(filename),
-      csv.toString,
-      StandardCharsets.UTF_8,
-      false
-    )
+    writeToFile(filename, csv.toString)
   }
 }
 
@@ -208,11 +208,6 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
 
     tree.update("data", dataTree.toMap.toJson)
 
-    FileUtils.write(
-      new File(filename),
-      tree.toMap.toJson.prettyPrint,
-      java.nio.charset.StandardCharsets.UTF_8,
-      false
-    )
+    writeToFile(filename, tree.toMap.toJson.prettyPrint)
   }
 }

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -138,12 +138,9 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
   private def systemPropertyAsJson(name: String) = Option(System.getProperty(name)).toJson
 
   private def getEnvironment(termination: String) = {
-    val osInfo = getOsInfo
-    val vmInfo = getVmInfo(termination)
-
     Map(
-      "os" -> osInfo.toJson,
-      "vm" -> vmInfo.toJson
+      "os" -> getOsInfo.toJson,
+      "vm" -> getVmInfo(termination).toJson
     )
   }
 
@@ -157,13 +154,12 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
 
   private def getVmInfo(termination: String) = {
     val runtimeMxBean = management.ManagementFactory.getRuntimeMXBean
-    val vmArgs = runtimeMxBean.getInputArguments
 
     Map(
       "name" -> systemPropertyAsJson("java.vm.name"),
       "vm_version" -> systemPropertyAsJson("java.vm.version"),
       "jre_version" -> systemPropertyAsJson("java.version"),
-      "args" -> vmArgs.asScala.toList.toJson,
+      "args" -> runtimeMxBean.getInputArguments.asScala.toList.toJson,
       "termination" -> termination.toJson
     )
   }

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -1,8 +1,13 @@
 package org.renaissance.harness
 
 import java.io.File
+import java.lang.management.MemoryUsage
 import java.nio.charset.StandardCharsets
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
 
+import com.sun.management.UnixOperatingSystemMXBean
 import org.apache.commons.io.FileUtils
 import org.renaissance.Benchmark
 import org.renaissance.Plugin.BeforeHarnessShutdownListener
@@ -114,10 +119,11 @@ private final class CsvWriter(val filename: String) extends ResultWriter {
 
   private def formatHeader(metricNames: Seq[String], csv: StringBuffer): Unit = {
     // There will always be at least one column after "benchmark".
-    csv.append("benchmark,").append(metricNames.mkString(",")).append("\n")
+    csv.append("benchmark,").append(metricNames.mkString(",")).append(",vm_start_unix_ms\n")
   }
 
   private def formatResults(metricNames: Seq[String], csv: StringBuffer): Unit = {
+    val vmStartTime = management.ManagementFactory.getRuntimeMXBean.getStartTime
     for ((benchmark, _, metricsByName, repetitionCount) <- getBenchmarkResults) {
       for (i <- 0 until repetitionCount) {
         csv.append(benchmark)
@@ -128,7 +134,7 @@ private final class CsvWriter(val filename: String) extends ResultWriter {
           csv.append(",").append(stringValue)
         }
 
-        csv.append("\n")
+        csv.append(",").append(vmStartTime).append("\n")
       }
     }
   }
@@ -139,35 +145,178 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
 
   private def systemPropertyAsJson(name: String) = Option(System.getProperty(name)).toJson
 
+  private def pathsAsJson(pathSpec: String) = pathSpec.split(File.pathSeparator).toJson
+
   private def getEnvironment(normalTermination: Boolean) = {
     Map(
       "os" -> getOsInfo,
       "vm" -> getVmInfo(normalTermination),
+      "jre" -> getJreInfo
     )
   }
 
   private def getOsInfo = {
-    Map(
-      "name" -> systemPropertyAsJson("os.name"),
-      "arch" -> systemPropertyAsJson("os.arch"),
-      "version" -> systemPropertyAsJson("os.version")
+    val os = management.ManagementFactory.getOperatingSystemMXBean
+
+    val result = mutable.Map(
+      "name" -> os.getName.toJson,
+      "arch" -> os.getArch.toJson,
+      "version" -> os.getVersion.toJson,
+      "available_processors" -> os.getAvailableProcessors.toJson
     )
+
+    os match {
+      case unixOs: UnixOperatingSystemMXBean =>
+        result ++= Map(
+          "phys_mem_total" -> unixOs.getTotalPhysicalMemorySize.toJson,
+          "phys_mem_free" -> unixOs.getFreePhysicalMemorySize.toJson,
+          "virt_mem_committed" -> unixOs.getCommittedVirtualMemorySize.toJson,
+          "swap_space_total" -> unixOs.getTotalSwapSpaceSize.toJson,
+          "swap_space_free" -> unixOs.getFreeSwapSpaceSize.toJson,
+          "max_fd_count" -> unixOs.getMaxFileDescriptorCount.toJson,
+          "open_fd_count" -> unixOs.getOpenFileDescriptorCount.toJson
+        )
+    }
+
+    result.toMap
   }
 
   private def getVmInfo(normalTermination: Boolean) = {
     val runtimeMxBean = management.ManagementFactory.getRuntimeMXBean
 
     Map(
-      "name" -> systemPropertyAsJson("java.vm.name"),
-      "vm_version" -> systemPropertyAsJson("java.vm.version"),
-      "jre_version" -> systemPropertyAsJson("java.version"),
+      "name" -> runtimeMxBean.getVmName.toJson,
+      "vendor" -> runtimeMxBean.getVmVendor.toJson,
+      "version" -> runtimeMxBean.getVmVersion.toJson,
+      "spec_name" -> runtimeMxBean.getSpecName.toJson,
+      "spec_vendor" -> runtimeMxBean.getSpecVendor.toJson,
+      "spec_version" -> runtimeMxBean.getSpecVersion.toJson,
+      "mode" -> systemPropertyAsJson("java.vm.info"),
       "args" -> runtimeMxBean.getInputArguments.asScala.toList.toJson,
       "termination" -> (if (normalTermination) "normal" else "forced").toJson,
+      "start_unix_ms" -> runtimeMxBean.getStartTime.toJson,
+      "start_iso" -> unixTimeAsIso(runtimeMxBean.getStartTime).toJson,
+      "uptime_ms" -> runtimeMxBean.getUptime.toJson,
+      "collectors" -> getCollectorInfo.toJson,
+      "compiler" -> getCompilationInfo.toJson,
+      "classloading" -> getClassLoadingInfo.toJson,
+      "memory" -> getMemoryInfo.toJson,
+      "pools" -> getMemoryPoolInfo.toJson,
+      "threads" -> getThreadInfo.toJson
+    )
+  }
+
+  private def getJreInfo = {
+    val runtimeMxBean = management.ManagementFactory.getRuntimeMXBean
+
+    Map(
+      "name" -> systemPropertyAsJson("java.runtime.name"),
+      "version" -> systemPropertyAsJson("java.runtime.version"),
+      "java_vendor" -> systemPropertyAsJson("java.vendor"),
+      "java_version" -> systemPropertyAsJson("java.version"),
+      "spec_name" -> systemPropertyAsJson("java.specification.name"),
+      "spec_vendor" -> systemPropertyAsJson("java.specification.vendor"),
+      "spec_version" -> systemPropertyAsJson("java.specification.version"),
+      "home" -> systemPropertyAsJson("java.home"),
+      "library_path" -> pathsAsJson(runtimeMxBean.getLibraryPath),
+      "boot_class_path" -> pathsAsJson(runtimeMxBean.getBootClassPath),
+      "class_path" -> pathsAsJson(runtimeMxBean.getClassPath)
+    )
+  }
+
+  private def unixTimeAsIso(unixTime: Long) = {
+    val formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    formatter.setTimeZone(TimeZone.getTimeZone("UTC"))
+    formatter.format(new Date(unixTime))
+  }
+
+  private def getMemoryUsageInfo(usage: MemoryUsage) = {
+    Map(
+      "init" -> usage.getInit.toJson,
+      "used" -> usage.getUsed.toJson,
+      "committed" -> usage.getCommitted.toJson,
+      "max" -> usage.getMax.toJson
+    )
+  }
+
+  private def getMemoryInfo = {
+    val info = management.ManagementFactory.getMemoryMXBean
+
+    Map(
+      "heap_usage" -> getMemoryUsageInfo(info.getHeapMemoryUsage).toJson,
+      "nonheap_usage" -> getMemoryUsageInfo(info.getNonHeapMemoryUsage).toJson,
+      "pending_finalization_count" -> info.getObjectPendingFinalizationCount.toJson
+    )
+  }
+
+  private def getMemoryPoolInfo = {
+    val pools = management.ManagementFactory.getMemoryPoolMXBeans.asScala
+
+    pools
+      .map(pool => {
+        Map(
+          "name" -> pool.getName.toJson,
+          "type" -> pool.getType.name().toJson,
+          "usage" -> getMemoryUsageInfo(pool.getUsage).toJson,
+          "peak_usage" -> getMemoryUsageInfo(pool.getPeakUsage).toJson
+        )
+      })
+      .toList
+  }
+
+  private def getCollectorInfo = {
+    val collectors = management.ManagementFactory.getGarbageCollectorMXBeans.asScala
+
+    collectors
+      .map(gc => {
+        Map(
+          "name" -> gc.getName.toJson,
+          "collection_count" -> gc.getCollectionCount.toJson,
+          "collection_time_ms" -> gc.getCollectionTime.toJson
+        )
+      })
+      .toList
+  }
+
+  private def getCompilationInfo = {
+    val info = management.ManagementFactory.getCompilationMXBean
+    if (info != null) {
+      val result = mutable.Buffer(
+        "name" -> info.getName.toJson
+      )
+
+      if (info.isCompilationTimeMonitoringSupported) {
+        result += ("compilation_time_ms" -> info.getTotalCompilationTime.toJson)
+      }
+
+      Option(result.toMap)
+    } else {
+      // Compilation MX Bean is not available in interpreted mode.
+      Option.empty
+    }
+  }
+
+  private def getClassLoadingInfo = {
+    val info = management.ManagementFactory.getClassLoadingMXBean
+
+    Map(
+      "class_count" -> info.getLoadedClassCount.toJson,
+      "classes_total" -> info.getTotalLoadedClassCount.toJson
+    )
+  }
+
+  private def getThreadInfo = {
+    val info = management.ManagementFactory.getThreadMXBean
+
+    Map(
+      "thread_count" -> info.getThreadCount.toJson,
+      "thread_count_max" -> info.getPeakThreadCount.toJson,
+      "daemon_thread_count" -> info.getDaemonThreadCount.toJson,
+      "threads_total" -> info.getTotalStartedThreadCount.toJson
     )
   }
 
   private def getSuiteInfo = {
-
     val manifest = {
       val benchClass = classOf[Benchmark]
       val stream = benchClass.getResourceAsStream("/META-INF/MANIFEST.MF")
@@ -195,7 +344,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
 
   override def store(normalTermination: Boolean): Unit = {
     val result = Map(
-      "format_version" -> 4.toJson,
+      "format_version" -> 5.toJson,
       "benchmarks" -> getBenchmarkNames.toJson,
       "environment" -> getEnvironment(normalTermination).toJson,
       "suite" -> getSuiteInfo.toJson,

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -81,16 +81,10 @@ private abstract class ResultWriter
     : Iterable[(String, Boolean, Map[String, mutable.ArrayBuffer[Long]], Int)] =
     for {
       benchName <- getBenchmarks
-      benchResults = allResults(benchName)
+      benchResults = allResults(benchName).toMap
       benchFailed = failedBenchmarks.contains(benchName)
       valueCountMax = benchResults.values.map(_.size).max
-    } yield
-      (
-        benchName,
-        benchFailed,
-        benchResults.toMap,
-        valueCountMax
-      )
+    } yield (benchName, benchFailed, benchResults, valueCountMax)
 
   protected final def writeToFile(fileName: String, string: String): Unit = {
     FileUtils.write(new File(fileName), string, StandardCharsets.UTF_8, false)

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -135,6 +135,8 @@ private final class CsvWriter(val filename: String) extends ResultWriter {
 
 private final class JsonWriter(val filename: String) extends ResultWriter {
 
+  private def systemPropertyAsJson(name: String) = Option(System.getProperty(name)).toJson
+
   private def getEnvironment(termination: String): JsValue = {
     val osInfo = getOsInfo
     val vmInfo = getVmInfo(termination)
@@ -147,9 +149,9 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
 
   private def getOsInfo = {
     val osInfo = new mutable.HashMap[String, JsValue]
-    osInfo.update("name", System.getProperty("os.name", "unknown").toJson)
-    osInfo.update("arch", System.getProperty("os.arch", "unknown").toJson)
-    osInfo.update("version", System.getProperty("os.version", "unknown").toJson)
+    osInfo.update("name", systemPropertyAsJson("os.name"))
+    osInfo.update("arch", systemPropertyAsJson("os.arch"))
+    osInfo.update("version", systemPropertyAsJson("os.version"))
     osInfo
   }
 
@@ -158,9 +160,9 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
     val vmArgs = runtimeMxBean.getInputArguments
 
     val vmInfo = new mutable.HashMap[String, JsValue]
-    vmInfo.update("name", System.getProperty("java.vm.name", "unknown").toJson)
-    vmInfo.update("vm_version", System.getProperty("java.vm.version", "unknown").toJson)
-    vmInfo.update("jre_version", System.getProperty("java.version", "unknown").toJson)
+    vmInfo.update("name", systemPropertyAsJson("java.vm.name"))
+    vmInfo.update("vm_version", systemPropertyAsJson("java.vm.version"))
+    vmInfo.update("jre_version", systemPropertyAsJson("java.version"))
     vmInfo.update("args", vmArgs.asScala.toList.toJson)
     vmInfo.update("termination", termination.toJson)
     vmInfo

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -8,8 +8,8 @@ import org.renaissance.Benchmark
 import org.renaissance.Plugin.BeforeHarnessShutdownListener
 import org.renaissance.Plugin.BenchmarkFailureListener
 import org.renaissance.Plugin.MeasurementResultListener
-import spray.json._
 import spray.json.DefaultJsonProtocol._
+import spray.json._
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -141,7 +141,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
 
   private def getEnvironment(normalTermination: Boolean) = {
     Map(
-      "os" -> getOsInfo.toJson,
+      "os" -> getOsInfo,
       "vm" -> getVmInfo(normalTermination),
     )
   }

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -158,7 +158,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
   private def getOsInfo = {
     val os = management.ManagementFactory.getOperatingSystemMXBean
 
-    val result = mutable.Map(
+    val result = mutable.Buffer(
       "name" -> os.getName.toJson,
       "arch" -> os.getArch.toJson,
       "version" -> os.getVersion.toJson,
@@ -167,7 +167,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
 
     os match {
       case unixOs: UnixOperatingSystemMXBean =>
-        result ++= Map(
+        result += (
           "phys_mem_total" -> unixOs.getTotalPhysicalMemorySize.toJson,
           "phys_mem_free" -> unixOs.getFreePhysicalMemorySize.toJson,
           "virt_mem_committed" -> unixOs.getCommittedVirtualMemorySize.toJson,

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -141,31 +141,31 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
     val osInfo = getOsInfo
     val vmInfo = getVmInfo(termination)
 
-    val result = new mutable.HashMap[String, JsValue]
-    result.update("os", osInfo.toMap.toJson)
-    result.update("vm", vmInfo.toMap.toJson)
-    result.toMap.toJson
+    Map(
+      "os" -> osInfo.toJson,
+      "vm" -> vmInfo.toJson
+    ).toJson
   }
 
   private def getOsInfo = {
-    val osInfo = new mutable.HashMap[String, JsValue]
-    osInfo.update("name", systemPropertyAsJson("os.name"))
-    osInfo.update("arch", systemPropertyAsJson("os.arch"))
-    osInfo.update("version", systemPropertyAsJson("os.version"))
-    osInfo
+    Map(
+      "name" -> systemPropertyAsJson("os.name"),
+      "arch" -> systemPropertyAsJson("os.arch"),
+      "version" -> systemPropertyAsJson("os.version")
+    )
   }
 
   private def getVmInfo(termination: String) = {
     val runtimeMxBean = management.ManagementFactory.getRuntimeMXBean
     val vmArgs = runtimeMxBean.getInputArguments
 
-    val vmInfo = new mutable.HashMap[String, JsValue]
-    vmInfo.update("name", systemPropertyAsJson("java.vm.name"))
-    vmInfo.update("vm_version", systemPropertyAsJson("java.vm.version"))
-    vmInfo.update("jre_version", systemPropertyAsJson("java.version"))
-    vmInfo.update("args", vmArgs.asScala.toList.toJson)
-    vmInfo.update("termination", termination.toJson)
-    vmInfo
+    Map(
+      "name" -> systemPropertyAsJson("java.vm.name"),
+      "vm_version" -> systemPropertyAsJson("java.vm.version"),
+      "jre_version" -> systemPropertyAsJson("java.version"),
+      "args" -> vmArgs.asScala.toList.toJson,
+      "termination" -> termination.toJson
+    )
   }
 
   private def getMainManifest: java.util.jar.Manifest = {
@@ -182,29 +182,30 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
     }
 
     def getGitInfo = {
-      val git = new mutable.HashMap[String, JsValue]
-      git.update("commit_hash", manifestAttrAsJson("Git-Head-Commit", "unknown"))
-      git.update("commit_date", manifestAttrAsJson("Git-Head-Commit-Date", "unknown"))
-      git.update("dirty", manifestAttrAsJson("Git-Uncommitted-Changes", "true"))
-      git
+      Map(
+        "commit_hash" -> manifestAttrAsJson("Git-Head-Commit", "unknown"),
+        "commit_date" -> manifestAttrAsJson("Git-Head-Commit-Date", "unknown"),
+        "dirty" -> manifestAttrAsJson("Git-Uncommitted-Changes", "true")
+      )
     }
 
-    val result = new mutable.HashMap[String, JsValue]
-    result.update("git", getGitInfo.toMap.toJson)
-    result.update("name", manifestAttrAsJson("Specification-Title", ""))
-    result.update("version", manifestAttrAsJson("Specification-Version", ""))
-    result.toMap.toJson
+    Map(
+      "git" -> getGitInfo.toMap.toJson,
+      "name" -> manifestAttrAsJson("Specification-Title", ""),
+      "version" -> manifestAttrAsJson("Specification-Version", "")
+    ).toJson
   }
 
   override def store(normalTermination: Boolean): Unit = {
-    val tree = new mutable.HashMap[String, JsValue]
-    tree.update("format_version", 4.toJson)
-    tree.update("benchmarks", getBenchmarks.toList.toJson)
-    tree.update("environment", getEnvironment(if (normalTermination) "normal" else "forced"))
-    tree.update("suite", getSuiteInfo)
-    tree.update("data", getResultData.toMap.toJson)
+    val tree = Map(
+      "format_version" -> 4.toJson,
+      "benchmarks" -> getBenchmarks.toList.toJson,
+      "environment" -> getEnvironment(if (normalTermination) "normal" else "forced"),
+      "suite" -> getSuiteInfo,
+      "data" -> getResultData.toMap.toJson
+    )
 
-    writeToFile(filename, tree.toMap.toJson.prettyPrint)
+    writeToFile(filename, tree.toJson.prettyPrint)
   }
 
   private def getResultData = {
@@ -224,11 +225,12 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
         subtree += scores.toMap.toJson
       }
 
-      val resultsTree = new mutable.HashMap[String, JsValue]
-      resultsTree.update("results", subtree.toList.toJson)
-      resultsTree.update("termination", (if (benchFailed) "failure" else "normal").toJson)
+      val resultsTree = Map(
+        "results" -> subtree.toList.toJson,
+        "termination" -> (if (benchFailed) "failure" else "normal").toJson
+      )
 
-      dataTree.update(benchmark, resultsTree.toMap.toJson)
+      dataTree.update(benchmark, resultsTree.toJson)
     }
 
     dataTree

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -176,23 +176,23 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
 
   private def getSuiteInfo: JsValue = {
     val manifestAttrs = getMainManifest.getMainAttributes
-    val getManifestAttr = (key: String, defaultValue: String) => {
+    val manifestAttrAsJson = (key: String, defaultValue: String) => {
       val tmp = manifestAttrs.getValue(key)
       if (tmp == null) defaultValue.toJson else tmp.toJson
     }
 
     def getGitInfo = {
       val git = new mutable.HashMap[String, JsValue]
-      git.update("commit_hash", getManifestAttr("Git-Head-Commit", "unknown"))
-      git.update("commit_date", getManifestAttr("Git-Head-Commit-Date", "unknown"))
-      git.update("dirty", getManifestAttr("Git-Uncommitted-Changes", "true"))
+      git.update("commit_hash", manifestAttrAsJson("Git-Head-Commit", "unknown"))
+      git.update("commit_date", manifestAttrAsJson("Git-Head-Commit-Date", "unknown"))
+      git.update("dirty", manifestAttrAsJson("Git-Uncommitted-Changes", "true"))
       git
     }
 
     val result = new mutable.HashMap[String, JsValue]
     result.update("git", getGitInfo.toMap.toJson)
-    result.update("name", getManifestAttr("Specification-Title", ""))
-    result.update("version", getManifestAttr("Specification-Version", ""))
+    result.update("name", manifestAttrAsJson("Specification-Title", ""))
+    result.update("version", manifestAttrAsJson("Specification-Version", ""))
     result.toMap.toJson
   }
 

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -101,14 +101,23 @@ private final class CsvWriter(val filename: String) extends ResultWriter {
 
   override def store(normalTermination: Boolean): Unit = {
     val csv = new StringBuffer
+
+    val columns = getColumns
+    formatHeader(columns, csv)
+    formatResults(columns, csv)
+
+    writeToFile(filename, csv.toString)
+  }
+
+  private def formatHeader(columns: Seq[String], csv: StringBuffer) = {
     csv.append("benchmark")
-    val columns = new mutable.ArrayBuffer[String]
-    for (c <- getColumns) {
-      columns += c
+    for (c <- columns) {
       csv.append(",").append(c)
     }
     csv.append("\n")
+  }
 
+  private def formatResults(columns: Seq[String], csv: StringBuffer) = {
     for ((benchmark, goodRuns, results, repetitions) <- getResults) {
       for (i <- repetitions) {
         val line = new StringBuffer
@@ -121,9 +130,8 @@ private final class CsvWriter(val filename: String) extends ResultWriter {
         csv.append(line).append("\n")
       }
     }
-
-    writeToFile(filename, csv.toString)
   }
+
 }
 
 private final class JsonWriter(val filename: String) extends ResultWriter {

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -328,13 +328,13 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
       new java.util.jar.Manifest(stream)
     }
 
-    def manifestAttrAsJson(key: String, defaultValue: String) = {
-      Option(manifest.getMainAttributes.getValue(key)).getOrElse(defaultValue).toJson
+    def manifestAttrAsJson(key: String, defaultValue: String = null) = {
+      Option(manifest.getMainAttributes.getValue(key)).orElse(Option(defaultValue)).toJson
     }
 
     val gitInfo = Map(
-      "commit_hash" -> manifestAttrAsJson("Git-Head-Commit", "unknown"),
-      "commit_date" -> manifestAttrAsJson("Git-Head-Commit-Date", "unknown"),
+      "commit_hash" -> manifestAttrAsJson("Git-Head-Commit"),
+      "commit_date" -> manifestAttrAsJson("Git-Head-Commit-Date"),
       "dirty" -> manifestAttrAsJson("Git-Uncommitted-Changes", "true")
     )
 
@@ -342,8 +342,8 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
 
     Map(
       "git" -> gitInfo.toJson,
-      "name" -> manifestAttrAsJson("Specification-Title", ""),
-      "version" -> manifestAttrAsJson("Specification-Version", "")
+      "name" -> manifestAttrAsJson("Specification-Title"),
+      "version" -> manifestAttrAsJson("Specification-Version")
     )
   }
 

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -139,10 +139,10 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
 
   private def systemPropertyAsJson(name: String) = Option(System.getProperty(name)).toJson
 
-  private def getEnvironment(termination: String) = {
+  private def getEnvironment(normalTermination: Boolean) = {
     Map(
       "os" -> getOsInfo.toJson,
-      "vm" -> getVmInfo(termination).toJson
+      "vm" -> getVmInfo(normalTermination),
     )
   }
 
@@ -154,7 +154,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
     )
   }
 
-  private def getVmInfo(termination: String) = {
+  private def getVmInfo(normalTermination: Boolean) = {
     val runtimeMxBean = management.ManagementFactory.getRuntimeMXBean
 
     Map(
@@ -162,7 +162,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
       "vm_version" -> systemPropertyAsJson("java.vm.version"),
       "jre_version" -> systemPropertyAsJson("java.version"),
       "args" -> runtimeMxBean.getInputArguments.asScala.toList.toJson,
-      "termination" -> termination.toJson
+      "termination" -> (if (normalTermination) "normal" else "forced").toJson,
     )
   }
 
@@ -197,7 +197,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
     val result = Map(
       "format_version" -> 4.toJson,
       "benchmarks" -> getBenchmarkNames.toJson,
-      "environment" -> getEnvironment(if (normalTermination) "normal" else "forced").toJson,
+      "environment" -> getEnvironment(normalTermination).toJson,
       "suite" -> getSuiteInfo.toJson,
       "data" -> getResultData.toJson
     )

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -284,21 +284,20 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
   }
 
   private def getCompilationInfo = {
-    val info = management.ManagementFactory.getCompilationMXBean
-    if (info != null) {
-      val result = mutable.Buffer(
-        "name" -> info.getName.toJson
-      )
+    // Compilation MX Bean is not available in interpreted mode.
+    Option(management.ManagementFactory.getCompilationMXBean).map(
+      info => {
+        val result = mutable.Buffer(
+          "name" -> info.getName.toJson
+        )
 
-      if (info.isCompilationTimeMonitoringSupported) {
-        result += ("compilation_time_ms" -> info.getTotalCompilationTime.toJson)
+        if (info.isCompilationTimeMonitoringSupported) {
+          result += ("compilation_time_ms" -> info.getTotalCompilationTime.toJson)
+        }
+
+        result.toMap
       }
-
-      Option(result.toMap)
-    } else {
-      // Compilation MX Bean is not available in interpreted mode.
-      Option.empty
-    }
+    )
   }
 
   private def getClassLoadingInfo = {

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -182,21 +182,21 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
   }
 
   private def getVmInfo(normalTermination: Boolean) = {
-    val runtimeMxBean = management.ManagementFactory.getRuntimeMXBean
+    val runtime = management.ManagementFactory.getRuntimeMXBean
 
     Map(
-      "name" -> runtimeMxBean.getVmName.toJson,
-      "vendor" -> runtimeMxBean.getVmVendor.toJson,
-      "version" -> runtimeMxBean.getVmVersion.toJson,
-      "spec_name" -> runtimeMxBean.getSpecName.toJson,
-      "spec_vendor" -> runtimeMxBean.getSpecVendor.toJson,
-      "spec_version" -> runtimeMxBean.getSpecVersion.toJson,
+      "name" -> runtime.getVmName.toJson,
+      "vendor" -> runtime.getVmVendor.toJson,
+      "version" -> runtime.getVmVersion.toJson,
+      "spec_name" -> runtime.getSpecName.toJson,
+      "spec_vendor" -> runtime.getSpecVendor.toJson,
+      "spec_version" -> runtime.getSpecVersion.toJson,
       "mode" -> systemPropertyAsJson("java.vm.info"),
-      "args" -> runtimeMxBean.getInputArguments.asScala.toList.toJson,
+      "args" -> runtime.getInputArguments.asScala.toList.toJson,
       "termination" -> (if (normalTermination) "normal" else "forced").toJson,
-      "start_unix_ms" -> runtimeMxBean.getStartTime.toJson,
-      "start_iso" -> unixTimeAsIso(runtimeMxBean.getStartTime).toJson,
-      "uptime_ms" -> runtimeMxBean.getUptime.toJson,
+      "start_unix_ms" -> runtime.getStartTime.toJson,
+      "start_iso" -> unixTimeAsIso(runtime.getStartTime).toJson,
+      "uptime_ms" -> runtime.getUptime.toJson,
       "collectors" -> getCollectorInfo.toJson,
       "compiler" -> getCompilationInfo.toJson,
       "classloading" -> getClassLoadingInfo.toJson,
@@ -207,7 +207,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
   }
 
   private def getJreInfo = {
-    val runtimeMxBean = management.ManagementFactory.getRuntimeMXBean
+    val runtime = management.ManagementFactory.getRuntimeMXBean
 
     val result = mutable.Buffer(
       "name" -> systemPropertyAsJson("java.runtime.name"),
@@ -218,12 +218,12 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
       "spec_vendor" -> systemPropertyAsJson("java.specification.vendor"),
       "spec_version" -> systemPropertyAsJson("java.specification.version"),
       "home" -> systemPropertyAsJson("java.home"),
-      "library_path" -> pathsAsJson(runtimeMxBean.getLibraryPath),
-      "class_path" -> pathsAsJson(runtimeMxBean.getClassPath)
+      "library_path" -> pathsAsJson(runtime.getLibraryPath),
+      "class_path" -> pathsAsJson(runtime.getClassPath)
     )
 
-    if (runtimeMxBean.isBootClassPathSupported) {
-      result += ("boot_class_path" -> pathsAsJson(runtimeMxBean.getBootClassPath))
+    if (runtime.isBootClassPathSupported) {
+      result += ("boot_class_path" -> pathsAsJson(runtime.getBootClassPath))
     }
 
     result.toMap
@@ -245,12 +245,12 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
   }
 
   private def getMemoryInfo = {
-    val info = management.ManagementFactory.getMemoryMXBean
+    val memory = management.ManagementFactory.getMemoryMXBean
 
     Map(
-      "heap_usage" -> getMemoryUsageInfo(info.getHeapMemoryUsage).toJson,
-      "nonheap_usage" -> getMemoryUsageInfo(info.getNonHeapMemoryUsage).toJson,
-      "pending_finalization_count" -> info.getObjectPendingFinalizationCount.toJson
+      "heap_usage" -> getMemoryUsageInfo(memory.getHeapMemoryUsage).toJson,
+      "nonheap_usage" -> getMemoryUsageInfo(memory.getNonHeapMemoryUsage).toJson,
+      "pending_finalization_count" -> memory.getObjectPendingFinalizationCount.toJson
     )
   }
 
@@ -297,22 +297,22 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
   }
 
   private def getClassLoadingInfo = {
-    val info = management.ManagementFactory.getClassLoadingMXBean
+    val classLoading = management.ManagementFactory.getClassLoadingMXBean
 
     Map(
-      "class_count" -> info.getLoadedClassCount.toJson,
-      "classes_total" -> info.getTotalLoadedClassCount.toJson
+      "class_count" -> classLoading.getLoadedClassCount.toJson,
+      "classes_total" -> classLoading.getTotalLoadedClassCount.toJson
     )
   }
 
   private def getThreadInfo = {
-    val info = management.ManagementFactory.getThreadMXBean
+    val threads = management.ManagementFactory.getThreadMXBean
 
     Map(
-      "thread_count" -> info.getThreadCount.toJson,
-      "thread_count_max" -> info.getPeakThreadCount.toJson,
-      "daemon_thread_count" -> info.getDaemonThreadCount.toJson,
-      "threads_total" -> info.getTotalStartedThreadCount.toJson
+      "thread_count" -> threads.getThreadCount.toJson,
+      "thread_count_max" -> threads.getPeakThreadCount.toJson,
+      "daemon_thread_count" -> threads.getDaemonThreadCount.toJson,
+      "threads_total" -> threads.getTotalStartedThreadCount.toJson
     )
   }
 
@@ -359,7 +359,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
 
     val dataTree = mutable.Map[String, JsValue]()
     for ((benchmark, benchFailed, metricsByName, repetitionCount) <- getBenchmarkResults) {
-      // Collect (name -> value) tuples for metrics into a map for each repetition.
+      // For each repetition, collect (name -> value) tuples for metrics into a map.
       val repetitions = (0 until repetitionCount).map(
         i =>
           metricNames

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -137,14 +137,14 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
 
   private def systemPropertyAsJson(name: String) = Option(System.getProperty(name)).toJson
 
-  private def getEnvironment(termination: String): JsValue = {
+  private def getEnvironment(termination: String) = {
     val osInfo = getOsInfo
     val vmInfo = getVmInfo(termination)
 
     Map(
       "os" -> osInfo.toJson,
       "vm" -> vmInfo.toJson
-    ).toJson
+    )
   }
 
   private def getOsInfo = {
@@ -174,7 +174,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
     new java.util.jar.Manifest(stream)
   }
 
-  private def getSuiteInfo: JsValue = {
+  private def getSuiteInfo = {
     val manifest = getMainManifest
 
     def manifestAttrAsJson(key: String, defaultValue: String) = {
@@ -190,19 +190,19 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
     }
 
     Map(
-      "git" -> getGitInfo.toMap.toJson,
+      "git" -> getGitInfo.toJson,
       "name" -> manifestAttrAsJson("Specification-Title", ""),
       "version" -> manifestAttrAsJson("Specification-Version", "")
-    ).toJson
+    )
   }
 
   override def store(normalTermination: Boolean): Unit = {
     val tree = Map(
       "format_version" -> 4.toJson,
       "benchmarks" -> getBenchmarks.toList.toJson,
-      "environment" -> getEnvironment(if (normalTermination) "normal" else "forced"),
-      "suite" -> getSuiteInfo,
-      "data" -> getResultData.toMap.toJson
+      "environment" -> getEnvironment(if (normalTermination) "normal" else "forced").toJson,
+      "suite" -> getSuiteInfo.toJson,
+      "data" -> getResultData.toJson
     )
 
     writeToFile(filename, tree.toJson.prettyPrint)
@@ -233,7 +233,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
       dataTree.update(benchmark, resultsTree.toJson)
     }
 
-    dataTree
+    dataTree.toMap
   }
 
 }

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -14,13 +14,13 @@ import spray.json.DefaultJsonProtocol._
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-/** Common functionality for JSON and CSV results writers.
+/** Provides common functionality for JSON and CSV result writers.
  *
- * This class takes care of registering a shutdown hook so that the results
- * are not lost when JVM is forcefully terminated.
+ * Registers a shutdown hook to avoid losing unsaved results in case
+ * the JVM is forcefully terminated.
  *
- * Descendants are expected to override only the store() method that
- * actually stores the collected data.
+ * Subclasses are expected to only override the [[store()]] method
+ * which actually stores the collected data.
  */
 private abstract class ResultWriter
   extends BeforeHarnessShutdownListener
@@ -37,7 +37,6 @@ private abstract class ResultWriter
 
   Runtime.getRuntime.addShutdownHook(storeHook)
 
-  protected def store(normalTermination: Boolean): Unit
   // A result is a map of metric names to a sequence of metric values.
   private final val resultsByBenchmarkName =
     mutable.Map[String, mutable.Map[String, mutable.Buffer[Long]]]()
@@ -96,6 +95,9 @@ private abstract class ResultWriter
     FileUtils.write(new File(fileName), string, StandardCharsets.UTF_8, false)
   }
 
+  //
+
+  protected def store(normalTermination: Boolean): Unit
 }
 
 private final class CsvWriter(val filename: String) extends ResultWriter {

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -112,12 +112,12 @@ private final class CsvWriter(val filename: String) extends ResultWriter {
     writeToFile(filename, csv.toString)
   }
 
-  private def formatHeader(metricNames: Seq[String], csv: StringBuffer) = {
+  private def formatHeader(metricNames: Seq[String], csv: StringBuffer): Unit = {
     // There will always be at least one column after "benchmark".
     csv.append("benchmark,").append(metricNames.mkString(",")).append("\n")
   }
 
-  private def formatResults(metricNames: Seq[String], csv: StringBuffer) = {
+  private def formatResults(metricNames: Seq[String], csv: StringBuffer): Unit = {
     for ((benchmark, _, metricsByName, repetitionCount) <- getBenchmarkResults) {
       for (i <- 0 until repetitionCount) {
         csv.append(benchmark)

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -209,7 +209,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
   private def getJreInfo = {
     val runtimeMxBean = management.ManagementFactory.getRuntimeMXBean
 
-    Map(
+    val result = mutable.Buffer(
       "name" -> systemPropertyAsJson("java.runtime.name"),
       "version" -> systemPropertyAsJson("java.runtime.version"),
       "java_vendor" -> systemPropertyAsJson("java.vendor"),
@@ -219,9 +219,14 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
       "spec_version" -> systemPropertyAsJson("java.specification.version"),
       "home" -> systemPropertyAsJson("java.home"),
       "library_path" -> pathsAsJson(runtimeMxBean.getLibraryPath),
-      "boot_class_path" -> pathsAsJson(runtimeMxBean.getBootClassPath),
       "class_path" -> pathsAsJson(runtimeMxBean.getClassPath)
     )
+
+    if (runtimeMxBean.isBootClassPathSupported) {
+      result += ("boot_class_path" -> pathsAsJson(runtimeMxBean.getBootClassPath))
+    }
+
+    result.toMap
   }
 
   private def unixTimeAsIso(unixTime: Long) = {

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -78,17 +78,17 @@ private abstract class ResultWriter
   }
 
   protected final def getResults
-    : Iterable[(String, Boolean, Map[String, mutable.ArrayBuffer[Long]], Iterable[Int])] =
+    : Iterable[(String, Boolean, Map[String, mutable.ArrayBuffer[Long]], Int)] =
     for {
       benchName <- getBenchmarks
       benchResults = allResults(benchName)
-      maxIndex = benchResults.values.map(_.size).max - 1
+      valueCountMax = benchResults.values.map(_.size).max
     } yield
       (
         benchName,
         !failedBenchmarks.contains(benchName),
         benchResults.toMap,
-        0 to maxIndex
+        valueCountMax
       )
 
   protected final def writeToFile(fileName: String, string: String): Unit = {
@@ -116,7 +116,7 @@ private final class CsvWriter(val filename: String) extends ResultWriter {
 
   private def formatResults(columns: Seq[String], csv: StringBuffer) = {
     for ((benchmark, goodRuns, results, repetitions) <- getResults) {
-      for (i <- repetitions) {
+      for (i <- 0 until repetitions) {
         csv.append(benchmark)
 
         for (c <- columns) {
@@ -196,7 +196,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
     val dataTree = new mutable.HashMap[String, JsValue]
     for ((benchmark, goodRuns, results, repetitions) <- getResults) {
       val subtree = new mutable.ArrayBuffer[JsValue]
-      for (i <- repetitions) {
+      for (i <- 0 until repetitions) {
         val scores = new mutable.HashMap[String, JsValue]
         for (c <- columns) {
           val values = results.getOrElse(c, new mutable.ArrayBuffer)

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -175,10 +175,10 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
   }
 
   private def getSuiteInfo: JsValue = {
-    val manifestAttrs = getMainManifest.getMainAttributes
-    val manifestAttrAsJson = (key: String, defaultValue: String) => {
-      val tmp = manifestAttrs.getValue(key)
-      if (tmp == null) defaultValue.toJson else tmp.toJson
+    val manifest = getMainManifest
+
+    def manifestAttrAsJson(key: String, defaultValue: String) = {
+      Option(manifest.getMainAttributes.getValue(key)).getOrElse(defaultValue).toJson
     }
 
     def getGitInfo = {

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -110,24 +110,22 @@ private final class CsvWriter(val filename: String) extends ResultWriter {
   }
 
   private def formatHeader(columns: Seq[String], csv: StringBuffer) = {
-    csv.append("benchmark")
-    for (c <- columns) {
-      csv.append(",").append(c)
-    }
-    csv.append("\n")
+    // There will always be at least one column after "benchmark".
+    csv.append("benchmark,").append(columns.mkString(",")).append("\n")
   }
 
   private def formatResults(columns: Seq[String], csv: StringBuffer) = {
     for ((benchmark, goodRuns, results, repetitions) <- getResults) {
       for (i <- repetitions) {
-        val line = new StringBuffer
-        line.append(benchmark)
+        csv.append(benchmark)
+
         for (c <- columns) {
           val values = results.getOrElse(c, new mutable.ArrayBuffer)
-          val score = if (i < values.size) values(i).toString else "NA"
-          line.append(",").append(score.toString)
+          val score = if (values.isDefinedAt(i)) values(i).toString else "NA"
+          csv.append(",").append(score)
         }
-        csv.append(line).append("\n")
+
+        csv.append("\n")
       }
     }
   }
@@ -202,7 +200,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
         val scores = new mutable.HashMap[String, JsValue]
         for (c <- columns) {
           val values = results.getOrElse(c, new mutable.ArrayBuffer)
-          if (i < values.size) {
+          if (values.isDefinedAt(i)) {
             scores.update(c, values(i).toJson)
           }
         }

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -255,9 +255,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
   }
 
   private def getMemoryPoolInfo = {
-    val pools = management.ManagementFactory.getMemoryPoolMXBeans.asScala
-
-    pools
+    management.ManagementFactory.getMemoryPoolMXBeans.asScala
       .map(pool => {
         Map(
           "name" -> pool.getName.toJson,
@@ -270,9 +268,7 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
   }
 
   private def getCollectorInfo = {
-    val collectors = management.ManagementFactory.getGarbageCollectorMXBeans.asScala
-
-    collectors
+    management.ManagementFactory.getGarbageCollectorMXBeans.asScala
       .map(gc => {
         Map(
           "name" -> gc.getName.toJson,

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -49,12 +49,15 @@ private abstract class ResultWriter
     // the results when user sends Ctrl-C when store() is already being
     // called (i.e. shutdown hook is still registered but is *almost*
     // no longer needed).
+    if (normalTermination) {
+      Runtime.getRuntime.removeShutdownHook(storeHook)
+    }
+
     store(normalTermination)
   }
 
   final override def beforeHarnessShutdown(): Unit = {
     storeResults(true)
-    Runtime.getRuntime.removeShutdownHook(storeHook)
   }
 
   final override def onMeasurementResult(

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -60,10 +60,8 @@ private abstract class ResultWriter
     metric: String,
     value: Long
   ): Unit = {
-    val benchStorage = allResults.getOrElse(benchmark, new mutable.HashMap)
-    allResults.update(benchmark, benchStorage)
-    val metricStorage = benchStorage.getOrElse(metric, new mutable.ArrayBuffer)
-    benchStorage.update(metric, metricStorage)
+    val benchStorage = allResults.getOrElseUpdate(benchmark, new mutable.HashMap)
+    val metricStorage = benchStorage.getOrElseUpdate(metric, new mutable.ArrayBuffer)
     metricStorage += value
   }
 


### PR DESCRIPTION
This adds VM uptime timestamps (in nanoseconds) to the start of measured operations, as discussed in #107. To determine the value of `nanoTime()` at VM start, we use the average of two `nanoTime()` readings straddling two distinct but consecutive `currentTimeMillis()` values so that we get somewhere in the middle of the platforms `currentTimeMillis()` accuracy. 

Because this changes the version of the JSON output format, I also bundled changes which add much more info about the environment to the JSON output file (basically everything there is that you get in the `VM Summary` tab of `jconsole`). While the information is not going to be used most of the time, it does provide a more colorful picture of the VM the results were collected on (which GC, which compilation system, etc) which is sometimes useful (in retrospect).

All commits except the last massage the `ResultWriter` so that the very last commit (which actually adds the timestamps and the extra info) looks simple :-)