### PR TITLE
Make the benchmark primary groups more user-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,6 @@ Usage: renaissance [options] [benchmark-specification]
 
 The following is the complete list of benchmarks, separated into groups.
 
-#### actors
-
-- `akka-uct` - Runs the Unbalanced Cobwebbed Tree actor workload in Akka. (default repetitions: 24)
-
-- `reactors` - Runs benchmarks inspired by the Savina microbenchmark workloads in a sequence on Reactors.IO. (default repetitions: 10)
-
 #### apache-spark
 
 - `als` - Runs the ALS algorithm from the Spark MLlib. (default repetitions: 30)
@@ -119,51 +113,45 @@ The following is the complete list of benchmarks, separated into groups.
 
 - `page-rank` - Runs a number of PageRank iterations, using RDDs. (default repetitions: 20)
 
+#### concurrency
+
+- `akka-uct` - Runs the Unbalanced Cobwebbed Tree actor workload in Akka. (default repetitions: 24)
+
+- `fj-kmeans` - Runs the k-means algorithm using the fork/join framework. (default repetitions: 30)
+
+- `reactors` - Runs benchmarks inspired by the Savina microbenchmark workloads in a sequence on Reactors.IO. (default repetitions: 10)
+
 #### database
 
 - `db-shootout` - Executes a shootout test using several in-memory databases. (default repetitions: 16)
 
-#### jdk-concurrent
+- `neo4j-analytics` - Executes Neo4J graph queries against a movie database. (default repetitions: 20)
 
-- `fj-kmeans` - Runs the k-means algorithm using the fork/join framework. (default repetitions: 30)
+#### functional
 
 - `future-genetic` - Runs a genetic algorithm using the Jenetics library and futures. (default repetitions: 50)
-
-#### jdk-streams
 
 - `mnemonics` - Solves the phone mnemonics problem using JDK streams. (default repetitions: 16)
 
 - `par-mnemonics` - Solves the phone mnemonics problem using parallel JDK streams. (default repetitions: 16)
 
-- `scrabble` - Solves the Scrabble puzzle using JDK Streams. (default repetitions: 50)
-
-#### neo4j
-
-- `neo4j-analytics` - Executes Neo4J graph queries against a movie database. (default repetitions: 20)
-
-#### rx
-
 - `rx-scrabble` - Solves the Scrabble puzzle using the Rx streams. (default repetitions: 80)
 
-#### scala-dotty
+- `scrabble` - Solves the Scrabble puzzle using JDK Streams. (default repetitions: 50)
+
+#### scala
 
 - `dotty` - Runs the Dotty compiler on a set of source code files. (default repetitions: 50)
 
-#### scala-sat
+- `philosophers` - Solves a variant of the dining philosophers problem using ScalaSTM. (default repetitions: 30)
 
 - `scala-doku` - Solves Sudoku Puzzles using Scala collections. (default repetitions: 20)
 
-#### scala-stdlib
-
 - `scala-kmeans` - Runs the K-Means algorithm using Scala collections. (default repetitions: 50)
-
-#### scala-stm
-
-- `philosophers` - Solves a variant of the dining philosophers problem using ScalaSTM. (default repetitions: 30)
 
 - `scala-stm-bench7` - Runs the stmbench7 benchmark using ScalaSTM. (default repetitions: 60)
 
-#### twitter-finagle
+#### web
 
 - `finagle-chirper` - Simulates a microblogging service using Twitter Finagle. (default repetitions: 90)
 

--- a/benchmarks/actors-akka/src/main/scala/org/renaissance/actors/AkkaUct.scala
+++ b/benchmarks/actors-akka/src/main/scala/org/renaissance/actors/AkkaUct.scala
@@ -10,6 +10,7 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("akka-uct")
+@Group("concurrency")
 @Group("actors")
 @Summary("Runs the Unbalanced Cobwebbed Tree actor workload in Akka.")
 @Licenses(Array(License.MIT))

--- a/benchmarks/actors-reactors/src/main/scala/org/renaissance/actors/Reactors.scala
+++ b/benchmarks/actors-reactors/src/main/scala/org/renaissance/actors/Reactors.scala
@@ -17,6 +17,7 @@ import scala.concurrent.duration._
 import scala.util.Random
 
 @Name("reactors")
