### PR TITLE
Don't include dummy benchmarks/groups in output of CLI list commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ refs:
       - 'test $(unzip -p renaissance-jmh/target/scala-2.12/renaissance-jmh-assembly-$RENAISSANCE_VERSION.jar META-INF/BenchmarkList | wc -l) -gt 0'
       - 'java -version'
       # Test benchmarks under Renaissance harness
-      - 'java -jar ./target/renaissance-gpl-$RENAISSANCE_VERSION.jar --raw-list | grep -v "^dummy" >list.txt'
+      - 'java -jar ./target/renaissance-gpl-$RENAISSANCE_VERSION.jar --raw-list >list.txt'
       - 'for BENCH in $(cat list.txt); do echo "====> $BENCH"; java -Xms2500M -Xmx2500M -jar ./target/renaissance-gpl-$RENAISSANCE_VERSION.jar -c test -r 1 --csv output.csv --json output.json "$BENCH" || exit 1; done'
       # Test benchmarks under JMH harness
       - 'java -Xms2500M -Xmx2500M -jar ./renaissance-jmh/target/scala-2.12/renaissance-jmh-assembly-$RENAISSANCE_VERSION.jar -wi 0 -i 1 -f 1 -foe true'

--- a/renaissance-core/src/main/java/org/renaissance/core/BenchmarkRegistry.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/BenchmarkRegistry.java
@@ -134,7 +134,6 @@ public final class BenchmarkRegistry {
     return benchmarksByName.get(name);
   }
 
-
   public List<BenchmarkInfo> getAll() {
     return new ArrayList<>(benchmarksByName.values());
   }
@@ -157,16 +156,6 @@ public final class BenchmarkRegistry {
 
   public Map<String, List<BenchmarkInfo>> byGroup() {
     return Collections.unmodifiableMap(benchmarksByGroup);
-  }
-
-
-  public List<String> names() {
-    return new ArrayList<>(benchmarksByName.keySet());
-  }
-
-
-  public List<String> groupNames() {
-    return new ArrayList<>(benchmarksByGroup.keySet());
   }
 
 


### PR DESCRIPTION
Removes `dummy` benchmarks and groups from the output of the `--list`, `--raw-list`, and `--group-list` CLI commands to remove the need to filter out these in scripts. This fixes #220. 

This is consistent with the fact that dummy benchmarks are ignored when the user requests to run `all` benchmarks, where `all` is considered to be a special group containing all (public) benchmarks.

I'm not so sure if this is the right behavior for the `--list` command, which is not usually consumed by scripts, but my OCD was happier when I filtered it everywhere :-)

This does not affect the list in `README.md`, where these dummy benchmarks/groups are still listed.