### PR TITLE
Revert "Use test configuration in CI runs of the JMH bundle" for now

### DIFF
--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
@@ -1,5 +1,10 @@
 package org.renaissance.apache.spark
 
+import java.nio.charset.Charset
+import java.nio.file.Paths
+
+import org.apache.commons.io.FileUtils
+import org.apache.spark.SparkContext
 import org.apache.spark.mllib.recommendation.MatrixFactorizationModel
 import org.apache.spark.mllib.recommendation.Rating
 import org.apache.spark.rdd.RDD
@@ -10,9 +15,6 @@ import org.renaissance.BenchmarkResult
 import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
-import java.nio.file.Files
-import java.nio.file.Path
-import scala.jdk.CollectionConverters.asJavaCollectionConverter
 import scala.util.Random
 
 @Name("als")
@@ -20,56 +22,45 @@ import scala.util.Random
 @Summary("Runs the ALS algorithm from the Spark MLlib.")
 @Licenses(Array(License.APACHE2))
 @Repetitions(30)
-@Parameter(
-  name = "spark_executor_count",
-  defaultValue = "4",
-  summary = "Number of executor instances."
-)
-@Parameter(
-  name = "spark_executor_thread_count",
-  defaultValue = "4",
-  summary = "Number of threads per executor."
-)
-@Parameter(
-  name = "user_count",
-  defaultValue = "20000",
-  summary = "Number of users giving ratings."
-)
-@Parameter(
-  name = "product_count",
-  defaultValue = "100",
-  summary = "Number of products rated by each user."
-)
-@Configuration(name = "test", settings = Array("user_count = 500"))
+@Parameter(name = "rating_count", defaultValue = "20000")
+@Configuration(name = "test", settings = Array("rating_count = 500"))
 @Configuration(name = "jmh")
 final class Als extends Benchmark with SparkUtil {
 
   // TODO: Consolidate benchmark parameters across the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/27
 
-  private val randomSeed = 17
+  private var ratingCountParam: Int = _
 
-  private var inputRatings: RDD[Rating] = _
+  private val THREAD_COUNT = 4
 
-  private var outputMatrixFactorization: MatrixFactorizationModel = _
+  val alsPath = Paths.get("target", "als")
 
-  private def prepareInput(userCount: Int, productCount: Int, outputFile: Path): Path = {
-    // TODO: Use a Renaissance-provided random generator.
-    val rand = new Random(randomSeed)
-    val lines = (0 until userCount).flatMap { user =>
-      (0 until productCount).map { product =>
+  val outputPath = alsPath.resolve("output")
+
+  val bigInputFile = alsPath.resolve("bigfile.txt")
+
+  var sc: SparkContext = _
+
+  var factModel: MatrixFactorizationModel = _
+
+  var ratings: RDD[Rating] = _
+
+  def prepareInput() = {
+    FileUtils.deleteDirectory(alsPath.toFile)
+    val rand = new Random
+    val lines = (0 until ratingCountParam).flatMap { user =>
+      (0 until 100).map { product =>
         val score = 1 + rand.nextInt(3) + rand.nextInt(3)
         s"$user::$product::$score"
       }
     }
-
-    // Write output using UTF-8 encoding.
-    Files.write(outputFile, lines.asJavaCollection)
+    FileUtils.write(bigInputFile.toFile, lines.mkString("\n"), Charset.defaultCharset(), true)
   }
 
-  private def loadData(inputFile: Path) = {
-    sparkContext
-      .textFile(inputFile.toString)
+  def loadData() = {
+    ratings = sc
+      .textFile(bigInputFile.toString)
       .map { line =>
         val parts = line.split("::")
         Rating(parts(0).toInt, parts(1).toInt, parts(2).toDouble)
@@ -77,38 +68,32 @@ final class Als extends Benchmark with SparkUtil {
       .cache()
   }
 
-  override def setUpBeforeAll(bc: BenchmarkContext): Unit = {
-    setUpSparkContext(bc)
+  override def setUpBeforeAll(c: BenchmarkContext): Unit = {
+    ratingCountParam = c.parameter("rating_count").toPositiveInteger
 
-    val inputFile = prepareInput(
-      bc.parameter("user_count").toPositiveInteger,
-      bc.parameter("product_count").toPositiveInteger,
-      bc.scratchDirectory().resolve("input.txt")
-    )
-
-    inputRatings = ensureCached(loadData(inputFile))
+    val tempDirPath = c.scratchDirectory()
+    sc = setUpSparkContext(tempDirPath, THREAD_COUNT, "als")
+    prepareInput()
+    loadData()
+    ensureCaching(ratings)
   }
 
-  override def run(bc: BenchmarkContext): BenchmarkResult = {
-    val als = new org.apache.spark.mllib.recommendation.ALS()
-    outputMatrixFactorization = als.run(inputRatings)
-
-    // TODO: add proper validation of the generated model
-    Validators.dummy(outputMatrixFactorization)
-  }
-
-  override def tearDownAfterAll(bc: BenchmarkContext): Unit = {
-    val outputPath = bc.scratchDirectory().resolve("output")
-    dumpResult(outputMatrixFactorization, outputPath)
-
-    tearDownSparkContext()
-  }
-
-  private def dumpResult(mfm: MatrixFactorizationModel, outputPath: Path) = {
-    mfm.userFeatures
+  override def tearDownAfterAll(c: BenchmarkContext): Unit = {
+    // Dump output.
+    factModel.userFeatures
       .map {
         case (user, features) => s"$user: ${features.mkString(", ")}"
       }
       .saveAsTextFile(outputPath.toString)
+
+    tearDownSparkContext(sc)
+  }
+
+  override def run(c: BenchmarkContext): BenchmarkResult = {
+    val als = new org.apache.spark.mllib.recommendation.ALS()
+    factModel = als.run(ratings)
+
+    // TODO: add proper validation of the generated model
+    Validators.dummy(factModel)
   }
 }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ChiSquare.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ChiSquare.scala
@@ -1,5 +1,10 @@
 package org.renaissance.apache.spark
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
+
+import org.apache.commons.io.FileUtils
+import org.apache.spark.SparkContext
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.stat.Statistics
@@ -12,9 +17,6 @@ import org.renaissance.BenchmarkResult
 import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
-import java.nio.file.Files
-import java.nio.file.Path
-import scala.jdk.CollectionConverters.asJavaCollectionConverter
 import scala.util.Random
 
 @Name("chi-square")
@@ -22,64 +24,53 @@ import scala.util.Random
 @Summary("Runs the chi-square test from Spark MLlib.")
 @Licenses(Array(License.APACHE2))
 @Repetitions(60)
-@Parameter(
-  name = "spark_executor_count",
-  defaultValue = "4",
-  summary = "Number of executor instances."
-)
-@Parameter(
-  name = "spark_executor_thread_count",
-  defaultValue = "$cpu.count",
-  summary = "Number of threads per executor."
-)
-@Parameter(
-  name = "point_count",
-  defaultValue = "1500000",
-  summary = "Number of data points to generate."
-)
-@Parameter(
-  name = "component_count",
-  defaultValue = "5",
-  summary = "Number of components in each data point."
-)
-@Configuration(name = "test", settings = Array("point_count = 10000"))
+@Parameter(name = "thread_count", defaultValue = "$cpu.count")
+@Parameter(name = "number_count", defaultValue = "1500000")
+@Configuration(name = "test", settings = Array("number_count = 10000"))
 @Configuration(name = "jmh")
 final class ChiSquare extends Benchmark with SparkUtil {
 
   // TODO: Consolidate benchmark parameters across the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/27
 
-  private var componentCountParam: Int = _
+  private var numberCountParam: Int = _
 
-  private var inputPoints: RDD[LabeledPoint] = _
+  private var threadCountParam: Int = _
 
-  private var outputTestResults: Array[ChiSqTestResult] = _
+  private val COMPONENTS = 5
 
-  private def prepareInput(pointCount: Int, componentCount: Int, outputFile: Path): Path = {
-    // TODO: Use a Renaissance-provided random generator.
+  val chiSquarePath = Paths.get("target", "chi-square")
+
+  val outputPath = chiSquarePath.resolve("output")
+
+  val measurementsFile = chiSquarePath.resolve("measurements.txt")
+
+  var sc: SparkContext = _
+
+  var input: RDD[LabeledPoint] = _
+
+  var results: Array[ChiSqTestResult] = _
+
+  def prepareInput() = {
+    FileUtils.deleteDirectory(chiSquarePath.toFile)
+
     val rand = new Random(0L)
-
-    def randDouble(): Double = {
-      (rand.nextDouble() * 10).toInt / 10.0
-    }
-
-    val line = new StringBuilder
-    val lines = (0 until pointCount).map { _ =>
-      line.clear()
-      line.append(rand.nextInt(2))
-      (0 until componentCount).map { _ =>
-        line.append(" ").append(randDouble())
+    val content = new StringBuilder
+    for (i <- 0 until numberCountParam) {
+      def randDouble(): Double = {
+        (rand.nextDouble() * 10).toInt / 10.0
       }
-      line.toString()
+      content.append(rand.nextInt(2) + " ")
+      content.append((0 until COMPONENTS).map(_ => randDouble()).mkString(" "))
+      content.append("\n")
     }
 
-    // Write output using UTF-8 encoding.
-    Files.write(outputFile, lines.asJavaCollection)
+    FileUtils.write(measurementsFile.toFile, content, StandardCharsets.UTF_8, true)
   }
 
-  private def loadData(inputFile: Path) = {
-    sparkContext
-      .textFile(inputFile.toString)
+  def loadData() = {
+    input = sc
+      .textFile(measurementsFile.toString)
       .map { line =>
         val raw = line.split(" ").map(_.toDouble)
         new LabeledPoint(raw.head, Vectors.dense(raw.tail))
@@ -87,37 +78,28 @@ final class ChiSquare extends Benchmark with SparkUtil {
       .cache()
   }
 
-  override def setUpBeforeAll(bc: BenchmarkContext): Unit = {
-    setUpSparkContext(bc)
+  override def setUpBeforeAll(c: BenchmarkContext): Unit = {
+    threadCountParam = c.parameter("thread_count").toPositiveInteger
+    numberCountParam = c.parameter("number_count").toPositiveInteger
 
-    componentCountParam = bc.parameter("component_count").toPositiveInteger
-
-    val inputFile = prepareInput(
-      bc.parameter("point_count").toPositiveInteger,
-      componentCountParam,
-      bc.scratchDirectory().resolve("input.txt")
-    )
-
-    inputPoints = ensureCached(loadData(inputFile))
+    val tempDirPath = c.scratchDirectory()
+    sc = setUpSparkContext(tempDirPath, threadCountParam, "chi-square")
+    prepareInput()
+    loadData()
+    ensureCaching(input)
   }
 
-  override def run(bc: BenchmarkContext): BenchmarkResult = {
-    outputTestResults = Statistics.chiSqTest(inputPoints)
+  override def run(c: BenchmarkContext): BenchmarkResult = {
+    results = Statistics.chiSqTest(input)
 
     // TODO: add more sophisticated validation
-    Validators.simple("component count", componentCountParam, outputTestResults.size)
+    Validators.simple("component count", COMPONENTS, results.size)
   }
 
-  override def tearDownAfterAll(bc: BenchmarkContext): Unit = {
-    val outputFile = bc.scratchDirectory().resolve("output.txt")
-    dumpResult(outputTestResults, outputFile)
-
-    tearDownSparkContext()
+  override def tearDownAfterAll(c: BenchmarkContext): Unit = {
+    val output = results.map(_.statistic).mkString(", ")
+    FileUtils.write(outputPath.toFile, output, StandardCharsets.UTF_8, true)
+    tearDownSparkContext(sc)
   }
 
-  private def dumpResult(testResults: Array[ChiSqTestResult], outputFile: Path) = {
-    val output = testResults.map(_.statistic).mkString(", ")
-    // Files.writeString() is only available from Java 11.
-    Files.write(outputFile, output.getBytes)
-  }
 }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/DecTree.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/DecTree.scala
@@ -1,6 +1,14 @@
 package org.renaissance.apache.spark
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import org.apache.commons.io.FileUtils
+import org.apache.commons.io.IOUtils
+import org.apache.spark.SparkContext
 import org.apache.spark.ml.Pipeline
+import org.apache.spark.ml.PipelineModel
 import org.apache.spark.ml.PipelineStage
 import org.apache.spark.ml.classification.DecisionTreeClassificationModel
 import org.apache.spark.ml.classification.DecisionTreeClassifier
@@ -15,33 +23,13 @@ import org.renaissance.BenchmarkResult
 import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.StandardOpenOption
-import java.util.stream.Collectors
-
 @Name("dec-tree")
 @Group("apache-spark")
 @Summary("Runs the Random Forest algorithm from Spark MLlib.")
 @Licenses(Array(License.APACHE2))
 @Repetitions(40)
-@Parameter(
-  name = "spark_executor_count",
-  defaultValue = "4",
-  summary = "Number of executor instances."
-)
-@Parameter(
-  name = "spark_executor_thread_count",
-  defaultValue = "$cpu.count",
-  summary = "Number of threads per executor."
-)
-@Parameter(
-  name = "copy_count",
-  defaultValue = "100",
-  summary = "Number of sample data copies to make in the input data."
-)
+@Parameter(name = "thread_count", defaultValue = "$cpu.count")
+@Parameter(name = "copy_count", defaultValue = "100")
 @Configuration(name = "test", settings = Array("copy_count = 5"))
 @Configuration(name = "jmh")
 final class DecTree extends Benchmark with SparkUtil {
@@ -49,42 +37,49 @@ final class DecTree extends Benchmark with SparkUtil {
   // TODO: Consolidate benchmark parameters across the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/27
 
-  private val inputResource = "/sample_libsvm_data.txt"
+  private var threadCountParam: Int = _
 
-  private var inputTrainingData: DataFrame = _
+  private var copyCountParam: Int = _
 
-  private var outputClassificationModel: DecisionTreeClassificationModel = _
+  val decisionTreePath = Paths.get("target", "dec-tree")
 
-  private def prepareInput(resourcePath: String, copyCount: Int, outputFile: Path): Path = {
-    def loadInputResource() = {
-      val resourceStream = getClass.getResourceAsStream(resourcePath)
-      val reader = new BufferedReader(new InputStreamReader(resourceStream))
-      reader.lines().collect(Collectors.toList())
+  val outputPath = decisionTreePath.resolve("output")
+
+  val inputFile = "/sample_libsvm_data.txt"
+
+  val bigInputFile = decisionTreePath.resolve("bigfile.txt")
+
+  var sc: SparkContext = null
+
+  var training: DataFrame = null
+
+  var pipeline: Pipeline = null
+
+  var pipelineModel: PipelineModel = null
+
+  var iteration: Int = 0
+
+  def prepareAndLoadInput(decisionTreePath: Path, inputFile: String): DataFrame = {
+    FileUtils.deleteDirectory(decisionTreePath.toFile)
+
+    val text =
+      IOUtils.toString(this.getClass.getResourceAsStream(inputFile), StandardCharsets.UTF_8)
+    for (i <- 0 until copyCountParam) {
+      FileUtils.write(bigInputFile.toFile, text, StandardCharsets.UTF_8, true)
     }
 
-    val lines = loadInputResource()
-    for (_ <- 0 until copyCount) {
-      Files.write(outputFile, lines, StandardOpenOption.CREATE, StandardOpenOption.APPEND)
-    }
-
-    outputFile
-  }
-
-  private def loadData(inputFile: Path): DataFrame = {
-    val sqlContext = new SQLContext(sparkContext)
-    sqlContext.read.format("libsvm").load(inputFile.toString).cache()
+    val sqlContext = new SQLContext(sc)
+    return sqlContext.read.format("libsvm").load(bigInputFile.toString)
   }
 
   def constructPipeline(): Pipeline = {
     val labelIndexer = new StringIndexer()
       .setInputCol("label")
       .setOutputCol("indexedLabel")
-
     val featureIndexer = new VectorIndexer()
       .setInputCol("features")
       .setOutputCol("indexedFeatures")
       .setMaxCategories(10)
-
     val dtc = new DecisionTreeClassifier()
       .setFeaturesCol("indexedFeatures")
       .setLabelCol("indexedLabel")
@@ -94,9 +89,7 @@ final class DecTree extends Benchmark with SparkUtil {
       .setMinInfoGain(0.0)
       .setCacheNodeIds(false)
       .setCheckpointInterval(10)
-      .setSeed(159147643)
-
-    new Pipeline().setStages(
+    return new Pipeline().setStages(
       Array[PipelineStage](
         labelIndexer,
         featureIndexer,
@@ -105,52 +98,37 @@ final class DecTree extends Benchmark with SparkUtil {
     )
   }
 
-  override def setUpBeforeAll(bc: BenchmarkContext): Unit = {
-    setUpSparkContext(bc)
+  override def setUpBeforeAll(c: BenchmarkContext): Unit = {
+    threadCountParam = c.parameter("thread_count").toPositiveInteger
+    copyCountParam = c.parameter("copy_count").toPositiveInteger
 
-    val inputFile = prepareInput(
-      inputResource,
-      bc.parameter("copy_count").toPositiveInteger,
-      bc.scratchDirectory().resolve("input.txt")
-    )
-
-    inputTrainingData = loadData(inputFile)
+    val tempDirPath = c.scratchDirectory()
+    sc = setUpSparkContext(tempDirPath, threadCountParam, "dec-tree")
+    training = prepareAndLoadInput(decisionTreePath, inputFile).cache()
+    pipeline = constructPipeline()
   }
 
-  override def run(bc: BenchmarkContext): BenchmarkResult = {
-    // Always create a new pipeline to avoid (potential) caching.
-    val outputPipelineModel = constructPipeline().fit(inputTrainingData)
-    val lastStage = outputPipelineModel.stages.last
-    outputClassificationModel = lastStage.asInstanceOf[DecisionTreeClassificationModel]
+  override def run(c: BenchmarkContext): BenchmarkResult = {
+    pipelineModel = pipeline.fit(training)
+    val treeModel =
+      pipelineModel.stages.last.asInstanceOf[DecisionTreeClassificationModel]
+    val thisIterOutputPath = outputPath.resolve(iteration.toString)
+    FileUtils.write(
+      thisIterOutputPath.toFile,
+      treeModel.toDebugString,
+      StandardCharsets.UTF_8,
+      true
+    )
+    iteration += 1
 
     // TODO: add more in-depth validation
     Validators.compound(
-      Validators.simple("tree depth", 2, outputClassificationModel.depth),
-      Validators.simple("node count", 5, outputClassificationModel.numNodes),
-      Validators.simple("class count", 2, outputClassificationModel.numClasses),
-      Validators.simple("feature count", 692, outputClassificationModel.numFeatures)
+      Validators.simple("tree depth", 2, treeModel.depth),
+      Validators.simple("node count", 5, treeModel.numNodes)
     )
   }
 
-  override def tearDownAfterAll(bc: BenchmarkContext): Unit = {
-    val outputFile = bc.scratchDirectory().resolve("output.txt")
-    dumpResult(outputClassificationModel, outputFile)
-
-    tearDownSparkContext()
+  override def tearDownAfterAll(c: BenchmarkContext): Unit = {
+    tearDownSparkContext(sc)
   }
-
-  private def dumpResult(dtcm: DecisionTreeClassificationModel, outputFile: Path) = {
-    // Create a header with information about model properties and attach to
-    // it a debug dump of the underlying tree (without the first line containing UID).
-    val header = Seq(
-      s"depth=${dtcm.depth}, numNodes=${dtcm.numNodes}, " +
-        s"numClasses=${dtcm.numClasses}, numFeatures=${dtcm.numFeatures}"
-    )
-    val body = dtcm.toDebugString.linesIterator.toSeq.tail
-    val dtcmDump = (header ++ body).mkString("\n")
-
-    // Files.writeString() is only available from Java 11.
-    Files.write(outputFile, dtcmDump.getBytes)
-  }
-
 }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/GaussMix.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/GaussMix.scala
@@ -1,5 +1,10 @@
 package org.renaissance.apache.spark
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
+
+import org.apache.commons.io.FileUtils
+import org.apache.spark.SparkContext
 import org.apache.spark.mllib.clustering.GaussianMixture
 import org.apache.spark.mllib.clustering.GaussianMixtureModel
 import org.apache.spark.mllib.linalg.Vectors
@@ -11,9 +16,6 @@ import org.renaissance.BenchmarkResult
 import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
-import java.nio.file.Files
-import java.nio.file.Path
-import scala.jdk.CollectionConverters.asJavaCollectionConverter
 import scala.util.Random
 
 @Name("gauss-mix")
@@ -21,70 +23,71 @@ import scala.util.Random
 @Summary("Computes a Gaussian mixture model using expectation-maximization.")
 @Licenses(Array(License.APACHE2))
 @Repetitions(40)
-@Parameter(
-  name = "spark_executor_count",
-  defaultValue = "4",
-  summary = "Number of executor instances."
-)
-@Parameter(
-  name = "spark_executor_thread_count",
-  defaultValue = "$cpu.count",
-  summary = "Number of threads per executor."
-)
-@Parameter(
-  name = "point_count",
-  defaultValue = "15000",
-  summary = "Number of data points to generate."
-)
-@Parameter(
-  name = "component_count",
-  defaultValue = "10",
-  summary = "Number of components in each data point."
-)
-@Parameter(
-  name = "distribution_count",
-  defaultValue = "6",
-  summary = "Number of gaussian distributions in the mix."
-)
+@Parameter(name = "thread_count", defaultValue = "$cpu.count")
+@Parameter(name = "number_count", defaultValue = "15000")
 @Parameter(
   name = "max_iterations",
   defaultValue = "15",
-  summary = "Maximum number of iterations of the clustering algorithm."
+  summary = "The maximum number of iterations allowed"
 )
-@Configuration(name = "test", settings = Array("point_count = 7", "max_iterations = 3"))
+@Configuration(name = "test", settings = Array("number_count = 7", "max_iterations = 3"))
 @Configuration(name = "jmh")
 final class GaussMix extends Benchmark with SparkUtil {
 
   // TODO: Consolidate benchmark parameters across the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/27
 
+  private var threadCountParam: Int = _
+
+  private var numberCountParam: Int = _
+
   private var maxIterationsParam: Int = _
 
-  private var distributionCountParam: Int = _
+  private val DISTRIBUTION_COUNT = 6
 
-  private var inputVectors: RDD[org.apache.spark.mllib.linalg.Vector] = _
+  private val COMPONENTS = 10
 
-  private var outputGaussianMixture: GaussianMixtureModel = _
+  val gaussMixPath = Paths.get("target", "gauss-mix")
 
-  private def prepareInput(pointCount: Int, componentCount: Int, outputFile: Path): Path = {
-    // TODO: Use a Renaissance-provided random generator.
-    val rand = new Random(0L)
+  val outputPath = gaussMixPath.resolve("output")
 
-    def randDouble(): Double = {
-      (rand.nextDouble() * 10).toInt / 10.0
-    }
+  val measurementsFile = gaussMixPath.resolve("measurements.txt")
 
-    val lines = (0 until pointCount).map { _ =>
-      (0 until componentCount).map(_ => randDouble()).mkString(" ")
-    }
+  var sc: SparkContext = _
 
-    // Write output using UTF-8 encoding.
-    Files.write(outputFile, lines.asJavaCollection)
+  var gmm: GaussianMixtureModel = _
+
+  var input: RDD[org.apache.spark.mllib.linalg.Vector] = _
+
+  override def setUpBeforeAll(c: BenchmarkContext): Unit = {
+    threadCountParam = c.parameter("thread_count").toPositiveInteger
+    numberCountParam = c.parameter("number_count").toPositiveInteger
+    maxIterationsParam = c.parameter("max_iterations").toPositiveInteger
+
+    val tempDirPath = c.scratchDirectory()
+    sc = setUpSparkContext(tempDirPath, threadCountParam, "gauss-mix")
+    prepareInput()
+    loadData()
+    ensureCaching(input)
   }
 
-  private def loadData(inputFile: Path) = {
-    sparkContext
-      .textFile(inputFile.toString)
+  def prepareInput() = {
+    FileUtils.deleteDirectory(gaussMixPath.toFile)
+    val rand = new Random(0L)
+    val content = new StringBuilder
+    for (i <- 0 until numberCountParam) {
+      def randDouble(): Double = {
+        (rand.nextDouble() * 10).toInt / 10.0
+      }
+      content.append((0 until COMPONENTS).map(_ => randDouble()).mkString(" "))
+      content.append("\n")
+    }
+    FileUtils.write(measurementsFile.toFile, content, StandardCharsets.UTF_8, true)
+  }
+
+  def loadData(): Unit = {
+    input = sc
+      .textFile(measurementsFile.toString)
       .map { line =>
         val raw = line.split(" ").map(_.toDouble)
         Vectors.dense(raw)
@@ -92,57 +95,20 @@ final class GaussMix extends Benchmark with SparkUtil {
       .cache()
   }
 
-  override def setUpBeforeAll(bc: BenchmarkContext): Unit = {
-    setUpSparkContext(bc)
-
-    maxIterationsParam = bc.parameter("max_iterations").toPositiveInteger
-    distributionCountParam = bc.parameter("distribution_count").toPositiveInteger
-
-    val inputFile = prepareInput(
-      bc.parameter("point_count").toPositiveInteger,
-      bc.parameter("component_count").toPositiveInteger,
-      bc.scratchDirectory().resolve("input.txt")
-    )
-
-    inputVectors = ensureCached(loadData(inputFile))
+  override def tearDownAfterAll(c: BenchmarkContext) = {
+    val output = gmm.gaussians.mkString(", ")
+    FileUtils.write(outputPath.toFile, output, StandardCharsets.UTF_8, true)
+    tearDownSparkContext(sc)
   }
 
-  override def run(bc: BenchmarkContext): BenchmarkResult = {
-    outputGaussianMixture = new GaussianMixture()
-      .setK(distributionCountParam)
+  override def run(c: BenchmarkContext): BenchmarkResult = {
+    gmm = new GaussianMixture()
+      .setK(DISTRIBUTION_COUNT)
       .setMaxIterations(maxIterationsParam)
-      .setSeed(159147643)
-      .run(inputVectors)
+      .run(input)
 
     // TODO: add more in-depth validation
-    Validators.simple("number of gaussians", distributionCountParam, outputGaussianMixture.k)
-  }
-
-  override def tearDownAfterAll(bc: BenchmarkContext) = {
-    val outputFile = bc.scratchDirectory().resolve("output.txt")
-    dumpResult(outputGaussianMixture, outputFile)
-
-    tearDownSparkContext()
-  }
-
-  private def dumpResult(gmm: GaussianMixtureModel, outputFile: Path) = {
-    val output = new StringBuilder
-    gmm.gaussians
-      .zip(gmm.weights)
-      .zipWithIndex
-      .foreach({
-        case ((g, w), i) =>
-          output.append(s"gaussian $i:\n")
-          output.append(s"  weight: $w\n")
-          output.append("  mu: ").append(g.mu).append("\n")
-          output
-            .append("  sigma: ")
-            .append(g.sigma.rowIter.mkString("[", ", ", "]"))
-            .append("\n\n")
-      })
-
-    // Files.writeString() is only available from Java 11.
-    Files.write(outputFile, output.toString.getBytes)
+    Validators.simple("number of gaussians", 6, gmm.k)
   }
 
 }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
@@ -1,5 +1,11 @@
 package org.renaissance.apache.spark
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
+
+import org.apache.commons.io.FileUtils
+import org.apache.commons.io.IOUtils
+import org.apache.spark.SparkContext
 import org.apache.spark.ml.classification.LogisticRegression
 import org.apache.spark.ml.classification.LogisticRegressionModel
 import org.apache.spark.ml.linalg.Vectors
@@ -12,38 +18,13 @@ import org.renaissance.BenchmarkResult
 import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.StandardOpenOption
-import java.util.stream.Collectors
-
 @Name("log-regression")
 @Group("apache-spark")
 @Summary("Runs the logistic regression workload from the Spark MLlib.")
 @Licenses(Array(License.APACHE2))
 @Repetitions(20)
-@Parameter(
-  name = "spark_executor_count",
-  defaultValue = "4",
-  summary = "Number of executor instances."
-)
-@Parameter(
-  name = "spark_executor_thread_count",
-  defaultValue = "$cpu.count",
-  summary = "Number of threads per executor."
-)
-@Parameter(
-  name = "copy_count",
-  defaultValue = "400",
-  summary = "Number of sample data copies to make in the input data."
-)
-@Parameter(
-  name = "max_iterations",
-  defaultValue = "20",
-  summary = "Maximum number of iterations of the logistic regression algorithm."
-)
+@Parameter(name = "thread_count", defaultValue = "$cpu.count")
+@Parameter(name = "copy_count", defaultValue = "400")
 @Configuration(name = "test", settings = Array("copy_count = 5"))
 @Configuration(name = "jmh")
 final class LogRegression extends Benchmark with SparkUtil {
@@ -51,43 +32,48 @@ final class LogRegression extends Benchmark with SparkUtil {
   // TODO: Consolidate benchmark parameters across the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/27
 
-  private val inputResource = "/sample_libsvm_data.txt"
+  private var threadCountParam: Int = _
 
-  private var maxIterationsParam: Int = _
+  private var copyCountParam: Int = _
 
-  private val lrRegularizationParam = 0.1
+  private val REGULARIZATION_PARAM = 0.1
 
-  private val lrElasticNetMixingParam = 0.0
+  private val MAX_ITERATIONS = 20
 
-  private val lrConvergenceToleranceParam = 0.0
+  private val ELASTIC_NET_PARAM = 0.0
 
-  private var inputTuples: RDD[(Double, org.apache.spark.ml.linalg.Vector)] = _
+  private val CONVERGENCE_TOLERANCE = 0.0
 
-  private var outputLogisticRegression: LogisticRegressionModel = _
+  val logisticRegressionPath = Paths.get("target", "logistic-regression");
 
-  private def prepareInput(resourcePath: String, copyCount: Int, outputFile: Path): Path = {
-    def loadInputResource() = {
-      val resourceStream = getClass.getResourceAsStream(resourcePath)
-      val reader = new BufferedReader(new InputStreamReader(resourceStream))
-      reader.lines().collect(Collectors.toList())
+  val outputPath = logisticRegressionPath.resolve("output")
+
+  val inputFile = "/sample_libsvm_data.txt"
+
+  val bigInputFile = logisticRegressionPath.resolve("bigfile.txt")
+
+  var mlModel: LogisticRegressionModel = _
+
+  var sc: SparkContext = _
+
+  var rdd: RDD[(Double, org.apache.spark.ml.linalg.Vector)] = _
+
+  def prepareInput() = {
+    FileUtils.deleteDirectory(logisticRegressionPath.toFile)
+    val text =
+      IOUtils.toString(this.getClass.getResourceAsStream(inputFile), StandardCharsets.UTF_8)
+    for (i <- 0 until copyCountParam) {
+      FileUtils.write(bigInputFile.toFile, text, StandardCharsets.UTF_8, true)
     }
-
-    val lines = loadInputResource()
-    for (_ <- 0 until copyCount) {
-      Files.write(outputFile, lines, StandardOpenOption.CREATE, StandardOpenOption.APPEND)
-    }
-
-    outputFile
   }
 
-  private def loadData(inputFile: Path) = {
-    val featureCount = 692
-
-    sparkContext
-      .textFile(inputFile.toString)
+  def loadData() = {
+    val num_features = 692
+    rdd = sc
+      .textFile(bigInputFile.toString)
       .map { line =>
         val parts = line.split(" ")
-        val features = new Array[Double](featureCount)
+        val features = new Array[Double](num_features)
         parts.tail.foreach { part =>
           val dimval = part.split(":")
           val index = dimval(0).toInt - 1
@@ -99,54 +85,41 @@ final class LogRegression extends Benchmark with SparkUtil {
       .cache()
   }
 
-  override def setUpBeforeAll(bc: BenchmarkContext): Unit = {
-    setUpSparkContext(bc)
+  override def setUpBeforeAll(c: BenchmarkContext): Unit = {
+    threadCountParam = c.parameter("thread_count").toPositiveInteger
+    copyCountParam = c.parameter("copy_count").toPositiveInteger
 
-    maxIterationsParam = bc.parameter("max_iterations").toPositiveInteger
-
-    val inputFile = prepareInput(
-      inputResource,
-      bc.parameter("copy_count").toPositiveInteger,
-      bc.scratchDirectory().resolve("input.txt")
-    )
-
-    inputTuples = ensureCached(loadData(inputFile))
+    val tempDirPath = c.scratchDirectory()
+    sc = setUpSparkContext(tempDirPath, threadCountParam, "log-regression")
+    prepareInput()
+    loadData()
+    ensureCaching(rdd)
   }
 
-  override def run(bc: BenchmarkContext): BenchmarkResult = {
+  override def run(c: BenchmarkContext): BenchmarkResult = {
+    // TODO: Create only once per benchmark?
     val lor = new LogisticRegression()
-      .setElasticNetParam(lrElasticNetMixingParam)
-      .setRegParam(lrRegularizationParam)
-      .setTol(lrConvergenceToleranceParam)
-      .setMaxIter(maxIterationsParam)
+      .setElasticNetParam(ELASTIC_NET_PARAM)
+      .setRegParam(REGULARIZATION_PARAM)
+      .setMaxIter(MAX_ITERATIONS)
+      .setTol(CONVERGENCE_TOLERANCE)
 
-    val sqlContext = new SQLContext(inputTuples.context)
+    val sqlContext = new SQLContext(rdd.context)
     import sqlContext.implicits._
-    outputLogisticRegression = lor.fit(inputTuples.toDF("label", "features"))
+    mlModel = lor.fit(rdd.toDF("label", "features"))
 
-    // TODO: add more in-depth validation
-    Validators.compound(
-      Validators.simple("class count", 2, outputLogisticRegression.numClasses),
-      Validators.simple("feature count", 692, outputLogisticRegression.numFeatures)
+    // TODO: add proper validation
+    Validators.dummy(mlModel)
+  }
+
+  override def tearDownAfterAll(c: BenchmarkContext): Unit = {
+    FileUtils.write(
+      outputPath.toFile,
+      mlModel.coefficients.toString + "\n",
+      StandardCharsets.UTF_8,
+      true
     )
+    FileUtils.write(outputPath.toFile, mlModel.intercept.toString, StandardCharsets.UTF_8, true)
+    tearDownSparkContext(sc)
   }
-
-  override def tearDownAfterAll(bc: BenchmarkContext): Unit = {
-    val outputFile = bc.scratchDirectory().resolve("output.txt")
-    dumpResult(outputLogisticRegression, outputFile)
-
-    tearDownSparkContext()
-  }
-
-  private def dumpResult(lrm: LogisticRegressionModel, outputFile: Path) = {
-    val output = new StringBuilder
-    output.append(s"num features: ${lrm.numFeatures}\n")
-    output.append(s"num classes: ${lrm.numClasses}\n")
-    output.append(s"intercepts: ${lrm.interceptVector.toString}\n")
-    output.append(s"coefficients: ${lrm.coefficients.toString}\n")
-
-    // Files.writeString() is only available from Java 11.
-    Files.write(outputFile, output.toString.getBytes)
-  }
-
 }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/MovieLens.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/MovieLens.scala
@@ -30,16 +30,6 @@ import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
 @Summary("Recommends movies using the ALS algorithm.")
 @Licenses(Array(License.APACHE2))
 @Repetitions(20)
-@Parameter(
-  name = "spark_executor_count",
-  defaultValue = "4",
-  summary = "Number of executor instances."
-)
-@Parameter(
-  name = "spark_executor_thread_count",
-  defaultValue = "4",
-  summary = "Number of threads per executor."
-)
 @Parameter(name = "input_file", defaultValue = "/ratings.csv")
 @Parameter(name = "als_ranks", defaultValue = "8, 12")
 @Parameter(name = "als_lambdas", defaultValue = "0.1, 10.0")
@@ -58,6 +48,8 @@ final class MovieLens extends Benchmark with SparkUtil {
 
   // TODO: Consolidate benchmark parameters across the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/27
+
+  private val THREAD_COUNT = 4
 
   private var inputFileParam: String = _
 
@@ -260,11 +252,11 @@ final class MovieLens extends Benchmark with SparkUtil {
     }
 
     def verifyCaches() = {
-      ensureCached(ratings)
-      ensureCached(personalRatingsRDD)
-      ensureCached(training)
-      ensureCached(test)
-      ensureCached(validation)
+      ensureCaching(ratings)
+      ensureCaching(personalRatingsRDD)
+      ensureCaching(training)
+      ensureCaching(test)
+      ensureCaching(validation)
     }
   }
 
@@ -273,14 +265,15 @@ final class MovieLens extends Benchmark with SparkUtil {
     Logger.getLogger("org.eclipse.jetty.server").setLevel(Level.OFF)
   }
 
-  override def setUpBeforeAll(bc: BenchmarkContext): Unit = {
-    inputFileParam = bc.parameter("input_file").value
-    alsRanksParam = bc.parameter("als_ranks").toList(_.toInt).asScala.toList
-    alsLambdasParam = bc.parameter("als_lambdas").toList(_.toDouble).asScala.toList
-    alsIterationsParam = bc.parameter("als_iterations").toList(_.toInt).asScala.toList
+  override def setUpBeforeAll(c: BenchmarkContext): Unit = {
+    inputFileParam = c.parameter("input_file").value
+    alsRanksParam = c.parameter("als_ranks").toList(_.toInt).asScala.toList
+    alsLambdasParam = c.parameter("als_lambdas").toList(_.toDouble).asScala.toList
+    alsIterationsParam = c.parameter("als_iterations").toList(_.toInt).asScala.toList
 
+    val tempDirPath = c.scratchDirectory()
     setUpLogger()
-    sc = setUpSparkContext(bc)
+    sc = setUpSparkContext(tempDirPath, THREAD_COUNT, "movie-lens")
     sc.setCheckpointDir(checkpointPath.toString)
     loadData()
     // Split ratings into train (60%), validation (20%), and test (20%) based on the
@@ -311,7 +304,7 @@ final class MovieLens extends Benchmark with SparkUtil {
     )
   }
 
-  override def run(bc: BenchmarkContext): BenchmarkResult = {
+  override def run(c: BenchmarkContext): BenchmarkResult = {
     helper.trainModels(alsRanksParam, alsLambdasParam, alsIterationsParam)
     val recommendations = helper.recommendMovies()
 
@@ -319,7 +312,7 @@ final class MovieLens extends Benchmark with SparkUtil {
     Validators.dummy(recommendations)
   }
 
-  override def tearDownAfterAll(bc: BenchmarkContext): Unit = {
+  override def tearDownAfterAll(c: BenchmarkContext): Unit = {
     tearDownSparkContext(sc)
   }
 

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/NaiveBayes.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/NaiveBayes.scala
@@ -1,5 +1,11 @@
 package org.renaissance.apache.spark
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
+
+import org.apache.commons.io.FileUtils
+import org.apache.commons.io.IOUtils
+import org.apache.spark.SparkContext
 import org.apache.spark.mllib.classification.NaiveBayesModel
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.regression.LabeledPoint
@@ -11,71 +17,50 @@ import org.renaissance.BenchmarkResult
 import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.StandardOpenOption
-import java.util.stream.Collectors
-
 @Name("naive-bayes")
 @Group("apache-spark")
 @Summary("Runs the multinomial naive Bayes algorithm from the Spark MLlib.")
 @Licenses(Array(License.APACHE2))
 @Repetitions(30)
-@Parameter(
-  name = "spark_executor_count",
-  defaultValue = "4",
-  summary = "Number of executor instances."
-)
-@Parameter(
-  name = "spark_executor_thread_count",
-  defaultValue = "$cpu.count",
-  summary = "Number of threads per executor."
-)
-@Parameter(
-  name = "copy_count",
-  defaultValue = "8000",
-  summary = "Number of sample data copies to make in the input data."
-)
-@Configuration(name = "test", settings = Array("copy_count = 5"))
-@Configuration(name = "jmh")
-final class NaiveBayes extends Benchmark with SparkUtil {
+class NaiveBayes extends Benchmark with SparkUtil {
 
   // TODO: Consolidate benchmark parameters across the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/27
 
-  private val inputResource = "/sample_libsvm_data.txt"
+  val SMOOTHING = 1.0
 
-  private val nbSmoothingParam = 1.0
+  val THREAD_COUNT = Runtime.getRuntime.availableProcessors
 
-  private var inputLabeledPoints: RDD[LabeledPoint] = _
+  val naiveBayesPath = Paths.get("target", "naive-bayes")
 
-  private var outputNaiveBayes: NaiveBayesModel = _
+  val outputPath = naiveBayesPath.resolve("output")
 
-  private def prepareInput(resourcePath: String, copyCount: Int, outputFile: Path): Path = {
-    def loadInputResource() = {
-      val resourceStream = getClass.getResourceAsStream(resourcePath)
-      val reader = new BufferedReader(new InputStreamReader(resourceStream))
-      reader.lines().collect(Collectors.toList())
+  val inputFile = "/sample_libsvm_data.txt"
+
+  val bigInputFile = naiveBayesPath.resolve("bigfile.txt")
+
+  var sc: SparkContext = null
+
+  var data: RDD[LabeledPoint] = null
+
+  var bayesModel: NaiveBayesModel = null
+
+  def prepareInput() = {
+    FileUtils.deleteDirectory(naiveBayesPath.toFile)
+    val text =
+      IOUtils.toString(this.getClass.getResourceAsStream(inputFile), StandardCharsets.UTF_8)
+    for (i <- 0 until 8000) {
+      FileUtils.write(bigInputFile.toFile, text, true)
     }
-
-    val lines = loadInputResource()
-    for (_ <- 0 until copyCount) {
-      Files.write(outputFile, lines, StandardOpenOption.CREATE, StandardOpenOption.APPEND)
-    }
-
-    outputFile
   }
 
-  private def loadData(inputFile: Path) = {
-    val featureCount = 692
-
-    sparkContext
-      .textFile(inputFile.toString)
+  def loadData() = {
+    val num_features = 692
+    data = sc
+      .textFile(bigInputFile.toString)
       .map { line =>
         val parts = line.split(" ")
-        val features = new Array[Double](featureCount)
+        val features = new Array[Double](num_features)
         parts.tail.foreach { part =>
           val dimval = part.split(":")
           val index = dimval(0).toInt - 1
@@ -87,51 +72,55 @@ final class NaiveBayes extends Benchmark with SparkUtil {
       .cache()
   }
 
-  override def setUpBeforeAll(bc: BenchmarkContext): Unit = {
-    setUpSparkContext(bc)
-
-    val inputFile = prepareInput(
-      inputResource,
-      bc.parameter("copy_count").toPositiveInteger,
-      bc.scratchDirectory().resolve("input.txt")
-    )
-
-    inputLabeledPoints = ensureCached(loadData(inputFile))
+  override def setUpBeforeAll(c: BenchmarkContext): Unit = {
+    val tempDirPath = c.scratchDirectory()
+    sc = setUpSparkContext(tempDirPath, THREAD_COUNT, "naive-bayes")
+    prepareInput()
+    loadData()
+    ensureCaching(data)
   }
 
-  override def run(bc: BenchmarkContext): BenchmarkResult = {
-    // Avoid conflict with the Renaissance benchmark class name.
-    val bayes = new org.apache.spark.mllib.classification.NaiveBayes()
-      .setLambda(nbSmoothingParam)
-      .setModelType("multinomial")
+  override def tearDownAfterAll(c: BenchmarkContext): Unit = {
+    // Dump output.
+    FileUtils.write(
+      outputPath.toFile,
+      bayesModel.labels.mkString("labels: ", ", ", "\n"),
+      StandardCharsets.UTF_8,
+      true
+    )
 
-    outputNaiveBayes = bayes.run(inputLabeledPoints)
+    FileUtils.write(
+      outputPath.toFile,
+      bayesModel.pi.mkString("a priori: ", ", ", "\n"),
+      StandardCharsets.UTF_8,
+      true
+    )
+
+    FileUtils.write(
+      outputPath.toFile,
+      bayesModel.theta.zipWithIndex
+        .map {
+          case (cls, i) =>
+            cls.mkString(s"class $i: ", ", ", "")
+        }
+        .mkString("thetas:\n", "\n", ""),
+      StandardCharsets.UTF_8,
+      true
+    )
+
+    tearDownSparkContext(sc)
+  }
+
+  override def run(c: BenchmarkContext): BenchmarkResult = {
+    // Using full package name to avoid conflicting with the renaissance benchmark class name.
+    val bayes = new org.apache.spark.mllib.classification.NaiveBayes()
+      .setLambda(SMOOTHING)
+      .setModelType("multinomial")
+    bayesModel = bayes.run(data)
 
     Validators.compound(
-      Validators.simple("pi 0", -0.84397, outputNaiveBayes.pi(0), 0.001),
-      Validators.simple("pi 1", -0.56212, outputNaiveBayes.pi(1), 0.001)
+      Validators.simple("pi 0", -0.84397, bayesModel.pi(0), 0.001),
+      Validators.simple("pi 1", -0.56212, bayesModel.pi(1), 0.001)
     )
   }
-
-  override def tearDownAfterAll(bc: BenchmarkContext): Unit = {
-    val outputFile = bc.scratchDirectory().resolve("output.txt")
-    dumpResult(outputNaiveBayes, outputFile)
-
-    tearDownSparkContext()
-  }
-
-  private def dumpResult(nbm: NaiveBayesModel, outputFile: Path) = {
-    val output = new StringBuilder
-    output.append(nbm.labels.mkString("labels: ", ", ", "\n"))
-    output.append(nbm.pi.mkString("a priori: ", ", ", "\n"))
-    output.append(
-      nbm.theta.zipWithIndex
-        .map({ case (cls, i) => cls.mkString(s"class $i: ", ", ", "") })
-        .mkString("thetas:\n", "\n", "")
-    )
-
-    // Files.writeString() is only available from Java 11.
-    Files.write(outputFile, output.toString.getBytes)
-  }
-
 }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
@@ -1,5 +1,8 @@
 package org.renaissance.apache.spark
 
+import java.util.regex.Pattern
+
+import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.renaissance.Benchmark
 import org.renaissance.Benchmark._
@@ -9,35 +12,15 @@ import org.renaissance.BenchmarkResult.Assert
 import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
-import java.util.regex.Pattern
 import scala.collection.JavaConverters._
-import scala.io.BufferedSource
 
 @Name("page-rank")
 @Group("apache-spark")
 @Summary("Runs a number of PageRank iterations, using RDDs.")
 @Licenses(Array(License.APACHE2))
 @Repetitions(20)
-@Parameter(
-  name = "spark_executor_count",
-  defaultValue = "4",
-  summary = "Number of executor instances."
-)
-@Parameter(
-  name = "spark_executor_thread_count",
-  defaultValue = "$cpu.count",
-  summary = "Number of threads per executor."
-)
-@Parameter(
-  name = "max_iterations",
-  defaultValue = "2",
-  summary = "Maximum number of iterations of the page rank algorithm."
-)
-@Parameter(
-  name = "input_line_count",
-  defaultValue = "-1",
-  summary = "Number of lines to take as input from the input dataset."
-)
+@Parameter(name = "thread_count", defaultValue = "$cpu.count")
+@Parameter(name = "input_line_count", defaultValue = "-1")
 @Parameter(name = "expected_rank_count", defaultValue = "598652")
 @Parameter(name = "expected_rank_hash", defaultValue = "9b39ddf5eaa8b3d2")
 @Configuration(
@@ -54,26 +37,35 @@ final class PageRank extends Benchmark with SparkUtil {
   // TODO: Consolidate benchmark parameters across the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/27
 
-  /**
-   * Maximum difference in neighboring ranks for web sites in the same class.
-   * The value is slightly lower but in the same order as 1/685230, which
-   * corresponds to the number of web sites in the input data set
-   */
-  private val rankDifferenceLimit = 1e-6
+  private var threadCountParam: Int = _
 
-  private val inputZipResource = "/web-berkstan.txt.zip"
-
-  private val inputZipEntry = "web-BerkStan.txt"
-
-  private var maxIterationsParam: Int = _
+  private var inputLineCountParam: Int = _
 
   private var expectedRankCountParam: Int = _
 
   private var expectedRankHashParam: String = _
 
-  private var inputLinks: RDD[(Int, Iterable[Int])] = _
+  /** Number of iterations of the page rank algorithm. */
+  private val PAGE_RANK_ITERATIONS = 2
 
-  private def loadData(inputSource: BufferedSource, lineCount: Int) = {
+  private val INPUT_ZIP_RESOURCE = "/web-berkstan.txt.zip"
+
+  private val INPUT_ZIP_ENTRY = "web-BerkStan.txt"
+
+  /**
+   * Maximum difference in neighboring ranks for web sites in the same class.
+   * The value is slightly lower but in the same order as 1/685230, which
+   * corresponds to the number of web sites in the input data set
+   */
+  private val RANK_DIFFERENCE_LIMIT = 1e-6
+
+  private var sc: SparkContext = _
+
+  private var links: RDD[(Int, Iterable[Int])] = _
+
+  private def loadData(zipName: String, entryName: String, lineCount: Int) = {
+    val inputSource = ZipResourceUtil.sourceFromZipResource(entryName, zipName)
+
     try {
       var inputLines = inputSource.getLines().dropWhile(_.startsWith("#"))
       if (lineCount >= 0) {
@@ -81,8 +73,7 @@ final class PageRank extends Benchmark with SparkUtil {
       }
 
       val splitter = Pattern.compile("\\s+")
-      sparkContext
-        .parallelize(inputLines.toSeq)
+      sc.parallelize(inputLines.toSeq)
         .map { line =>
           val parts = splitter.split(line, 2)
           parts(0).toInt -> parts(1).toInt
@@ -94,22 +85,22 @@ final class PageRank extends Benchmark with SparkUtil {
     }
   }
 
-  override def setUpBeforeAll(bc: BenchmarkContext): Unit = {
-    setUpSparkContext(bc)
+  override def setUpBeforeAll(c: BenchmarkContext): Unit = {
+    threadCountParam = c.parameter("thread_count").toPositiveInteger
+    inputLineCountParam = c.parameter("input_line_count").toInteger
+    expectedRankCountParam = c.parameter("expected_rank_count").toInteger
+    expectedRankHashParam = c.parameter("expected_rank_hash").value
 
-    maxIterationsParam = bc.parameter("max_iterations").toPositiveInteger
-    expectedRankCountParam = bc.parameter("expected_rank_count").toInteger
-    expectedRankHashParam = bc.parameter("expected_rank_hash").value
-
-    val inputSource = ResourceUtil.sourceFromZipResource(inputZipResource, inputZipEntry)
-
-    inputLinks = ensureCached(loadData(inputSource, bc.parameter("input_line_count").toInteger))
+    val tempDirPath = c.scratchDirectory()
+    sc = setUpSparkContext(tempDirPath, threadCountParam, "page-rank")
+    links = loadData(INPUT_ZIP_RESOURCE, INPUT_ZIP_ENTRY, inputLineCountParam)
+    ensureCaching(links)
   }
 
-  override def run(bc: BenchmarkContext): BenchmarkResult = {
-    var ranks = inputLinks.mapValues(_ => 1.0)
-    for (_ <- 0 until maxIterationsParam) {
-      val contributions = inputLinks.join(ranks).values.flatMap {
+  override def run(c: BenchmarkContext): BenchmarkResult = {
+    var ranks = links.mapValues(_ => 1.0)
+    for (_ <- 0 until PAGE_RANK_ITERATIONS) {
+      val contributions = links.join(ranks).values.flatMap {
         case (urls, rank) => urls.map(url => (url, rank / urls.size))
       }
       ranks = contributions.reduceByKey(_ + _).mapValues(0.15 + 0.85 * _)
@@ -136,7 +127,7 @@ final class PageRank extends Benchmark with SparkUtil {
         Assert.assertEquals(expectedRankCountParam, rankCount, "ranks count")
 
         val preSortedEntries = ranks.sortBy { case (_, rank) => rank }.collect
-        val sortedEntries = relaxedRanks(preSortedEntries, rankDifferenceLimit).sortBy {
+        val sortedEntries = relaxedRanks(preSortedEntries, RANK_DIFFERENCE_LIMIT).sortBy {
           case (url, rank) => (rank, url)
         }
 
@@ -164,7 +155,7 @@ final class PageRank extends Benchmark with SparkUtil {
     }
   }
 
-  override def tearDownAfterAll(bc: BenchmarkContext): Unit = {
-    tearDownSparkContext()
+  override def tearDownAfterAll(c: BenchmarkContext): Unit = {
+    tearDownSparkContext(sc)
   }
 }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ZipResourceUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ZipResourceUtil.scala
@@ -7,17 +7,17 @@ import java.util.zip.ZipInputStream
 import scala.io.BufferedSource
 import scala.io.Source
 
-private object ResourceUtil {
+private object ZipResourceUtil {
 
   /**
    * Creates a {@link Source} from a file within a ZIP resource
-   * associated with the {@link ResourceUtil} class.
+   * associated with the {@link ZipResourceUtil} class.
    *
-   * @param resourceName path to the ZIP resource
    * @param entryName name of the ZIP entry
+   * @param resourceName path to the ZIP resource
    * @return {@link Source} instance for the given file within a ZIP
    */
-  def sourceFromZipResource(resourceName: String, entryName: String): BufferedSource = {
+  def sourceFromZipResource(entryName: String, resourceName: String): BufferedSource = {
     val is = this.getClass.getResourceAsStream(resourceName)
     if (is == null) {
       throw new FileNotFoundException(

--- a/renaissance-jmh/src/main/java/org/renaissance/jmh/JmhRenaissanceBenchmark.java
+++ b/renaissance-jmh/src/main/java/org/renaissance/jmh/JmhRenaissanceBenchmark.java
@@ -51,11 +51,6 @@ public abstract class JmhRenaissanceBenchmark {
     System.getProperty("org.renaissance.jmh.keepScratch", "false")
   );
 
-  /** Determines the benchmark configuration to use. Defaults to 'jmh'. */
-  private static final String configuration = System.getProperty(
-    "org.renaissance.jmh.configuration", "jmh"
-  );
-
   private final Path scratchRootDir;
   private final org.renaissance.Benchmark benchmark;
   private final BenchmarkContext context;
@@ -111,7 +106,7 @@ public abstract class JmhRenaissanceBenchmark {
   }
 
   private static int compare(Version v1, Optional<Version> maybeV2) {
-    return maybeV2.map(v1::compareTo).orElse(0);
+    return maybeV2.map(v2 -> v1.compareTo(v2)).orElse(0);
   }
 
   //
@@ -154,7 +149,7 @@ public abstract class JmhRenaissanceBenchmark {
 
       @Override
       public BenchmarkParameter parameter(String name) {
-        return benchInfo.parameter(configuration, name);
+        return benchInfo.parameter("jmh", name);
       }
 
       @Override

--- a/tools/ci/bench-jmh.sh
+++ b/tools/ci/bench-jmh.sh
@@ -2,7 +2,4 @@
 source "$(dirname "$0")/common.sh"
 
 # Test benchmarks under JMH harness, replacing incompatible benchmarks with 'dummy-empty'
-java -Xms2500M -Xmx2500M \
-	-Dorg.renaissance.jmh.fakeIncompatible=true \
-	-Dorg.renaissance.jmh.configuration=test \
-	-jar "$RENAISSANCE_JMH_JAR" -wi 0 -i 1 -f 1 -foe true
+java -Xms2500M -Xmx2500M -Dorg.renaissance.jmh.fakeIncompatible=true -jar "$RENAISSANCE_JMH_JAR" -wi 0 -i 1 -f 1 -foe true

--- a/tools/renaissance-jmh.sh
+++ b/tools/renaissance-jmh.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-BASE_DIR="$(dirname "$0")"
-ROOT_DIR="$(git -C "$BASE_DIR" rev-parse --show-toplevel)"
-RENAISSANCE_GIT_VERSION=$(git -C "$BASE_DIR" describe --dirty=-SNAPSHOT)
-RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}
-
-exec java $JAVA_OPTS -jar "$ROOT_DIR/renaissance-jmh/target/scala-2.12/renaissance-jmh-assembly-$RENAISSANCE_VERSION.jar" "$@"

--- a/tools/renaissance.sh
+++ b/tools/renaissance.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-BASE_DIR="$(dirname "$0")"
-ROOT_DIR="$(git -C "$BASE_DIR" rev-parse --show-toplevel)"
-RENAISSANCE_GIT_VERSION=$(git -C "$BASE_DIR" describe --dirty=-SNAPSHOT)
-RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}
-
-exec java $JAVA_OPTS -jar "$ROOT_DIR/target/renaissance-gpl-$RENAISSANCE_VERSION.jar" "$@"


### PR DESCRIPTION
Reverts renaissance-benchmarks/renaissance#255, because it also brought most of the Spark benchmark cleanup with itself.
I thought that I branched the CI changes much earlier. I will merge it after the Spark cleanup is complete.