### PR TITLE
Print a message if the benchmark operation fails

### DIFF
--- a/renaissance-core/src/main/java/org/renaissance/BenchmarkResult.java
+++ b/renaissance-core/src/main/java/org/renaissance/BenchmarkResult.java
@@ -40,8 +40,10 @@ public interface BenchmarkResult {
       return () -> {
         Arrays.fill(objects, null);
 
-        System.err.println("WARNING: This benchmark provides no result that can be validated.");
-        System.err.println("         There is no way to check that no silent failure occurred.");
+        System.err.print(
+          "WARNING: This benchmark provides no result that can be validated.\n"+
+          "There is no way to check that no silent failure occurred.\n"
+        );
       };
     }
 


### PR DESCRIPTION
This gives us a chance to at least print the name of the failure exception, because the exception can be lost if any of the tear-down methods in the *finally* blocks throws an exception.

This can actually occur in some of the Spark benchmarks because they try to dump the result of the last operation but do not expect the very first operation to fail. This assumption has been proven wrong #283 and losing the original exception makes things a bit more confusing. A fix for that is in #288.

An alternative would be to complicate the exception handling to make sure the original exception does not get lost even though the benchmark is already doomed at that point.