### PR TITLE
Use test configuration in CI runs of the JMH bundle (and add convenience scripts)

### DIFF
--- a/renaissance-jmh/src/main/java/org/renaissance/jmh/JmhRenaissanceBenchmark.java
+++ b/renaissance-jmh/src/main/java/org/renaissance/jmh/JmhRenaissanceBenchmark.java
@@ -51,6 +51,11 @@ public abstract class JmhRenaissanceBenchmark {
     System.getProperty("org.renaissance.jmh.keepScratch", "false")
   );
 
+  /** Determines the benchmark configuration to use. Defaults to 'jmh'. */
+  private static final String configuration = System.getProperty(
+    "org.renaissance.jmh.configuration", "jmh"
+  );
+
   private final Path scratchRootDir;
   private final org.renaissance.Benchmark benchmark;
   private final BenchmarkContext context;
@@ -74,7 +79,7 @@ public abstract class JmhRenaissanceBenchmark {
       }
 
       System.out.printf(
-        "\n!!!!! %s. Using '%s' instead to avoid failure. !!!!!\n",
+        "\n!!!!! %s Using '%s' to avoid failure. !!!!!\n",
         message, benchInfo.name()
       );
     }
@@ -106,7 +111,7 @@ public abstract class JmhRenaissanceBenchmark {
   }
 
   private static int compare(Version v1, Optional<Version> maybeV2) {
-    return maybeV2.map(v2 -> v1.compareTo(v2)).orElse(0);
+    return maybeV2.map(v1::compareTo).orElse(0);
   }
 
   //
@@ -149,7 +154,7 @@ public abstract class JmhRenaissanceBenchmark {
 
       @Override
       public BenchmarkParameter parameter(String name) {
-        return benchInfo.parameter("jmh", name);
+        return benchInfo.parameter(configuration, name);
       }
 
       @Override

--- a/tools/ci/bench-jmh.sh
+++ b/tools/ci/bench-jmh.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 source "$(dirname "$0")/common.sh"
 
-# Test benchmarks under JMH harness, replacing incompatible benchmarks with 'dummy-empty'
-java -Xms2500M -Xmx2500M \
-	-Dorg.renaissance.jmh.fakeIncompatible=true \
-	-Dorg.renaissance.jmh.configuration=test \
-	-jar "$RENAISSANCE_JMH_JAR" -wi 0 -i 1 -f 1 -foe true
+# Test benchmarks under JMH harness using the 'test' configuration
+# and replacing incompatible benchmarks with 'dummy-empty'.
+
+java -jar "$RENAISSANCE_JMH_JAR" \
+	-jvmArgs -Xms2500M -jvmArgs -Xmx2500m \
+	-jvmArgs -Dorg.renaissance.jmh.configuration=test \
+	-jvmArgs -Dorg.renaissance.jmh.fakeIncompatible=true \
+	-wi 0 -i 1 -f 1 -foe true

--- a/tools/ci/bench-jmh.sh
+++ b/tools/ci/bench-jmh.sh
@@ -2,4 +2,7 @@
 source "$(dirname "$0")/common.sh"
 
 # Test benchmarks under JMH harness, replacing incompatible benchmarks with 'dummy-empty'
-java -Xms2500M -Xmx2500M -Dorg.renaissance.jmh.fakeIncompatible=true -jar "$RENAISSANCE_JMH_JAR" -wi 0 -i 1 -f 1 -foe true
+java -Xms2500M -Xmx2500M \
+	-Dorg.renaissance.jmh.fakeIncompatible=true \
+	-Dorg.renaissance.jmh.configuration=test \
+	-jar "$RENAISSANCE_JMH_JAR" -wi 0 -i 1 -f 1 -foe true

--- a/tools/renaissance-jmh.sh
+++ b/tools/renaissance-jmh.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+BASE_DIR="$(dirname "$0")"
+ROOT_DIR="$(git -C "$BASE_DIR" rev-parse --show-toplevel)"
+RENAISSANCE_GIT_VERSION=$(git -C "$BASE_DIR" describe --dirty=-SNAPSHOT)
+RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}
+
+exec java $JAVA_OPTS -jar "$ROOT_DIR/renaissance-jmh/target/scala-2.12/renaissance-jmh-assembly-$RENAISSANCE_VERSION.jar" "$@"

--- a/tools/renaissance.sh
+++ b/tools/renaissance.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+BASE_DIR="$(dirname "$0")"
+ROOT_DIR="$(git -C "$BASE_DIR" rev-parse --show-toplevel)"
+RENAISSANCE_GIT_VERSION=$(git -C "$BASE_DIR" describe --dirty=-SNAPSHOT)
+RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}
+
+exec java $JAVA_OPTS -jar "$ROOT_DIR/target/renaissance-gpl-$RENAISSANCE_VERSION.jar" "$@"


### PR DESCRIPTION
This modifies the JMH wrapper to be able to use other configurations, changes the CI script that runs the JMH bundle to use the `test` configuration, and ensures that we pass the right JVM arguments to the JMH-forked VM.  These are relatively small changes on top of `master`, not a long-running branch (what #255 should have been but wasn't). And yes, it also tacks on two convenience scripts to run the current build of Renaissance and the JMH bundle, which is useful during development.