### PR TITLE
Make build.sbt (and friends) a bit easier to understand

### DIFF
--- a/benchmarks/actors-akka/build.sbt
+++ b/benchmarks/actors-akka/build.sbt
@@ -12,5 +12,5 @@ lazy val actorsAkka = (project in file("."))
     )
   )
   .dependsOn(
-    renaissanceCore
+    renaissanceCore % "provided"
   )

--- a/benchmarks/actors-reactors/build.sbt
+++ b/benchmarks/actors-reactors/build.sbt
@@ -11,7 +11,7 @@ lazy val actorsReactors = (project in file("."))
     scalaVersion := "2.12.13"
   )
   .dependsOn(
-    renaissanceCore,
+    renaissanceCore % "provided",
     reactorsCommon,
     reactorsCore
   )

--- a/benchmarks/apache-spark/build.sbt
+++ b/benchmarks/apache-spark/build.sbt
@@ -17,5 +17,5 @@ lazy val apacheSpark = (project in file("."))
     )
   )
   .dependsOn(
-    renaissanceCore
+    renaissanceCore % "provided"
   )

--- a/benchmarks/database/build.sbt
+++ b/benchmarks/database/build.sbt
@@ -25,5 +25,5 @@ lazy val database = (project in file("."))
     )
   )
   .dependsOn(
-    renaissanceCore
+    renaissanceCore % "provided"
   )

--- a/benchmarks/dummy/build.sbt
+++ b/benchmarks/dummy/build.sbt
@@ -9,5 +9,5 @@ lazy val dummy = (project in file("."))
     autoScalaLibrary := false
   )
   .dependsOn(
-    renaissanceCore
+    renaissanceCore % "provided"
   )

--- a/benchmarks/jdk-concurrent/build.sbt
+++ b/benchmarks/jdk-concurrent/build.sbt
@@ -11,5 +11,5 @@ lazy val jdkConcurrent = (project in file("."))
     )
   )
   .dependsOn(
-    renaissanceCore
+    renaissanceCore % "provided"
   )

--- a/benchmarks/jdk-streams/build.sbt
+++ b/benchmarks/jdk-streams/build.sbt
@@ -8,5 +8,5 @@ lazy val jdkStreams = (project in file("."))
     scalaVersion := "2.13.6"
   )
   .dependsOn(
-    renaissanceCore
+    renaissanceCore % "provided"
   )

--- a/benchmarks/neo4j/build.sbt
+++ b/benchmarks/neo4j/build.sbt
@@ -14,5 +14,5 @@ lazy val neo4j = (project in file("."))
     )
   )
   .dependsOn(
-    renaissanceCore
+    renaissanceCore % "provided"
   )

--- a/benchmarks/rx/build.sbt
+++ b/benchmarks/rx/build.sbt
@@ -11,5 +11,5 @@ lazy val rx = (project in file("."))
     )
   )
   .dependsOn(
-    renaissanceCore
+    renaissanceCore % "provided"
   )

--- a/benchmarks/scala-dotty/build.sbt
+++ b/benchmarks/scala-dotty/build.sbt
@@ -14,5 +14,5 @@ lazy val scalaDotty = (project in file("."))
     )
   )
   .dependsOn(
-    renaissanceCore
+    renaissanceCore % "provided"
   )

--- a/benchmarks/scala-sat/build.sbt
+++ b/benchmarks/scala-sat/build.sbt
@@ -12,7 +12,7 @@ lazy val scalaSAT = (project in file("."))
     scalaVersion := "2.13.6"
   )
   .dependsOn(
-    renaissanceCore,
+    renaissanceCore % "provided",
     scalaSMTLib,
     scalaCafeSAT
   )

--- a/benchmarks/scala-stdlib/build.sbt
+++ b/benchmarks/scala-stdlib/build.sbt
@@ -8,5 +8,5 @@ lazy val scalaStdlib = (project in file("."))
     scalaVersion := "2.13.6"
   )
   .dependsOn(
-    renaissanceCore
+    renaissanceCore % "provided"
   )

