### PR TITLE
Report compressed OOPs mode

### DIFF
--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -207,6 +207,7 @@ private final class JsonWriter(val jsonFile: Path) extends ResultWriter {
       "spec_vendor" -> runtime.getSpecVendor.toJson,
       "spec_version" -> runtime.getSpecVersion.toJson,
       "mode" -> systemPropertyAsJson("java.vm.info"),
+      "compressed_oops_mode" -> systemPropertyAsJson("java.vm.compressedOopsMode"),
       "args" -> runtime.getInputArguments.asScala.toList.toJson,
       "termination" -> (if (normalTermination) "normal" else "forced").toJson,
       "start_unix_ms" -> runtime.getStartTime.toJson,
@@ -375,8 +376,7 @@ private final class JsonWriter(val jsonFile: Path) extends ResultWriter {
       // For each repetition, collect (name -> value) tuples for metrics into a map.
       val repetitions = (0 until repetitionCount).map(i =>
         metricNames
-          .map(name => metricsByName.get(name).map(values => (name -> values(i).toJson)))
-          .flatten
+          .flatMap(name => metricsByName.get(name).map(values => name -> values(i).toJson))
           .toMap
       )
 


### PR DESCRIPTION
There is a `java.vm.compressedOopsMode` system property on newer JVMs (found it on OpenJDK 11, but not on OpenJDK 8) which provides information about the compressed OOPs mode (either `Zero based` or `Non-zero disjoint base`) **if** used by the JVM. This is a useful bit of information to store in the benchmark result.

On older JVMs (JDK8), the property is unset even though the JVM uses compressed OOPs. There does not seem to be a reasonable way  (e.g., an MXBean) to find out *if and what mode the JVM uses*, so we just have to assume that it is used for heaps <= 32G (unless disabled using the `-XX:-UseCompressedOops` option).

On newer JVMs that support the property, e.g., JDK11, the property will be unset when the JVM does not use compressed OOPs. This was tested using the `-XX:-UseCompressedOops` option.

Either way, if the system property is unset, the `compressed_oops_mode` object in the `vm` part of the JSON output will be `null`.

I did not bump the JSON output version number, because the extra key does not really change the structure of the JSON output and it should not really affect scripts that expect output version 5.