### PR TITLE
Attempted fix for #272 (broken Windows builds)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.util.Properties
 import scala.collection._
+import scala.jdk.CollectionConverters.asScalaIteratorConverter
 
 enablePlugins(GitBranchPrompt)
 
@@ -91,7 +92,10 @@ def defineModulesPropertiesGeneratorTask =
     defineCompoundProjectJarsCollectorTask(renaissanceModules).value.foreach { module =>
       val (moduleName, modulePath, moduleJars) = module
       val jarLine = moduleJars
-        .map(jar => modulePath.resolve(jar.getName).toString().replace("\\", "/"))
+        .map {
+          // The path to a module JAR needs to use Unix-like paths (even on Windows).
+          jar => modulePath.resolve(jar.getName).iterator().asScala.mkString("/")
+        }
         .mkString(",")
       modulesProps.setProperty(moduleName, jarLine)
     }

--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,9 @@ def defineModulesPropertiesGeneratorTask =
     val modulesProps = new Properties
     defineCompoundProjectJarsCollectorTask(renaissanceModules).value.foreach { module =>
       val (moduleName, modulePath, moduleJars) = module
-      val jarLine = moduleJars.map(jar => modulePath.resolve(jar.getName)).mkString(",")
+      val jarLine = moduleJars
+        .map(jar => modulePath.resolve(jar.getName).toString().replace("\\", "/"))
+        .mkString(",")
       modulesProps.setProperty(moduleName, jarLine)
     }
 

--- a/renaissance-core/src/main/java/org/renaissance/core/ModuleLoader.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/ModuleLoader.java
@@ -45,13 +45,15 @@ public final class ModuleLoader {
    * Map of module names to sets of JAR files representing the class path of
    * each module. There may be multiple benchmark classes in one module, but
    * each will be instantiated using a separate class loader.
+   *
+   * The resource paths use a Unix-style component separator.
    */
-  private final Map<String, Set<String>> jarPathsByModule;
+  private final Map<String, Set<String>> jarResourcePathsByModule;
 
 
   ModuleLoader(Path scratchRootDir, Map<String, Set<String>> jarPathsByModule) {
     this.scratchRootDir = scratchRootDir;
-    this.jarPathsByModule = jarPathsByModule;
+    this.jarResourcePathsByModule = jarPathsByModule;
   }
 
 
@@ -150,13 +152,13 @@ public final class ModuleLoader {
     // avoid repeatedly extracting the JAR files for the same module.
     //
     try {
-      Set<String> jarPaths = jarPathsByModule.get(name);
-      if (jarPaths == null) {
+      Set<String> jarResourcePaths = jarResourcePathsByModule.get(name);
+      if (jarResourcePaths == null) {
         throw new ModuleLoadingException("module not found");
       }
 
       Path moduleJarsDir = createModuleJarsDirectory(name);
-      List<Path> filePaths = extractResources(jarPaths, moduleJarsDir);
+      List<Path> filePaths = extractResources(jarResourcePaths, moduleJarsDir);
       final URL[] urls = pathsToUrls(filePaths);
 
       // Make sure that all paths were converted to URL.
@@ -244,6 +246,7 @@ public final class ModuleLoader {
   }
 
 
+  /** Returns the last component of a resource path (base name). */
   private static String resourceFileName(String resourcePath) {
     final int nameStart = resourcePath.lastIndexOf(RESOURCE_PATH_SEPARATOR);
     return nameStart >= 0 ? resourcePath.substring(nameStart + 1) : resourcePath;


### PR DESCRIPTION
The family of `getResource` functions requires [Unix-style paths](https://docs.oracle.com/javase/8/docs/api/java/lang/ClassLoader.html#getResource-java.lang.String-).

The filenames are sane here so this trivial fix should work but perhaps @lbulej could confirm that it will not break something else. Thanks!