### PR TITLE
Fix issues with outdated JDK trust store on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
 
     - <<: *bundle
       os: osx
-      osx_image: xcode9.3
+      osx_image: xcode9.4
       jdk: oraclejdk9
     - <<: *bundle
       jdk: openjdk8
@@ -83,7 +83,7 @@ jobs:
 
     - <<: *bench
       os: osx
-      osx_image: xcode9.3
+      osx_image: xcode9.4
       jdk: oraclejdk9
     - <<: *bench
       jdk: openjdk8


### PR DESCRIPTION
Fixes #249 caused by an outdated JDK trust store on OS X when using `xcode9.3` as `osx_image`.