### PR TITLE
Bump Scala 2.12 version to 2.12.14

### DIFF
--- a/benchmarks/actors-reactors/build.sbt
+++ b/benchmarks/actors-reactors/build.sbt
@@ -8,7 +8,7 @@ lazy val actorsReactors = (project in file("."))
     name := "actors-reactors",
     version := (renaissanceCore / version).value,
     organization := (renaissanceCore / organization).value,
-    scalaVersion := "2.12.13"
+    scalaVersion := "2.12.14"
   )
   .dependsOn(
     renaissanceCore % "provided",

--- a/benchmarks/apache-spark/build.sbt
+++ b/benchmarks/apache-spark/build.sbt
@@ -7,7 +7,7 @@ lazy val apacheSpark = (project in file("."))
     name := "apache-spark",
     version := (renaissanceCore / version).value,
     organization := (renaissanceCore / organization).value,
-    scalaVersion := "2.12.13",
+    scalaVersion := "2.12.14",
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-core" % sparkVersion,
       "org.apache.spark" %% "spark-sql" % sparkVersion,

--- a/benchmarks/neo4j/build.sbt
+++ b/benchmarks/neo4j/build.sbt
@@ -5,7 +5,7 @@ lazy val neo4j = (project in file("."))
     name := "neo4j",
     version := (renaissanceCore / version).value,
     organization := (renaissanceCore / organization).value,
-    scalaVersion := "2.12.13",
+    scalaVersion := "2.12.14",
     scalacOptions += "-target:jvm-1.8",
     libraryDependencies ++= Seq(
       // neo4j 4.2 does not support 2.13

--- a/benchmarks/scala-stm/build.sbt
+++ b/benchmarks/scala-stm/build.sbt
@@ -7,7 +7,7 @@ lazy val scalaStm = (project in file("."))
     name := "scala-stm",
     version := (renaissanceCore / version).value,
     organization := (renaissanceCore / organization).value,
-    scalaVersion := "2.12.13"
+    scalaVersion := "2.12.14"
   )
   .dependsOn(
     renaissanceCore % "provided",

--- a/benchmarks/scala-stm/scala-stm-library/build.sbt
+++ b/benchmarks/scala-stm/scala-stm-library/build.sbt
@@ -5,7 +5,7 @@ organization := "org.scala-stm"
 
 version := "0.8-SNAPSHOT"
 
-scalaVersion := "2.12.13"
+scalaVersion := "2.12.14"
 
 crossScalaVersions := Seq("2.11.11", "2.12.3", "2.13.0-M2")
 

--- a/benchmarks/scala-stm/scala-stm-library/dep_tests/sbt/build.sbt
+++ b/benchmarks/scala-stm/scala-stm-library/dep_tests/sbt/build.sbt
@@ -5,7 +5,7 @@ organization := "org.scala-stm"
 
 version := "0.1-SNAPSHOT"
 
-scalaVersion := "2.12.0"
+scalaVersion := "2.12.14"
 
 crossScalaVersions := Seq("2.12.0", "2.11.6")
 

--- a/benchmarks/twitter-finagle/build.sbt
+++ b/benchmarks/twitter-finagle/build.sbt
@@ -5,7 +5,7 @@ lazy val twitterFinagle = (project in file("."))
     name := "twitter-finagle",
     version := (renaissanceCore / version).value,
     organization := (renaissanceCore / organization).value,
-    scalaVersion := "2.12.13",
+    scalaVersion := "2.12.14",
     libraryDependencies := Seq(
       "com.twitter" %% "finagle-http" % "19.4.0",
       "com.twitter" %% "finagle-stats" % "19.4.0",


### PR DESCRIPTION
Scala 2.12.14 was released at the end of May and I think we can afford to be up-to-date here.