### PR TITLE
GitHub Actions: run on Windows too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,14 +98,11 @@ jobs:
         shell: bash
         run: "tools/ci/bench-jmh.sh"
 
-  other:
+  macos:
     strategy:
       matrix:
         java: [ '8', '11' ] #, '13', '15' ]
-        os:
-          #- windows-latest
-          - macos-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     continue-on-error: true
     steps:
       - name: Git checkout
@@ -133,6 +130,51 @@ jobs:
       - name: Stop SBT
         shell: bash
         run: "tools/ci/stop-sbt.sh"
+
+      - name: Check JMH
+        shell: bash
+        run: "tools/ci/check-jmh.sh"
+
+      - name: Dummy run and environment configuration
+        shell: bash
+        run: "tools/ci/bench-show-env.sh"
+
+      - name: Run the suite
+        shell: bash
+        run: "tools/ci/bench-base.sh"
+
+      - name: Run the suite with JMH
+        shell: bash
+        run: "tools/ci/bench-jmh.sh"
+
+  windows:
+    strategy:
+      matrix:
+        java: [ '8', '11' ] #, '13', '15' ]
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup correct Java version
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: ${{ matrix.java }}
+
+      - name: Environment configuration
+        shell: bash
+        run: "tools/ci/pre-show-env.sh"
+
+      - name: Build base
+        shell: bash
+        run: java -jar tools/sbt/bin/sbt-launch.jar assembly
+
+      - name: Build JMH
+        shell: bash
+        run: java -jar tools/sbt/bin/sbt-launch.jar renaissanceJmh/jmh:assembly
 
       - name: Check JMH
         shell: bash


### PR DESCRIPTION
It is not perfect as the helper shell scripts are not used -- as on Linux and MacOS -- but they fail without any hint why (it seems to me that it is related to the SBT server/client feature but that is only a guess).

It would be nice to have it more Windows-only -- i.e. use `.bat` instead of Bash scripts --  but that can be changed later. I would like to have it in `master` ASAP to catch issues on Windows earlier. At the moment, it compiles and runs on Windows without any issues (up to JDK 11).
