### PR TITLE
Address RDD caching problems

### DIFF
--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
@@ -86,6 +86,7 @@ final class Als extends Benchmark with SparkUtil {
     sc = setUpSparkContext(tempDirPath, THREAD_COUNT, "als")
     prepareInput()
     loadData()
+    ensureCaching(ratings)
   }
 
   override def tearDownAfterAll(c: BenchmarkContext): Unit = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ChiSquare.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ChiSquare.scala
@@ -101,6 +101,7 @@ final class ChiSquare extends Benchmark with SparkUtil {
     sc = setUpSparkContext(tempDirPath, threadCountParam, "chi-square")
     prepareInput()
     loadData()
+    ensureCaching(input)
   }
 
   override def run(c: BenchmarkContext): BenchmarkResult = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/DecTree.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/DecTree.scala
@@ -118,7 +118,7 @@ final class DecTree extends Benchmark with SparkUtil {
 
     tempDirPath = c.generateTempDir("dec_tree")
     sc = setUpSparkContext(tempDirPath, threadCountParam, "dec-tree")
-    training = prepareAndLoadInput(decisionTreePath, inputFile)
+    training = prepareAndLoadInput(decisionTreePath, inputFile).cache()
     pipeline = constructPipeline()
   }
 

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/GaussMix.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/GaussMix.scala
@@ -86,6 +86,7 @@ final class GaussMix extends Benchmark with SparkUtil {
     sc = setUpSparkContext(tempDirPath, threadCountParam, "gauss-mix")
     prepareInput()
     loadData()
+    ensureCaching(input)
   }
 
   def prepareInput() = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
@@ -107,6 +107,7 @@ final class LogRegression extends Benchmark with SparkUtil {
     sc = setUpSparkContext(tempDirPath, threadCountParam, "log-regression")
     prepareInput()
     loadData()
+    checkCaching(rdd)
   }
 
   override def run(c: BenchmarkContext): BenchmarkResult = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
@@ -107,7 +107,7 @@ final class LogRegression extends Benchmark with SparkUtil {
     sc = setUpSparkContext(tempDirPath, threadCountParam, "log-regression")
     prepareInput()
     loadData()
-    checkCaching(rdd)
+    ensureCaching(rdd)
   }
 
   override def run(c: BenchmarkContext): BenchmarkResult = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
@@ -96,7 +96,7 @@ final class LogRegression extends Benchmark with SparkUtil {
           features(index) = value
         }
         (parts(0).toDouble, Vectors.dense(features))
-      }
+      }.cache()
   }
 
   override def setUpBeforeAll(c: BenchmarkContext): Unit = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/NaiveBayes.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/NaiveBayes.scala
@@ -83,6 +83,7 @@ class NaiveBayes extends Benchmark with SparkUtil {
     sc = setUpSparkContext(tempDirPath, THREAD_COUNT, "naive-bayes")
     prepareInput()
     loadData()
+    ensureCaching(data)
   }
 
   override def tearDownAfterAll(c: BenchmarkContext): Unit = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
@@ -109,7 +109,7 @@ final class PageRank extends Benchmark with SparkUtil {
     tempDirPath = c.generateTempDir("page_rank")
     sc = setUpSparkContext(tempDirPath, threadCountParam, "page-rank")
     links = loadData(INPUT_ZIP_RESOURCE, INPUT_ZIP_ENTRY, inputLineCountParam)
-
+    ensureCaching(links)
   }
 
   override def run(c: BenchmarkContext): BenchmarkResult = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
@@ -8,6 +8,8 @@ import java.nio.file.Paths
 import org.apache.commons.io.IOUtils
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+
 
 trait SparkUtil {
 
@@ -57,6 +59,12 @@ trait SparkUtil {
         new FileOutputStream(winutilsPath.toString + winUtils)
       )
       System.setProperty("hadoop.home.dir", tempDirPath.toAbsolutePath.toString)
+    }
+  }
+
+  def checkCaching[T](rdd: RDD[T]): Unit = {
+    if (!rdd.getStorageLevel.useMemory) {
+      throw new Exception("Spark RDD must be cached !")
     }
   }
 }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
@@ -62,7 +62,7 @@ trait SparkUtil {
     }
   }
 
-  def checkCaching[T](rdd: RDD[T]): Unit = {
+  def ensureCaching[T](rdd: RDD[T]): Unit = {
     if (!rdd.getStorageLevel.useMemory) {
       throw new Exception("Spark RDD must be cached !")
     }


### PR DESCRIPTION
This fixes #226 .
Moreover, since we don't really have unit tests, I've added a `checkCaching` method to the `SparkUtil` trait. That way we can explicitly mark some RDDs that need to be cached and fail otherwise. That will make things explicit and avoid such problems in the future.
Before I start porting this extra check to all Spark benchmarks that use RDDs, please let me know if you think this idea makes sense (or if you see a better way to achieve the same thing).