### PR TITLE
Update dotty to final version and its scala version to 2.13.6

### DIFF
--- a/benchmarks/actors-akka/build.sbt
+++ b/benchmarks/actors-akka/build.sbt
@@ -5,7 +5,7 @@ lazy val actorsAkka = (project in file("."))
     name := "actors-akka",
     version := (version in renaissanceCore).value,
     organization := (organization in renaissanceCore).value,
-    scalaVersion := "2.13.5",
+    scalaVersion := "2.13.6",
     libraryDependencies ++= Seq(
       // akka-actor 2.6.x supports Scala 2.12, 2.13
       "com.typesafe.akka" %% "akka-actor" % "2.6.12"

--- a/benchmarks/database/build.sbt
+++ b/benchmarks/database/build.sbt
@@ -5,7 +5,7 @@ lazy val database = (project in file("."))
     name := "database",
     version := (version in renaissanceCore).value,
     organization := (organization in renaissanceCore).value,
-    scalaVersion := "2.13.5",
+    scalaVersion := "2.13.6",
     libraryDependencies ++= Seq(
       "com.github.jnr" % "jnr-posix" % "3.0.29",
       "org.apache.commons" % "commons-math3" % "3.6.1",

--- a/benchmarks/jdk-concurrent/build.sbt
+++ b/benchmarks/jdk-concurrent/build.sbt
@@ -5,7 +5,7 @@ lazy val jdkConcurrent = (project in file("."))
     name := "jdk-concurrent",
     version := (version in renaissanceCore).value,
     organization := (organization in renaissanceCore).value,
-    scalaVersion := "2.13.5",
+    scalaVersion := "2.13.6",
     libraryDependencies ++= Seq(
       "io.jenetics" % "jenetics" % "4.4.0"
     )

--- a/benchmarks/jdk-streams/build.sbt
+++ b/benchmarks/jdk-streams/build.sbt
@@ -5,7 +5,7 @@ lazy val jdkStreams = (project in file("."))
     name := "jdk-streams",
     version := (version in renaissanceCore).value,
     organization := (organization in renaissanceCore).value,
-    scalaVersion := "2.13.5"
+    scalaVersion := "2.13.6"
   )
   .dependsOn(
     renaissanceCore

--- a/benchmarks/rx/build.sbt
+++ b/benchmarks/rx/build.sbt
@@ -5,7 +5,7 @@ lazy val rx = (project in file("."))
     name := "rx",
     version := (version in renaissanceCore).value,
     organization := (organization in renaissanceCore).value,
-    scalaVersion := "2.13.5",
+    scalaVersion := "2.13.6",
     libraryDependencies ++= Seq(
       "io.reactivex" % "rxjava" % "1.3.7"
     )

--- a/benchmarks/scala-dotty/build.sbt
+++ b/benchmarks/scala-dotty/build.sbt
@@ -5,12 +5,11 @@ lazy val scalaDotty = (project in file("."))
     name := "scala-dotty",
     version := (version in renaissanceCore).value,
     organization := (organization in renaissanceCore).value,
-    scalaVersion := "2.13.5",
+    scalaVersion := "2.13.6",
     scalacOptions += "-Ytasty-reader",
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.2",
-      // 3.0.0-RC1 is as far as we can go with Tasty reader in 2.13.5
-      "org.scala-lang" % "scala3-compiler_3.0.0-RC1" % "3.0.0-RC1"
+      "org.scala-lang" % "scala3-compiler_3" % "3.0.0"
     )
   )
   .dependsOn(

--- a/benchmarks/scala-sat/build.sbt
+++ b/benchmarks/scala-sat/build.sbt
@@ -9,7 +9,7 @@ lazy val scalaSAT = (project in file("."))
     name := "scala-sat",
     version := (version in renaissanceCore).value,
     organization := (organization in renaissanceCore).value,
-    scalaVersion := "2.13.5"
+    scalaVersion := "2.13.6"
   )
   .dependsOn(
     renaissanceCore,

--- a/benchmarks/scala-stdlib/build.sbt
+++ b/benchmarks/scala-stdlib/build.sbt
@@ -5,7 +5,7 @@ lazy val scalaStdlib = (project in file("."))
     name := "scala-stdlib",
     version := (version in renaissanceCore).value,
     organization := (organization in renaissanceCore).value,
-    scalaVersion := "2.13.5"
+    scalaVersion := "2.13.6"
   )
   .dependsOn(
     renaissanceCore

--- a/renaissance-harness/build.sbt
+++ b/renaissance-harness/build.sbt
@@ -5,7 +5,7 @@ lazy val renaissanceHarness = (project in file("."))
     name := "renaissance-harness",
     version := (version in renaissanceCore).value,
     organization := (organization in renaissanceCore).value,
-    scalaVersion := "2.13.5",
+    scalaVersion := "2.13.6",
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     libraryDependencies ++= Seq(
       "com.github.scopt" %% "scopt" % "4.0.0-RC2",


### PR DESCRIPTION
Scala 3 (Dotty compiler) got released last Friday in its final version.
The Scala 2 version with the matching Tasty reader got released today: 2.13.6.

This means that we won't face this https://github.com/scala/bug/issues/12374 nor https://github.com/lampepfl/dotty/issues/4192 anymore.

The benchmarks works as expected with the new version:
```
====== dotty (scala-dotty) [default], iteration 0 started ======
GC before operation: completed in 9.822 ms, heap usage 19.181 MB -> 4.119 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 0 completed (5541.862 ms) ======
====== dotty (scala-dotty) [default], iteration 1 started ======
GC before operation: completed in 42.440 ms, heap usage 184.515 MB -> 15.949 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 1 completed (2237.837 ms) ======
====== dotty (scala-dotty) [default], iteration 2 started ======
GC before operation: completed in 44.008 ms, heap usage 119.625 MB -> 16.034 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 2 completed (2109.014 ms) ======
====== dotty (scala-dotty) [default], iteration 3 started ======
GC before operation: completed in 52.945 ms, heap usage 147.397 MB -> 16.060 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 3 completed (1903.627 ms) ======
====== dotty (scala-dotty) [default], iteration 4 started ======
GC before operation: completed in 45.068 ms, heap usage 140.700 MB -> 16.080 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 4 completed (1769.460 ms) ======
====== dotty (scala-dotty) [default], iteration 5 started ======
GC before operation: completed in 61.991 ms, heap usage 94.394 MB -> 16.096 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 5 completed (1740.411 ms) ======
====== dotty (scala-dotty) [default], iteration 6 started ======
GC before operation: completed in 56.697 ms, heap usage 124.019 MB -> 16.103 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 6 completed (1679.062 ms) ======
====== dotty (scala-dotty) [default], iteration 7 started ======
GC before operation: completed in 64.145 ms, heap usage 112.209 MB -> 16.107 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 7 completed (1667.501 ms) ======
====== dotty (scala-dotty) [default], iteration 8 started ======
GC before operation: completed in 57.354 ms, heap usage 190.427 MB -> 16.112 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 8 completed (1585.877 ms) ======
====== dotty (scala-dotty) [default], iteration 9 started ======
GC before operation: completed in 68.497 ms, heap usage 171.134 MB -> 16.118 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 9 completed (1604.168 ms) ======
====== dotty (scala-dotty) [default], iteration 10 started ======
GC before operation: completed in 67.607 ms, heap usage 60.653 MB -> 16.132 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 10 completed (1542.296 ms) ======
====== dotty (scala-dotty) [default], iteration 11 started ======
GC before operation: completed in 62.868 ms, heap usage 122.257 MB -> 16.137 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 11 completed (1534.415 ms) ======
====== dotty (scala-dotty) [default], iteration 12 started ======
GC before operation: completed in 66.691 ms, heap usage 97.025 MB -> 16.146 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 12 completed (1513.667 ms) ======
====== dotty (scala-dotty) [default], iteration 13 started ======
GC before operation: completed in 69.300 ms, heap usage 133.725 MB -> 16.152 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 13 completed (1487.641 ms) ======
====== dotty (scala-dotty) [default], iteration 14 started ======
GC before operation: completed in 60.688 ms, heap usage 119.423 MB -> 16.156 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 14 completed (1428.665 ms) ======
====== dotty (scala-dotty) [default], iteration 15 started ======
GC before operation: completed in 72.065 ms, heap usage 59.564 MB -> 16.157 MB.
WARNING: This benchmark provides no result that can be validated.
         There is no way to check that no silent failure occurred.
====== dotty (scala-dotty) [default], iteration 15 completed (1408.411 ms) ======
```