### PR TITLE
Temporarily limit supported JVM in 'dbshootout' to version 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ requirements) for all the benchmarks:
 | akka-uct | MIT | MIT | 1.8 |  |
 | als | APACHE2 | MIT | 1.8 |  |
 | chi-square | APACHE2 | MIT | 1.8 |  |
-| db-shootout | APACHE2 | MIT | 1.8 |  |
+| db-shootout | APACHE2 | MIT | 1.8 | 11 |
 | dec-tree | APACHE2 | MIT | 1.8 |  |
 | dotty | BSD3 | MIT | 1.8 |  |
 | finagle-chirper | APACHE2 | MIT | 1.8 |  |

--- a/benchmarks/database/src/main/scala/org/renaissance/database/DbShootout.scala
+++ b/benchmarks/database/src/main/scala/org/renaissance/database/DbShootout.scala
@@ -14,6 +14,7 @@ import org.renaissance.License
 @Group("database")
 @Summary("Executes a shootout test using several in-memory databases.")
 @Licenses(Array(License.APACHE2))
+@SupportsJvm("11")
 @Repetitions(16)
 @Parameter(name = "rw_entry_count", defaultValue = "500000")
 @Configuration(name = "test", settings = Array("rw_entry_count = 10000"))


### PR DESCRIPTION
This is to avoid out-of-the-box crashes on JVM 12 before we can resolve issue #163.