### PR TITLE
Clean up apache-spark benchmarks

### DIFF
--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ChiSquare.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ChiSquare.scala
@@ -84,7 +84,6 @@ final class ChiSquare extends Benchmark with SparkUtil {
         val raw = line.split(" ").map(_.toDouble)
         new LabeledPoint(raw.head, Vectors.dense(raw.tail))
       }
-      .cache()
   }
 
   override def setUpBeforeAll(bc: BenchmarkContext): Unit = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/DecTree.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/DecTree.scala
@@ -72,7 +72,7 @@ final class DecTree extends Benchmark with SparkUtil {
 
   private def loadData(inputFile: Path): DataFrame = {
     val sqlContext = new SQLContext(sparkContext)
-    sqlContext.read.format("libsvm").load(inputFile.toString).cache()
+    sqlContext.read.format("libsvm").load(inputFile.toString)
   }
 
   def constructPipeline(): Pipeline = {
@@ -114,7 +114,7 @@ final class DecTree extends Benchmark with SparkUtil {
       bc.scratchDirectory().resolve("input.txt")
     )
 
-    inputTrainingData = loadData(inputFile)
+    inputTrainingData = ensureCached(loadData(inputFile))
   }
 
   override def run(bc: BenchmarkContext): BenchmarkResult = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/GaussMix.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/GaussMix.scala
@@ -89,7 +89,6 @@ final class GaussMix extends Benchmark with SparkUtil {
         val raw = line.split(" ").map(_.toDouble)
         Vectors.dense(raw)
       }
-      .cache()
   }
 
   override def setUpBeforeAll(bc: BenchmarkContext): Unit = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
@@ -96,7 +96,6 @@ final class LogRegression extends Benchmark with SparkUtil {
         }
         (parts(0).toDouble, Vectors.dense(features))
       }
-      .cache()
   }
 
   override def setUpBeforeAll(bc: BenchmarkContext): Unit = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/MovieLens.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/MovieLens.scala
@@ -261,7 +261,13 @@ final class MovieLens extends Benchmark with SparkUtil {
   }
 
   override def setUpBeforeAll(bc: BenchmarkContext): Unit = {
-    setUpSparkContext(bc)
+    //
+    // Without a checkpoint directory set, JMH runs of this
+    // benchmark in Travis CI tend to crash with stack overflow.
+    //
+    // TODO Only use checkpoint directory in test runs.
+    //
+    setUpSparkContext(bc, useCheckpointDir = true)
 
     inputFileParam = bc.parameter("input_file").value
 

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/MovieLens.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/MovieLens.scala
@@ -181,33 +181,33 @@ final class MovieLens extends Benchmark with SparkUtil {
     }
 
     def trainModels(configs: Iterable[AlsConfig]) = {
-
       // Train models and evaluate them on the validation set.
-
       for (config <- configs) {
-        def trainModel(ratings: RDD[Rating]) = {
-          new ALS()
-            .setIntermediateRDDStorageLevel(StorageLevel.MEMORY_ONLY)
-            .setFinalRDDStorageLevel(StorageLevel.MEMORY_ONLY)
-            .setIterations(config.iterations)
-            .setLambda(config.lambda)
-            .setRank(config.rank)
-            .setSeed(randomSeed)
-            .run(ratings)
-        }
+        val model = trainModel(training, config)
 
-        val model = trainModel(training)
         val validationRmse = computeRmse(model, validation, numValidation)
         println(
           s"RMSE (validation) = $validationRmse for the model trained with rank = ${config.rank}, " +
             s"lambda = ${config.lambda}, and numIter = ${config.iterations}."
         )
+
         if (validationRmse < bestValidationRmse) {
           bestModel = Some(model)
           bestValidationRmse = validationRmse
           bestConfig = config
         }
       }
+    }
+
+    private def trainModel(ratings: RDD[Rating], config: AlsConfig) = {
+      new ALS()
+        .setIntermediateRDDStorageLevel(StorageLevel.MEMORY_ONLY)
+        .setFinalRDDStorageLevel(StorageLevel.MEMORY_ONLY)
+        .setIterations(config.iterations)
+        .setLambda(config.lambda)
+        .setRank(config.rank)
+        .setSeed(randomSeed)
+        .run(ratings)
     }
 
     def recommendMovies() = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/NaiveBayes.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/NaiveBayes.scala
@@ -84,7 +84,6 @@ final class NaiveBayes extends Benchmark with SparkUtil {
         }
         new LabeledPoint(parts(0).toDouble, Vectors.dense(features))
       }
