### PR TITLE
Add missing default case to OS-type match in ResultWriter

### DIFF
--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -176,6 +176,9 @@ private final class JsonWriter(val filename: String) extends ResultWriter {
           "max_fd_count" -> unixOs.getMaxFileDescriptorCount.toJson,
           "open_fd_count" -> unixOs.getOpenFileDescriptorCount.toJson
         )
+
+      // No extra information to collect on non-Unix systems.
+      case _ =>
     }
 
     result.toMap


### PR DESCRIPTION
The intent is to collect additional information on systems that support it and do nothing on other systems. The missing match instead caused a MatchError on non-Unix systems.

Should fix #236
