### PR TITLE
finagle-chirper: fix resource path creation

### DIFF
--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleChirper.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleChirper.scala
@@ -353,7 +353,9 @@ final class FinagleChirper extends Benchmark {
     }
   }
 
-  val inputFile = File.separator + "new-years-resolution.csv"
+  // Start with / so it is treated as an absolute path
+  // (here, "/" is platform independent according to the JavaDoc)
+  val inputFile = "/new-years-resolution.csv"
 
   lazy val messages = IOUtils
     .toString(this.getClass.getResourceAsStream(inputFile), StandardCharsets.UTF_8)


### PR DESCRIPTION
This shall fix #211 (finagle-chirper fails on x86-64 Windows).