### PR TITLE
Set benchmark-specific thread limits for the Spark local executor

### DIFF
--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
@@ -24,7 +24,7 @@ import scala.util.Random
 @Repetitions(30)
 @Parameter(
   name = "spark_thread_limit",
-  defaultValue = "4",
+  defaultValue = "12",
   summary = "Maximum number of threads for the Spark local executor."
 )
 @Parameter(

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/AlsMl.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/AlsMl.scala
@@ -23,7 +23,7 @@ import scala.util.Random
 @Repetitions(30)
 @Parameter(
   name = "spark_thread_limit",
-  defaultValue = "4",
+  defaultValue = "12",
   summary = "Maximum number of threads for the Spark local executor."
 )
 @Parameter(

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ChiSquare.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ChiSquare.scala
@@ -24,7 +24,7 @@ import scala.util.Random
 @Repetitions(60)
 @Parameter(
   name = "spark_thread_limit",
-  defaultValue = "$cpu.count",
+  defaultValue = "4",
   summary = "Maximum number of threads for the Spark local executor."
 )
 @Parameter(

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/DecTree.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/DecTree.scala
@@ -25,7 +25,7 @@ import java.nio.file.Path
 @Repetitions(40)
 @Parameter(
   name = "spark_thread_limit",
-  defaultValue = "$cpu.count",
+  defaultValue = "6",
   summary = "Maximum number of threads for the Spark local executor."
 )
 @Parameter(

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/GaussMix.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/GaussMix.scala
@@ -23,7 +23,7 @@ import scala.util.Random
 @Repetitions(40)
 @Parameter(
   name = "spark_thread_limit",
-  defaultValue = "$cpu.count",
+  defaultValue = "4",
   summary = "Maximum number of threads for the Spark local executor."
 )
 @Parameter(

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
@@ -21,7 +21,7 @@ import java.nio.file.Path
 @Repetitions(20)
 @Parameter(
   name = "spark_thread_limit",
-  defaultValue = "$cpu.count",
+  defaultValue = "12",
   summary = "Maximum number of threads for the Spark local executor."
 )
 @Parameter(

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/MovieLens.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/MovieLens.scala
@@ -26,7 +26,7 @@ import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
 @Repetitions(20)
 @Parameter(
   name = "spark_thread_limit",
-  defaultValue = "4",
+  defaultValue = "8",
   summary = "Maximum number of threads for the Spark local executor."
 )
 @Parameter(name = "input_file", defaultValue = "/ratings.csv")

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
@@ -23,7 +23,7 @@ import scala.io.BufferedSource
 @Repetitions(20)
 @Parameter(
   name = "spark_thread_limit",
-  defaultValue = "$cpu.count",
+  defaultValue = "12",
   summary = "Maximum number of threads for the Spark local executor."
 )
 @Parameter(


### PR DESCRIPTION
The limits reflect the recommendations from #260, with the limits for `gauss-mix`, `chi-square` and `dec-tree` bumped up by 2 threads (providing a bit of slack that does not help but should not hurt), resulting in the following defaults for the `spark_thread_limit` parameter:

- 4 in `chi-square` and `gauss-mix`
- 6 in `dec-tree`
- 8 in `movie-lens`
- 12 in `als`, `als-ml`, `log-regression` and `page-rank`
- unlimited in `naive-bayes`
