### PR TITLE
Enable GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,10 +48,10 @@ jobs:
           - openjdk9
           - openjdk10
           - openjdk11
-          - openjdk12
+          #- openjdk12
           - openj9-openjdk8
           - openj9-openjdk11
-          - openj9-openjdk16
+          #- openj9-openjdk16
     runs-on: ubuntu-latest
     container: "renaissancebench/buildenv:${{ matrix.image }}"
     continue-on-error: true
@@ -100,7 +100,9 @@ jobs:
     strategy:
       matrix:
         java: [ '8', '11' ] #, '13', '15' ]
-        os: [ windows-latest, macos-latest ]
+        os:
+          #- windows-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
           path: |
             ~/.ivy2/cache
             ~/.sbt
+            ~/.cache/coursier
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
       - name: Check file encoding"
         shell: bash
@@ -66,6 +67,7 @@ jobs:
           path: |
             ~/.ivy2/cache
             ~/.sbt
+            ~/.cache/coursier
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
 
       - name: Environment configuration

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,147 @@
+name: build
+on: [push, pull_request]
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    container: "renaissancebench/buildenv:openjdk8"
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Cache SBT
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+      - name: Check file encoding"
+        shell: bash
+        run: tools/ci/check-encoding.sh
+
+      - name: "Start SBT"
+        shell: bash
+        run: tools/ci/check-sbt.sh
+
+      - name: "Check source code formatting"
+        shell: bash
+        run: tools/ci/check-formatting.sh
+
+      - name: "Build default JAR"
+        shell: bash
+        run: tools/ci/build-base.sh
+
+      - name: "Stop SBT"
+        shell: bash
+        run: tools/ci/stop-sbt.sh
+
+      - name: "Check generated files are up-to-date"
+        shell: bash
+        run: tools/ci/check-markdown.sh
+
+  linux:
+    strategy:
+      matrix:
+        image:
+          - openjdk8
+          - openjdk9
+          - openjdk10
+          - openjdk11
+          - openjdk12
+          - openj9-openjdk8
+          - openj9-openjdk11
+          - openj9-openjdk16
+    runs-on: ubuntu-latest
+    container: "renaissancebench/buildenv:${{ matrix.image }}"
+    continue-on-error: true
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Cache SBT
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+
+      - name: Environment configuration
+        shell: bash
+        run: "tools/ci/pre-show-env.sh"
+
+      - name: Build base
+        shell: bash
+        run: "tools/ci/build-base.sh"
+
+      - name: Build JMH
+        shell: bash
+        run: "tools/ci/build-jmh.sh"
+
+      - name: Stop SBT
+        shell: bash
+        run: "tools/ci/stop-sbt.sh"
+
+      - name: Check JMH
+        shell: bash
+        run: "tools/ci/check-jmh.sh"
+
+      - name: Run the suite
+        shell: bash
+        run: "tools/ci/bench-base.sh"
+
+      - name: Run the suite with JMH
+        shell: bash
+        run: "tools/ci/bench-jmh.sh"
+
+  other:
+    strategy:
+      matrix:
+        java: [ '8', '11' ] #, '13', '15' ]
+        os: [ windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup correct Java version
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: ${{ matrix.java }}
+
+      - name: Environment configuration
+        shell: bash
+        run: "tools/ci/pre-show-env.sh"
+
+      - name: Build base
+        shell: bash
+        run: "tools/ci/build-base.sh"
+
+      - name: Build JMH
+        shell: bash
+        run: "tools/ci/build-jmh.sh"
+
+      - name: Stop SBT
+        shell: bash
+        run: "tools/ci/stop-sbt.sh"
+
+      - name: Check JMH
+        shell: bash
+        run: "tools/ci/check-jmh.sh"
+
+      - name: Dummy run and environment configuration
+        shell: bash
+        run: "tools/ci/bench-show-env.sh"
+
+      - name: Run the suite
+        shell: bash
+        run: "tools/ci/bench-base.sh"
+
+      - name: Run the suite with JMH
+        shell: bash
+        run: "tools/ci/bench-jmh.sh"

--- a/tools/ci/bench-show-env.sh
+++ b/tools/ci/bench-show-env.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -uoe pipefail
+
+source "$(dirname "$0")/common.sh"
+
+set -x
+
+java -Xms1g -Xmx1g -jar "$RENAISSANCE_JAR" -c test -r 1 --json /dev/stdout dummy-empty

--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -10,13 +10,13 @@ set -o errexit
 # set -o xtrace
 
 # Project root directory
-ROOT_DIR="$(git rev-parse --show-toplevel)"
+ROOT_DIR="$(git rev-parse --show-toplevel || realpath "$( dirname "$0" )/../../" )"
 
 # Cache directory for files we explicitly produce
 CACHE_DIR="$HOME/.prebuilt"
 
 # Raw version as produced by git
-RENAISSANCE_GIT_VERSION=$(git describe --dirty=-SNAPSHOT)
+RENAISSANCE_GIT_VERSION=$(git describe --tags --always --dirty=-SNAPSHOT || echo "ci-SNAPSHOT" )
 
 # Strip leading 'v' from the git-produced version
 RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}

--- a/tools/ci/pre-show-env.sh
+++ b/tools/ci/pre-show-env.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -uoe pipefail
+
+set -x
+
+java -version
+javac -version
+git --version || echo "Git not installed." >&2
+
+cat /etc/os-release || echo "/etc/os-release not found" >&2
+uname -a
+locale
+
+source "$(dirname "$0")/common.sh"
+echo
+echo "RENAISSANCE_GIT_VERSION='$RENAISSANCE_GIT_VERSION'"
+echo "RENAISSANCE_JAR_NAME='$RENAISSANCE_JAR_NAME'"
+echo "RENAISSANCE_JMH_JAR_NAME='$RENAISSANCE_JMH_JAR_NAME'"
+echo


### PR DESCRIPTION
This PR enables use of GitHub Actions for CI. (Cleaned-up version of the `issue/243` branch. Travis CI will be removed as part of another PR.)

Current status:

* Checks (encoding, formatting) ... ok.
* Linux builds (and runs): JDK 8, 9, 10, 11, Openj9 on JDK 8 and 11 ... ok (ignoring spurious failures of the build servers).
* Linux builds (and runs): JDK 12+ .. failing.
* MacOS builds (and runs): JDK 8 and 11 ... ok.
* Windows builds (and runs): failing (see #265).

This is a base version, we can later switch to a more complex workflow.

GHA also allows for artifacts but the pricing is not clear to me at the moment (i.e., no artifacts are stored at this moment).

To decide before merge:

 * Remove the JDK12+ builds at the moment (they fail because of db-shootout)? I hope I will fix the Windows builds soon so these I would like to keep.