--- a/benchmarks/scala-stm/build.sbt
+++ b/benchmarks/scala-stm/build.sbt
@@ -10,7 +10,7 @@ lazy val scalaStm = (project in file("."))
     scalaVersion := "2.12.13"
   )
   .dependsOn(
-    renaissanceCore,
+    renaissanceCore % "provided",
     scalaStmLibrary % "compile->compile;compile->test"
   )
   .aggregate(

--- a/benchmarks/scala-stm/scala-stm-library/build.sbt
+++ b/benchmarks/scala-stm/scala-stm-library/build.sbt
@@ -9,7 +9,7 @@ scalaVersion := "2.12.13"
 
 crossScalaVersions := Seq("2.11.11", "2.12.3", "2.13.0-M2")
 
-javacOptions in (Compile, compile) ++= {
+Compile / compile / javacOptions ++= {
   val javaVersion = if (scalaVersion.value.startsWith("2.11")) "1.6" else "1.8"
   Seq("-source", javaVersion, "-target", javaVersion)
 }
@@ -22,7 +22,7 @@ libraryDependencies += ("junit" % "junit" % "4.12" % "test")
 testOptions += Tests.Argument("-l", "slow")
 
 // test of TxnExecutor.transformDefault must be run by itself
-parallelExecution in Test := false
+Test / parallelExecution := false
 
 exportJars := true
 

--- a/benchmarks/twitter-finagle/build.sbt
+++ b/benchmarks/twitter-finagle/build.sbt
@@ -15,5 +15,5 @@ lazy val twitterFinagle = (project in file("."))
     )
   )
   .dependsOn(
-    renaissanceCore
+    renaissanceCore % "provided"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,13 @@
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
-
+import RenaissanceJmh.generateJmhWrapperBenchmarkClass
 import org.renaissance.License
 import org.renaissance.core.Launcher
+import sbt.Def
 
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.Properties
 import scala.collection._
 
 enablePlugins(GitBranchPrompt)
@@ -13,20 +16,20 @@ lazy val renaissanceCore = RootProject(uri("renaissance-core"))
 
 lazy val renaissanceHarness = RootProject(uri("renaissance-harness"))
 
-val benchmarkProjects = for {
+val renaissanceBenchmarks = for {
   // Hint: add .filter(Seq("group1", "group2").contains(_)) to compile
   // selected benchmark groups only (this can significantly speed-up
   // compilation/assembly when debugging the harness).
-  dir <- file("benchmarks")
-    .list()
-  if dir != null && file("benchmarks/" + dir + "/build.sbt").exists()
+  dir <- file("benchmarks").list()
+  benchDir = file("benchmarks") / dir
+  if dir != null && (benchDir / "build.sbt").exists()
 } yield {
-  RootProject(uri("benchmarks/" + dir))
+  RootProject(benchDir)
 }
 
-val subProjects = benchmarkProjects :+ renaissanceHarness
+val renaissanceModules = renaissanceBenchmarks :+ renaissanceHarness
 
-val allProjects = subProjects :+ renaissanceCore
+val renaissanceProjects = renaissanceModules :+ renaissanceCore
 
 // Do not assemble fat JARs in subprojects
 assembly / aggregate := false
@@ -40,77 +43,113 @@ def flattenTasks[A](tasks: Seq[Def.Initialize[Task[A]]]): Def.Initialize[Task[Se
       }
   }
 
-def projectJars =
-  Def.taskDyn {
-    val rootJarBase = (Compile / resourceManaged).value
-    val coreJar = (renaissanceCore / Runtime / packageBin).value
+def savePropertiesAsResource(props: Properties, file: File, comments: String): File = {
+  file.getParentFile.mkdirs()
 
-    // Each generated task returns tuple of
-    // (project name, project path, all JAR files, all JAR files without renaissance core JAR*)
-    // * because renaissance core classes are shared across all benchmarks
-    val projectJarTasks = for {
-      project <- subProjects
-    } yield Def.task {
-      val mainJar = (project / Compile / packageBin).value
-      val depJars = (project / Compile / dependencyClasspathAsJars).value.map(_.data)
-      val loadedJars = mainJar +: depJars
-      val allJars = mainJar +: coreJar +: depJars
+  val fos = new FileOutputStream(file)
+  try {
+    props.store(fos, comments)
+    file
+  } finally {
+    fos.close()
+  }
+}
 
-      val projectPath = project.asInstanceOf[RootProject].build.getPath
-      val jarBase = rootJarBase / projectPath
-      jarBase.mkdirs()
-
-      val allJarFiles = for (jar <- allJars) yield {
-        val dest = jarBase / jar.getName
-        Files.copy(jar.toPath, dest.toPath, StandardCopyOption.REPLACE_EXISTING)
-        dest
-      }
-
-      val projectName = (project / name).value
-      (projectName, projectPath, allJarFiles, loadedJars)
-    }
-    flattenTasks(projectJarTasks)
+//
+// Creates a task that collects the runtime dependency jars for
+// the given project and returns a tuple as follows:
+// (project name, relative path, runtime jars)
+//
+def defineProjectJarsCollectorTask(
+  project: RootProject
+): Def.Initialize[Task[(String, Path, Seq[File])]] =
+  Def.task {
+    val rootBase = baseDirectory.value.toPath
+    val projectName = (project / name).value
+    val projectBase = (project / baseDirectory).value.toPath
+    val projectPath = rootBase.relativize(projectBase)
+    val projectJars = (project / Runtime / dependencyClasspathAsJars).value.map(_.data)
+    (projectName, projectPath, projectJars)
   }
 
-def jarsAndListGenerator =
-  Def.taskDyn {
-    val nonGpl = nonGplOnly.value
+//
+// Creates a compound task that collects the runtime dependency jars
+// for all given projects. This needs to be performed by aggregating
+// results from per-project tasks.
+//
+def defineCompoundProjectJarsCollectorTask(projects: Array[RootProject]) =
+  flattenTasks(projects.map { defineProjectJarsCollectorTask })
+
+//
+// Creates a task that generates the contents of the "modules.properties" file.
+//
+def defineModulesPropertiesGeneratorTask =
+  Def.task {
     val logger = streams.value.log
 
-    projectJars.map { groupJars =>
-      // Create the "modules.properties" file.
-      val modulesProps = new java.util.Properties
-      for ((projectName, projectPath, _, loadedJars) <- groupJars) {
-        val jarLine = loadedJars.map(jar => projectPath + "/" + jar.getName).mkString(",")
-        modulesProps.setProperty(projectName, jarLine)
-      }
+    val modulesProps = new Properties
+    defineCompoundProjectJarsCollectorTask(renaissanceModules).value.foreach { module =>
+      val (moduleName, modulePath, moduleJars) = module
+      val jarLine = moduleJars.map(jar => modulePath.resolve(jar.getName)).mkString(",")
+      modulesProps.setProperty(moduleName, jarLine)
+    }
 
-      val modulesPropsFile = (Compile / resourceManaged).value / "modules.properties"
-      val modulesPropsStream = new java.io.FileOutputStream(modulesPropsFile)
-      modulesProps.store(modulesPropsStream, "Module jars")
+    val modulesPropsFile = (Compile / resourceManaged).value / "modules.properties"
 
-      // Create the "benchmark.properties" file.
-      // Scan project jars for benchmarks and fill the property file.
-      // Use all project jars to ensure that the benchmark class be be loaded.
-      val benchmarksProps = new java.util.Properties
-      for ((projectName, _, allJars, _) <- groupJars) {
-        for (benchInfo <- Benchmarks.listBenchmarks(projectName, allJars, Some(logger))) {
-          if (!nonGpl || benchInfo.distro() == License.MIT) {
-            for ((k, v) <- benchInfo.toMap()) {
-              benchmarksProps.setProperty(s"benchmark.${benchInfo.name()}.$k", v)
-            }
+    logger.info(s"Writing $modulesPropsFile ...")
+    Seq(savePropertiesAsResource(modulesProps, modulesPropsFile, "Module jars"))
+  }
+
+//
+// Creates a task that generates the contents of the "benchmarks.properties" file.
+//
+def defineBenchmarksPropertiesGeneratorTask =
+  Def.task {
+    val logger = streams.value.log
+
+    val benchmarksProps = new Properties
+    defineCompoundProjectJarsCollectorTask(renaissanceBenchmarks).value.foreach { module =>
+      val (moduleName, _, moduleJars) = module
+      for (bench <- Benchmarks.listBenchmarks(moduleName, moduleJars, Some(logger))) {
+        if (!nonGplOnly.value || bench.distro == License.MIT) {
+          for ((k, v) <- bench.toMap) {
+            benchmarksProps.setProperty(s"benchmark.${bench.name}.$k", v)
           }
         }
       }
+    }
 
-      val benchmarksPropsFile = (Compile / resourceManaged).value / "benchmarks.properties"
-      val benchmarksPropsStream = new java.io.FileOutputStream(benchmarksPropsFile)
-      benchmarksProps.store(benchmarksPropsStream, "Benchmark details")
+    val benchmarksPropsFile = (Compile / resourceManaged).value / "benchmarks.properties"
 
-      benchmarksPropsFile +: modulesPropsFile +: groupJars.flatMap {
-        case (_, _, jars, _) => jars
+    logger.info(s"Writing $benchmarksPropsFile ...")
+    Seq(savePropertiesAsResource(benchmarksProps, benchmarksPropsFile, "Benchmark details"))
+  }
+
+//
+// Creates a task that copies the runtime jars of all benchmarks into
+// resource output directory of the root project.
+//
+def defineCollectRuntimeJarsTask =
+  Def.task {
+    val logger = streams.value.log
+
+    val outputDir = (Compile / resourceManaged).value.toPath
+    defineCompoundProjectJarsCollectorTask(renaissanceModules).value.flatMap { module =>
+      val (_, modulePath, moduleJars) = module
+
+      logger.info(s"Collecting runtime dependencies for $modulePath ...")
+      val moduleJarBase = Files.createDirectories(outputDir.resolve(modulePath))
+      for (srcJar <- moduleJars) yield {
+        val dstJar = moduleJarBase / srcJar.getName
+        Files.copy(srcJar.toPath, dstJar, StandardCopyOption.REPLACE_EXISTING).toFile
       }
     }
+  }
+
+def defineRenaissanceAssemblyNameTask =
+  Def.task {
+    val bundle = if (nonGplOnly.value) "mit" else "gpl"
+    "renaissance-" + bundle + "-" + (renaissanceCore / version).value + ".jar"
   }
 
 addCommandAlias("renaissanceFormat", ";scalafmt;scalafmtSbt")
@@ -160,7 +199,8 @@ def addLink(scriptFile: File, linkFile: File): Unit = {
 }
 
 lazy val renaissance: Project = {
-  // required for out of the box JDK16+ support of als, chi-square, gauss-mix, log-regression, naive-bayes, movie-lens
+  // Required for out of-the-box JDK16+ support in:
+  // als, chi-square, gauss-mix, log-regression, naive-bayes, movie-lens
   // https://github.com/renaissance-benchmarks/renaissance/issues/241
   val addOpensPackages = List(
     "java.base/java.lang",
@@ -169,6 +209,7 @@ lazy val renaissance: Project = {
     "java.base/java.nio",
     "java.base/sun.nio.ch"
   )
+
   val p = Project("renaissance", file("."))
     .settings(
       name := "renaissance",
@@ -176,11 +217,20 @@ lazy val renaissance: Project = {
       organization := (renaissanceCore / organization).value,
       crossPaths := false,
       autoScalaLibrary := false,
-      Compile / resourceGenerators += jarsAndListGenerator.taskValue,
-      run / fork := true,
-      Global / cancelable := true,
       remoteDebug := false,
       nonGplOnly := false,
+      Compile / javaOptions ++= {
+        if (remoteDebug.value) {
+          Seq("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000")
+        } else {
+          Seq()
+        }
+      },
+      Compile / resourceGenerators ++= Seq(
+        defineModulesPropertiesGeneratorTask.taskValue,
+        defineBenchmarksPropertiesGeneratorTask.taskValue,
+        defineCollectRuntimeJarsTask.taskValue
+      ),
       setupPrePush := addLink(file("tools") / "pre-push", file(".git") / "hooks" / "pre-push"),
       packageOptions := Seq(
         sbt.Package.ManifestAttributes(
@@ -194,33 +244,28 @@ lazy val renaissance: Project = {
       ),
       // Configure fat JAR: specify its name, main(), do not run tests when
       // building it and raise error on file conflicts.
-      assembly / assemblyJarName :=
-        "renaissance-" + (if (nonGplOnly.value) "mit" else "gpl") +
-          "-" + (renaissanceCore / version).value + ".jar",
+      assembly / assemblyJarName := defineRenaissanceAssemblyNameTask.value,
       assembly / mainClass := Some(classOf[Launcher].getName),
       assembly / test := {},
       assembly / assemblyMergeStrategy := {
         case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
         case _ => MergeStrategy.singleOrError
       },
-      Compile / javaOptions ++= {
-        if (remoteDebug.value) {
-          Seq("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000")
-        } else {
-          Seq()
-        }
-      },
+      Global / cancelable := true,
       Global / onLoad := {
         val old = (Global / onLoad).value
         old.andThen(startupTransition)
-      }
+      },
+      run / fork := true
     )
     .dependsOn(
       renaissanceCore
     )
-  allProjects.foldLeft(p)(_ aggregate _)
+
+  renaissanceProjects.foldLeft(p)(_ aggregate _)
 }
 
+//
 // This project generates a custom JMH wrapper for each Renaissance benchmark.
 // Then, the project inserts JMH-specific functionality into the final JAR,
 // which can then be run in a JMH-compliant way.
@@ -239,6 +284,25 @@ lazy val renaissance: Project = {
 // with a custom merge strategy -- this is fine, because the Scala library is only needed
 // by the extra functionality that the sbt-jmh inserts into the artifact, and we don't
 // need that anyway.
+
+def defineJmhSourcesGeneratorTask =
+  Def.task {
+    val logger = streams.value.log
+
+    val outputDir = (Compile / sourceManaged).value.toPath
+    defineCompoundProjectJarsCollectorTask(renaissanceBenchmarks).value.flatMap { module =>
+      val (moduleName, modulePath, moduleJars) = module
+      for {
+        bench <- Benchmarks.listBenchmarks(moduleName, moduleJars, Some(logger))
+        if (!nonGplOnly.value || bench.distro == License.MIT) &&
+          (!bench.groups.contains("dummy") || bench.name == "dummy-empty")
+      } yield {
+        logger.info(s"Generating JMH wrappers for $modulePath")
+        generateJmhWrapperBenchmarkClass(bench, outputDir)
+      }
+    }
+  }
+
 lazy val renaissanceJmh = (project in file("renaissance-jmh"))
   .enablePlugins(JmhPlugin)
   .settings(
@@ -247,19 +311,7 @@ lazy val renaissanceJmh = (project in file("renaissance-jmh"))
     organization := (renaissance / organization).value,
     nonGplOnly := (renaissance / nonGplOnly).value,
     assembly / mainClass := Some("org.openjdk.jmh.Main"),
-    Compile / sourceGenerators := Def.taskDyn {
-      val log = streams.value.log
-      val outputDir = (Compile / sourceManaged).value
-      val nonGpl = nonGplOnly.value
-      projectJars.map { groupJars =>
-        RenaissanceJmh.generateJmhWrapperBenchmarkClasses(
-          outputDir,
-          log,
-          nonGpl,
-          groupJars
-        )
-      }
-    }.taskValue +: (Compile / sourceGenerators).value,
+    Compile / sourceGenerators += defineJmhSourcesGeneratorTask.taskValue,
     Jmh / assembly := ((Jmh / assembly) dependsOn (Jmh / compile)).value,
     assembly / assemblyMergeStrategy := {
       case PathList("scala", _*) =>
@@ -272,5 +324,3 @@ lazy val renaissanceJmh = (project in file("renaissance-jmh"))
   .dependsOn(
     renaissance
   )
-
-Project.inConfig(Jmh)(baseAssemblySettings)

--- a/plugins/jmx-timers/project/plugins.sbt
+++ b/plugins/jmx-timers/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")

--- a/plugins/ubench-agent/project/plugins.sbt
+++ b/plugins/ubench-agent/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")

--- a/project/jmh.scala
+++ b/project/jmh.scala
@@ -1,19 +1,18 @@
-import org.renaissance.License
-import sbt.RootProject
 import sbt.io.IO
-import sbt.util.Logger
 
 import java.io.File
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
 
 object RenaissanceJmh {
 
-  def generateJmhWrapperBenchmarkClass(info: BenchmarkInfo, outputDir: File): File = {
+  def generateJmhWrapperBenchmarkClass(info: BenchmarkInfo, outputBaseDir: Path): File = {
     val packageName = info.benchClass.getPackage.getName
-    val jmhClassName = "Jmh" + info.benchClass.getSimpleName
+    val jmhClassName = s"Jmh${info.benchClass.getSimpleName}"
 
     val content = s"""
-package ${packageName};
+package $packageName;
 
 import org.openjdk.jmh.annotations.*;
 import org.renaissance.jmh.JmhRenaissanceBenchmark;
@@ -24,42 +23,16 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 @OutputTimeUnit(MILLISECONDS)
 @Warmup(iterations = ${info.repetitions})
 @Measurement(iterations = ${info.repetitions / 4 + 1})
-public class ${jmhClassName} extends JmhRenaissanceBenchmark {
-  public ${jmhClassName}() { super("${info.name}"); }
+public class $jmhClassName extends JmhRenaissanceBenchmark {
+  public $jmhClassName() { super("${info.name}"); }
 }
 """
 
-    val outputPackageDir =
-      new File(outputDir.toString + "/" + packageName.split("\\.").mkString("/"))
-    outputPackageDir.mkdirs()
-    val outputFile = new File(outputPackageDir, jmhClassName + ".java")
+    val packagePath = packageName.split("[.]").mkString(File.separator)
+    val outputDir = Files.createDirectories(outputBaseDir.resolve(packagePath))
+    val outputFile = outputDir.resolve(jmhClassName + ".java").toFile
     IO.write(outputFile, content, StandardCharsets.UTF_8)
     outputFile
   }
 
-  def generateJmhWrapperBenchmarkClasses(
-    outputDir: File,
-    logger: Logger,
-    nonGpl: Boolean,
-    groupJars: Seq[(String, String, Seq[File], Seq[File])]
-  ) = {
-    val perProjectBenchmarkClasses = for {
-      (projectName, projectPath, allJars, _) <- groupJars
-      // TODO: Filter projects in the build file if possible
-      if projectPath.startsWith("benchmarks/")
-    } yield {
-      // Scan project jars for benchmarks and fill the property file.
-      logger.info(s"Generating JMH wrappers for project $projectPath")
-      for {
-        info <- Benchmarks.listBenchmarks(projectName, allJars, None)
-        // TODO: Filter projects in the build file if possible
-        if (!nonGpl || info.distro() == License.MIT) &&
-          (!info.groups.contains("dummy") || info.name == "dummy-empty")
-      } yield {
-        generateJmhWrapperBenchmarkClass(info, outputDir)
-      }
-    }
-
-    perProjectBenchmarkClasses.flatten
-  }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.6")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.1")

--- a/renaissance-harness/build.sbt
+++ b/renaissance-harness/build.sbt
@@ -13,5 +13,5 @@ lazy val renaissanceHarness = (project in file("."))
     )
   )
   .dependsOn(
-    renaissanceCore
+    renaissanceCore % "provided"
   )


### PR DESCRIPTION
This does several things in an attempt to streamline the build process:
- Marks dependency on `renaissance-core` in other modules as `provided`.  This is a dependency that is expected to be provided by the *runtime*, which is exactly what we do. As a result, the `renaissance-core` JAR file is excluded from the runtime dependencies of other modules and is not repeatedly copied into the final bundle.
- Dismantles the `projectJars` and `jarsAndListGenerator` tasks which together did too many things into separate tasks responsible for generating the `modules.properties` and `benchmarks.properties` files and for copying the runtime dependencies into the `resource_managed` directory of the root project. 
- Factors the inline definition of the task to generate JMH wrappers out of the `renaissanceJmh` project configuration and makes it a separate task that also relies on the `renaissanceBenchmarks` projects to select benchmarks for which to generate the wrappers, reducing `RenaissanceJmh` to just a single method that generates the wrapper.