-      .cache()
   }
 
   override def setUpBeforeAll(bc: BenchmarkContext): Unit = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
@@ -88,7 +88,6 @@ final class PageRank extends Benchmark with SparkUtil {
           parts(0).toInt -> parts(1).toInt
         }
         .groupByKey()
-        .cache()
     } finally {
       inputSource.close()
     }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ResourceUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ResourceUtil.scala
@@ -2,12 +2,29 @@ package org.renaissance.apache.spark
 
 import java.io.FileNotFoundException
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import java.util.zip.ZipInputStream
-
 import scala.io.BufferedSource
 import scala.io.Source
 
 private object ResourceUtil {
+
+  /**
+   * Writes a resource associated with the {@link ResourceUtil} class
+   * to a file, replacing an existing file.
+   *
+   * @param resourceName path to the ZIP resource
+   * @param file path the output file
+   * @return {@link Path} path to the output file
+   */
+  def writeResourceToFile(resourceName: String, file: Path) = {
+    val resourceStream = getClass.getResourceAsStream(resourceName)
+    Files.copy(resourceStream, file, StandardCopyOption.REPLACE_EXISTING)
+
+    file
+  }
 
   /**
    * Creates a {@link Source} from a file within a ZIP resource

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
@@ -131,11 +131,11 @@ trait SparkUtil {
   }
 
   def ensureCached[T](rdd: RDD[T]): RDD[T] = {
-    if (!rdd.getStorageLevel.useMemory) {
-      throw new Exception("Spark RDD must be cached!")
-    }
+    rdd.persist(StorageLevel.MEMORY_ONLY).localCheckpoint()
+  }
 
-    rdd
+  def ensureCached[T](ds: Dataset[T]): Dataset[T] = {
+    ds.persist(StorageLevel.MEMORY_ONLY).localCheckpoint()
   }
 
   private def setUpLoggers(sparkLevel: Level, jettyLevel: Level) = {

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
@@ -2,6 +2,8 @@ package org.renaissance.apache.spark
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkConf
+import org.apache.log4j.Level
+import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.renaissance.Benchmark.Name
 import org.renaissance.BenchmarkContext
@@ -25,8 +27,12 @@ trait SparkUtil {
   private val winutilsSize = 109568
 
   protected var sparkContext: SparkContext = _
+  private val sparkLogLevel = Level.WARN
+  private val jettyLogLevel = Level.WARN
 
   def setUpSparkContext(bc: BenchmarkContext): SparkContext = {
+    setUpLoggers(sparkLogLevel, jettyLogLevel)
+
     val scratchDir = bc.scratchDirectory()
     setUpHadoop(scratchDir.resolve("hadoop"))
 
@@ -57,6 +63,7 @@ trait SparkUtil {
     sparkContext = new SparkContext(conf)
     sparkContext.setLogLevel("ERROR")
     sparkContext
+    sparkContext.setLogLevel(sparkLogLevel.toString)
   }
 
   def tearDownSparkContext(sc: SparkContext): Unit = {
@@ -112,4 +119,10 @@ trait SparkUtil {
 
     rdd
   }
+
+  private def setUpLoggers(sparkLevel: Level, jettyLevel: Level) = {
+    Logger.getLogger("org.apache.spark").setLevel(sparkLevel)
+    Logger.getLogger("org.eclipse.jetty.server").setLevel(jettyLevel)
+  }
+
 }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
@@ -70,6 +70,24 @@ trait SparkUtil {
     if (sc != null) {
       sc.stop()
     }
+  def createRddFromCsv[T: ClassTag](
+    file: Path,
+    header: Boolean,
+    delimiter: String,
+    mapper: Array[String] => T
+  ) = {
+    val lines = textFileAsRdd(file)
+    val linesWithoutHeader = if (header) dropFirstLine(lines) else lines
+    linesWithoutHeader.map(_.split(delimiter)).map[T](mapper).filter(_ != null)
+  }
+
+  private def textFileAsRdd(file: Path): RDD[String] = {
+    sparkContext.textFile(file.toString)
+  }
+
+  private def dropFirstLine(lines: RDD[String]): RDD[String] = {
+    val first = lines.first
+    lines.filter { line => line != first }
   }
 
   def tearDownSparkContext(): Unit = {

--- a/renaissance-core/src/main/java/org/renaissance/BenchmarkParameter.java
+++ b/renaissance-core/src/main/java/org/renaissance/BenchmarkParameter.java
@@ -1,6 +1,7 @@
 package org.renaissance;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -71,5 +72,28 @@ public interface BenchmarkParameter {
    * @return Parameter value as {@code double}.
    */
   <T> List<T> toList(Function<String, T> parser);
+
+  /**
+   * Interprets the value as a CSV-like table with rows separated by
+   * semicolons, columns separated by commas, and a header row with
+   * column names.
+   *
+   * @return A {@link List} of rows represented by a {@link Map} of column
+   * names to string values, with rows and columns preserving iteration order.
+   */
+  List<Map<String, String>> toCsvRows();
+
+  /**
+   * Interprets the value as a CSV-like table with rows separated by
+   * semicolons, columns separated by commas, and a header row with
+   * column names.
+   *
+   * @param parser Function to parse a row from a {@link Map} containing
+   * column values keyed by column names.
+   *
+   * @return A {@link List} of rows represented by a {@link Map} of column
+   * names to string values, with rows and columns preserving iteration order.
+   */
+  <R> List<R> toCsvRows(Function<Map<String, String>, R> parser);
 
 }


