### PR TITLE
Add empty "test" configuration to the dummy-empty benchmark

### DIFF
--- a/benchmarks/dummy/src/main/java/org/renaissance/dummy/DummyEmpty.java
+++ b/benchmarks/dummy/src/main/java/org/renaissance/dummy/DummyEmpty.java
@@ -12,6 +12,7 @@ import static org.renaissance.Benchmark.*;
 @Group("dummy")
 @Summary("A dummy benchmark which only serves to test the harness.")
 @Licenses(License.MIT)
+@Configuration(name = "test")
 public final class DummyEmpty implements Benchmark {
   @Override
   public BenchmarkResult run(BenchmarkContext c) {


### PR DESCRIPTION
The new parameter handling code now complains (failing the benchmark) if we ask for a non-existing configuration. This can fail the CI builds because the `dummy-empty` benchmark is used to replace incompatible benchmarks in JMH runs and I forgot to add the `test` configuration.

Fixes #268