### PR TITLE
Add JDK8 and JDK11 charts on the main page

### DIFF
--- a/website/_layouts/mainrenaissance.html
+++ b/website/_layouts/mainrenaissance.html
@@ -144,7 +144,14 @@ layout: base
   <div class="container_16">
     <div class="grid_16">
       <div id="measurements" class="text-snippet">
-        <img src="https://github.com/renaissance-benchmarks/measurements/raw/master/stripe.png"/>
+        <ul id="jdk-tabs">
+
+          <li><a id="jdk8">JDK 8</a></li>
+          <li><a id="jdk11">JDK 11</a></li>
+
+        </ul>
+        <div class="jdk-container" id="jdk8C"><img src="https://github.com/renaissance-benchmarks/measurements/raw/master/stripe-jdk-8.png"/></div>
+        <div class="jdk-container" id="jdk11C"><img src="https://github.com/renaissance-benchmarks/measurements/raw/master/stripe-jdk-11.png"/></div>
         <p>
           Sample benchmark measurements showing performance of multiple JVM implementations against the <a href="https://openjdk.java.net">OpenJDK</a> baseline.
           Visit <a href="https://github.com/renaissance-benchmarks/measurements">the measurements repository</a> for more technical details about the measurements.
@@ -152,6 +159,26 @@ layout: base
       </div>
     </div>
   </div>
+  <script type='text/javascript'>
+  $(document).ready(function() {
+
+  $('#jdk-tabs li a:not(:first)').addClass('inactive');
+  $('.jdk-container').hide();
+  $('.jdk-container:first').show();
+
+  $('#jdk-tabs li a').click(function(){
+      var t = $(this).attr('id');
+    if($(this).hasClass('inactive')){ //this is the start of our condition
+      $('#jdk-tabs li a').addClass('inactive');
+      $(this).removeClass('inactive');
+
+      $('.jdk-container').hide();
+      $('#'+ t + 'C').fadeIn('slow');
+   }
+  });
+
+  });
+  </script>
 
   <br/>
   <br/>

--- a/website/resources/styles/proj.css
+++ b/website/resources/styles/proj.css
@@ -1139,3 +1139,94 @@ a.faint-link:hover {
 #measurements img {
   width: 960px;
 }
+
+#jdk-tabs {
+  width: 100%;
+  height:30px;
+  border-bottom: solid 1px #CCC;
+  padding-right: 2px;
+  margin-top: 30px;
+}
+a {
+  cursor:pointer;
+}
+
+#jdk-tabs li {
+  float:left;
+  list-style:none;
+  border-top:1px solid #ccc;
+  border-left:1px solid #ccc;
+  border-right:1px solid #ccc;
+  margin-right:5px;
+  border-top-left-radius:3px;
+  border-top-right-radius:3px;
+  outline:none;
+}
+
+#jdk-tabs li a {
+  font-family:Arial, Helvetica, sans-serif;
+  font-size: small;
+  font-weight: bold;
+  color: #e9726e;
+  padding-top: 5px;
+  padding-left: 7px;
+  padding-right: 7px;
+  padding-bottom: 8px;
+  display:block;
+  background: #FFF;
+  border-top-left-radius:3px;
+  border-top-right-radius:3px;
+  text-decoration:none;
+  outline:none;
+}
+
+#jdk-tabs li a.inactive{
+  padding-top:5px;
+  padding-bottom:8px;
+  padding-left: 8px;
+  padding-right: 8px;
+  color:#666666;
+  background: #EEE;
+  outline:none;
+  border-bottom: solid 1px #CCC;
+}
+
+#jdk-tabs li a:hover, #jdk-tabs li a.inactive:hover {
+  color: #e9726e;
+  outline:none;
+}
+
+.jdk-container {
+  clear:both;
+  width:100%;
+  text-align:left;
+  padding-top: 20px;
+}
+
+.jdk-container h2 {
+  margin-left: 15px;
+  margin-right: 15px;
+  margin-bottom: 10px;
+  color: #e9726e;
+}
+
+.jdk-container p {
+  margin-left: 15px;
+  margin-right: 15px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  line-height: 1.3;
+  font-size: small;
+}
+
+.jdk-container ul {
+  margin-left: 25px;
+  font-size: small;
+  line-height: 1.4;
+  list-style-type: disc;
+}
+
+.jdk-container li {
+  padding-bottom: 5px;
+  margin-left: 5px;
+}


### PR DESCRIPTION
Website update to show the latest numbers from https://github.com/renaissance-benchmarks/measurements/pull/4/

Each JDK is shown in a different tab, making it future proof.

This assumes that, once the above PR will be merged, the JDK 8 and JDK 11 charts will be available at location : 

- https://github.com/renaissance-benchmarks/measurements/raw/master/stripe-jdk-8.png
- https://github.com/renaissance-benchmarks/measurements/raw/master/stripe-jdk-11.png

![JDK8](https://user-images.githubusercontent.com/2393555/77252521-97ea7880-6c54-11ea-86f9-9090f1cacb14.png)
![JDK11](https://user-images.githubusercontent.com/2393555/77252524-991ba580-6c54-11ea-8feb-223069e6facf.png)