### PR DESCRIPTION
This was originally intended as a simple follow-up to #246 (making actual use of the scratch directory), but I ended up reorganizing the code around a common pattern so that the benchmarks all look alike. The following benchmarks are being updated:
- [x] `als`
- [x]  `chi-square`
- [x] `dec-tree`
- [x] `gauss-mix`
- [x] `log-regression`
- [x] `movie-lens`
- [x] `naive-bayes`
- [x] `page-rank`

### Common changes

#### Code organization

- Avoid relying on method side-effects in the code responsible for preparing the input datasets.
  - The benchmark setup code now follows a common pattern in which `prepareInput()`, `loadData()` and `ensureCached()` methods return values that need to be passed around.
  - This makes the data flow more explicit and easier to follow, in addition to clearly separating preparation and loading.
- Use more (very) prominent names for the fields representing computation inputs and outputs.
- Get rid of unnecessary state held between benchmark method calls.
- Dump the result of the last repetition in benchmark teardown, so that we can find data to validate against.
  - Each benchmark (except `page-rank`, which already has validation) contains a `dumpResult()` method.
- Stop using all caps for constant-like values (follows Scala style).

#### Benchmark parameters

- Unify Spark parallelism level parameters
  - Introduce the `spark_executor_count` parameter, which determines the number of Spark executor instances. It currently defaults to `4`, but making the parameter explicit will (eventually) allow setting it from outside.
  - Rename the `thread_count` to `spark_executor_thread_count` (to make it clear that it represents the number of threads per Spark executor) and make it available in all Spark benchmarks.
- Add summary text to benchmark parameters which influence the workload size, e.g., `copy_count`, `input_line_count`.

#### Spark context handling

- Simplify the calls to the `setUpSparkContext()` method
  - Pass the `BenchmarkContext` instance to the method so that it can query the `spark_executor_count` and the `spark_executor_thread_count` parameters and the benchmark's scratch directory on its own.
  - Query the benchmark's `@Name` annotation to find out the benchmark's name, instead of having to duplicate it in code.
- Keep  `sparkContext` in the `SparkUtil` trait and have the benchmarks inherit the field.
- Use `SparkSession` and avoid creating `SparkConf` and `SparkContext` directly.

#### Spark RDD caching

- The `ensureCached()` method now sets the `RDD` or `Dataset` storage level to `MEMORY_ONLY` using the `persist()` method, because the `cache()` method switched to using `MEMORY_AND_DISK` in newer Spark versions.

#### Spark logging

- Spark loggers are now configured in all Spark benchmarks. For now, they are set to report at the `WARN` level.
- Most benchmarks will now output less Spark-related information during startup because they used to report at the `INFO` level and switching to `ERROR` level on `SparkContext`.
- The `movie-lens` benchmark may report a bit more because it used to report at the `ERROR` level only.