+@Group("concurrency")
 @Group("actors")
 @Summary(
   "Runs benchmarks inspired by the Savina microbenchmark workloads in a sequence on Reactors.IO."

--- a/benchmarks/jdk-concurrent/src/main/scala/org/renaissance/jdk/concurrent/FjKmeans.scala
+++ b/benchmarks/jdk-concurrent/src/main/scala/org/renaissance/jdk/concurrent/FjKmeans.scala
@@ -8,6 +8,7 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("fj-kmeans")
+@Group("concurrency")
 @Group("jdk-concurrent")
 @Summary("Runs the k-means algorithm using the fork/join framework.")
 @Licenses(Array(License.APACHE2))

--- a/benchmarks/jdk-concurrent/src/main/scala/org/renaissance/jdk/concurrent/FutureGenetic.scala
+++ b/benchmarks/jdk-concurrent/src/main/scala/org/renaissance/jdk/concurrent/FutureGenetic.scala
@@ -8,6 +8,7 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("future-genetic")
+@Group("functional")
 @Group("jdk-concurrent")
 @Summary("Runs a genetic algorithm using the Jenetics library and futures.")
 @Licenses(Array(License.APACHE2))

--- a/benchmarks/jdk-streams/src/main/scala/org/renaissance/jdk/streams/Mnemonics.scala
+++ b/benchmarks/jdk-streams/src/main/scala/org/renaissance/jdk/streams/Mnemonics.scala
@@ -8,6 +8,7 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("mnemonics")
+@Group("functional")
 @Group("jdk-streams")
 @Summary("Solves the phone mnemonics problem using JDK streams.")
 @Licenses(Array(License.MIT))

--- a/benchmarks/jdk-streams/src/main/scala/org/renaissance/jdk/streams/ParMnemonics.scala
+++ b/benchmarks/jdk-streams/src/main/scala/org/renaissance/jdk/streams/ParMnemonics.scala
@@ -8,6 +8,7 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("par-mnemonics")
+@Group("functional")
 @Group("jdk-streams")
 @Summary("Solves the phone mnemonics problem using parallel JDK streams.")
 @Licenses(Array(License.MIT))

--- a/benchmarks/jdk-streams/src/main/scala/org/renaissance/jdk/streams/Scrabble.scala
+++ b/benchmarks/jdk-streams/src/main/scala/org/renaissance/jdk/streams/Scrabble.scala
@@ -10,6 +10,7 @@ import org.renaissance.License
 import scala.jdk.CollectionConverters._
 
 @Name("scrabble")
+@Group("functional")
 @Group("jdk-streams")
 @Summary("Solves the Scrabble puzzle using JDK Streams.")
 @Licenses(Array(License.GPL2))

--- a/benchmarks/neo4j/src/main/scala/org/renaissance/neo4j/Neo4jAnalytics.scala
+++ b/benchmarks/neo4j/src/main/scala/org/renaissance/neo4j/Neo4jAnalytics.scala
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.io.{Codec, Source}
 
 @Name("neo4j-analytics")
+@Group("database")
 @Group("neo4j")
 @Summary("Executes Neo4J graph queries against a movie database.")
 @Licenses(Array(License.GPL3))

--- a/benchmarks/rx/src/main/scala/org/renaissance/rx/RxScrabble.scala
+++ b/benchmarks/rx/src/main/scala/org/renaissance/rx/RxScrabble.scala
@@ -8,6 +8,7 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("rx-scrabble")
+@Group("functional")
 @Group("rx")
 @Summary("Solves the Scrabble puzzle using the Rx streams.")
 @Licenses(Array(License.GPL2))

--- a/benchmarks/scala-dotty/src/main/scala/org/renaissance/scala/dotty/Dotty.scala
+++ b/benchmarks/scala-dotty/src/main/scala/org/renaissance/scala/dotty/Dotty.scala
@@ -31,6 +31,7 @@ import scala.collection._
 import scala.io.Source
 
 @Name("dotty")
+@Group("scala")
 @Group("scala-dotty")
 @Summary("Runs the Dotty compiler on a set of source code files.")
 @Licenses(Array(License.BSD3))

--- a/benchmarks/scala-sat/src/main/scala/org.renaissance.scala.sat/ScalaDoku.scala
+++ b/benchmarks/scala-sat/src/main/scala/org.renaissance.scala.sat/ScalaDoku.scala
@@ -92,6 +92,7 @@ object Solver {
 }
 
 @Name("scala-doku")
+@Group("scala")
 @Group("scala-sat")
 @Summary("Solves Sudoku Puzzles using Scala collections.")
 @Licenses(Array(License.MIT))

--- a/benchmarks/scala-stdlib/src/main/scala/org/renaissance/scala/stdlib/ScalaKmeans.scala
+++ b/benchmarks/scala-stdlib/src/main/scala/org/renaissance/scala/stdlib/ScalaKmeans.scala
@@ -118,6 +118,7 @@ trait KmeansUtilities {
 }
 
 @Name("scala-kmeans")
+@Group("scala")
 @Group("scala-stdlib")
 @Summary("Runs the K-Means algorithm using Scala collections.")
 @Licenses(Array(License.MIT))

--- a/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/Philosophers.scala
+++ b/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/Philosophers.scala
@@ -8,6 +8,7 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("philosophers")
+@Group("scala")
 @Group("scala-stm")
 @Summary("Solves a variant of the dining philosophers problem using ScalaSTM.")
 @Licenses(Array(License.BSD3))

--- a/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/ScalaStmBench7.scala
+++ b/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/ScalaStmBench7.scala
@@ -8,6 +8,7 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("scala-stm-bench7")
+@Group("scala")
 @Group("scala-stm")
 @Summary("Runs the stmbench7 benchmark using ScalaSTM.")
 @Licenses(Array(License.BSD3, License.GPL2))

--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleChirper.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleChirper.scala
@@ -35,6 +35,7 @@ import scala.io.Source
 import scala.util.hashing.byteswap32
 
 @Name("finagle-chirper")
+@Group("web")
 @Group("twitter-finagle")
 @Summary("Simulates a microblogging service using Twitter Finagle.")
 @Licenses(Array(License.APACHE2))

--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
@@ -26,6 +26,7 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("finagle-http")
+@Group("web")
 @Group("twitter-finagle")
 @Summary("Sends many small Finagle HTTP requests to a Finagle HTTP server and awaits response.")
 @Licenses(Array(License.APACHE2))

--- a/renaissance-core/src/main/java/org/renaissance/core/BenchmarkDescriptor.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/BenchmarkDescriptor.java
@@ -173,8 +173,8 @@ public final class BenchmarkDescriptor {
       return BenchmarkDescriptor.this.name();
     }
 
-    String benchmarkModule() {
-      return BenchmarkDescriptor.this.module();
+    String benchmarkPrimaryGroup() {
+      return BenchmarkDescriptor.this.primaryGroup();
     }
 
     private String visibleName(String name) {

--- a/renaissance-core/src/main/java/org/renaissance/core/BenchmarkSuite.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/BenchmarkSuite.java
@@ -167,8 +167,8 @@ public final class BenchmarkSuite {
       return configuration.benchmarkName();
     }
 
-    public String benchmarkModule() {
-      return configuration.benchmarkModule();
+    public String benchmarkPrimaryGroup() {
+      return configuration.benchmarkPrimaryGroup();
     }
 
     /**

--- a/renaissance-harness/src/main/java/org/renaissance/harness/ExecutionDriver.java
+++ b/renaissance-harness/src/main/java/org/renaissance/harness/ExecutionDriver.java
@@ -57,14 +57,20 @@ final class ExecutionDriver {
     this.vmStartNanos = vmStartNanos;
 
     this.benchmarkName = context.benchmarkName();
+
+    // Pre-format the before/after messages (escaping the format specifier
+    // for the operation index which keeps changing) so that we don't have
+    // to query the static information over and over.
     this.beforeEachMessageFormat = String.format(
       "====== %s (%s) [%s], iteration %%d started ======\n",
-      context.benchmarkName(), context.benchmarkModule(), context.configurationName()
+      context.benchmarkName(), context.benchmarkPrimaryGroup(),
+      context.configurationName()
     );
 
     this.afterEachMessageFormat = String.format(
       "====== %s (%s) [%s], iteration %%d completed (%%.3f ms) ======\n",
-      context.benchmarkName(), context.benchmarkModule(), context.configurationName()
+      context.benchmarkName(), context.benchmarkPrimaryGroup(),
+      context.configurationName()
     );
   }
 


### PR DESCRIPTION
For now, we retain the original groups that mostly correspond to benchmark modules, so that we don't break scripts that might have been using them. We also display the primary group in benchmark output (instead of benchmark module), which I believe we always intended, but there was no need to differentiate between benchmark module and benchmark group back then.