#### Scratch file handling

- Use the benchmark-specific scratch directory (instead of the hard-coded `target/<bench-name>` directory) for preparing the input datasets as well as for dumping the computation output after the last iteration.
- Use JDK-based file IO instead of relying on Apache Commons (`FileUtils` and `IO`) for such simple things.
  - JDK 9 and 11 provide an even better selection of file IO methods, but we have to (and can) make do with what's in JDK 8.

### Benchmark-specific changes

In addition to the common changes above, these are changes made in the individual benchmarks.

#### `als`

- Rename `rating_count` to `user_count` because that's what it actually is.
- Add `product_count` to the `als` benchmark, because it also influenced workload size.
- Add `als_rank`, `als_lambda`, and `als_iterations` parameters of the ALS algorithm
- Generate input using a random generator with a fixed seed.
  - Each run will now work with the same data.
  - We should provide our own random generator for this purpose, see #141 
- Configure ALS to only use memory for intermediate and final RDDs, and sets a fixed random seed.
- Read CSV using the facilities from SparkUtil

#### `chi-square`

- Rename the `number_count` parameter to `point_count`, because that's what it actually is.
- Add the `component_count` parameter (which determines the number of components in a point) to expose the other factor influencing the workload size.

#### `dec-tree`

- Dump hashable result so that it could be used for validation.

#### `gauss-mix`

- Rename the `number_count` parameter to `point_count`, because that's what it actually is.
- Add the `component_count` parameter (which determines the number of components in a point) to expose the other factor influencing the workload size.
- Add the `distribution_count` parameter, which determines the desired number of clusters.
- Use a fixed random seed for the `GaussianMixture` estimator.
  - This may make benchmark runs more repeatable.
- Dump a result that could be used for validation (after accounting for potential numerical instability).

#### `log-regression`

- Add the `max_iterations` parameter which controls the maximum number of the logistic regression algorithm iterations.
  - This has the same meaning as `max_iterations` in the `gauss-mix` benchmark.
- Dump slightly more information about the result.
- Add a very rudimentary validation.
  - We should at least check the intercept, but we need a configuration-specific expected value for that.

#### `movie-lens`

- Configure ALS to only use memory for intermediate and final RDDs, and sets a fixed random seed.
- Removes the individual ALS algorithm parameters (and their cartesian-product interpretation) and instead adds a CSV-like table of ALS configurations together with expected RMSE on the validation set.
- The choice of ALS parameters is intended to produce different RMSE values to make it easier to validate the results in presence of numerical instability.

#### `naive-bayes`

- Add the `copy_count` parameter to allow controlling the workload size, replacing the hard-coded constant.
  - The (default) value of `8000` results in writing an 800MB input file on benchmark setup.
- Add `test` configuration with `copy_count` set to 5.
- Add `jmh` configuration (so far without parameter tweaks) so that it at least exists.

#### `page-rank`

- Add the `max_iterations` parameter which controls the number of iterations of the page rank algorithm.
  - It is not exactly the same as the `max_iterations` parameter in the `gauss-mix` and `log-regression` benchmarks, but it does control the number of algorithm iterations.

### Things that came up (Spark-related)

 - Do we want to enable checkpointing for all benchmarks?
   - It is currently only used by `movie-lens`, but why there and not in the others? Maybe remove it from there?
   - **Update:** It appears that without checkpoint directory the `movie-lens` benchmark (which is not much different from `als`) kept failing the JMH runs in CI. Super strange.
 - What logging level do we want to use?
   - A few (I think two) benchmarks configure the Spark root logger level to `ERROR` and the Eclipse jetty server root logger level to `OFF`
   - All benchmarks configure the Spark context log level to `ERROR`.
   - I think we should go for `WARN` for a while and determine (and document) what kinds of warnings we are fine with.
- The choice of machine learning APIs.
  -  Some of our benchmarks still use the RDD-based `MLlib` API, which is in maintenance mode since Spark 2.0, with the DataFrame-based `ML` API being considered to be the recommended one.
  - Do we want to port the benchmarks, if possible, or do we keep them for as long as the API is supported?
  - We should probably discuss/track this in a separate issue.
