### PR TITLE
Add a missing null check and make dumping of Spark benchmark results optional (and disabled by default)

### DIFF
--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
@@ -126,8 +126,10 @@ final class Als extends Benchmark with SparkUtil {
   }
 
   override def tearDownAfterAll(bc: BenchmarkContext): Unit = {
-    val outputPath = bc.scratchDirectory().resolve("output")
-    dumpResult(outputMatrixFactorization, outputPath)
+    if (dumpResultsBeforeTearDown && outputMatrixFactorization != null) {
+      val outputPath = bc.scratchDirectory().resolve("output")
+      dumpResult(outputMatrixFactorization, outputPath)
+    }
 
     tearDownSparkContext()
   }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/AlsMl.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/AlsMl.scala
@@ -123,8 +123,8 @@ final class AlsMl extends Benchmark with SparkUtil {
   }
 
   override def tearDownAfterAll(bc: BenchmarkContext): Unit = {
-    val outputPath = bc.scratchDirectory().resolve("output")
-    if (outputAlsModel != null) {
+    if (dumpResultsBeforeTearDown && outputAlsModel != null) {
+      val outputPath = bc.scratchDirectory().resolve("output")
       dumpResult(outputAlsModel, outputPath)
     }
 

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ChiSquare.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ChiSquare.scala
@@ -103,8 +103,10 @@ final class ChiSquare extends Benchmark with SparkUtil {
   }
 
   override def tearDownAfterAll(bc: BenchmarkContext): Unit = {
-    val outputFile = bc.scratchDirectory().resolve("output.txt")
-    dumpResult(outputTestResults, outputFile)
+    if (dumpResultsBeforeTearDown && outputTestResults != null) {
+      val outputFile = bc.scratchDirectory().resolve("output.txt")
+      dumpResult(outputTestResults, outputFile)
+    }
 
     tearDownSparkContext()
   }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/DecTree.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/DecTree.scala
@@ -113,8 +113,10 @@ final class DecTree extends Benchmark with SparkUtil {
   }
 
   override def tearDownAfterAll(bc: BenchmarkContext): Unit = {
-    val outputFile = bc.scratchDirectory().resolve("output.txt")
-    dumpResult(outputClassificationModel, outputFile)
+    if (dumpResultsBeforeTearDown && outputClassificationModel != null) {
+      val outputFile = bc.scratchDirectory().resolve("output.txt")
+      dumpResult(outputClassificationModel, outputFile)
+    }
 
     tearDownSparkContext()
   }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/GaussMix.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/GaussMix.scala
@@ -113,8 +113,10 @@ final class GaussMix extends Benchmark with SparkUtil {
   }
 
   override def tearDownAfterAll(bc: BenchmarkContext) = {
-    val outputFile = bc.scratchDirectory().resolve("output.txt")
-    dumpResult(outputGaussianMixture, outputFile)
+    if (dumpResultsBeforeTearDown && outputGaussianMixture != null) {
+      val outputFile = bc.scratchDirectory().resolve("output.txt")
+      dumpResult(outputGaussianMixture, outputFile)
+    }
 
     tearDownSparkContext()
   }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
@@ -99,8 +99,10 @@ final class LogRegression extends Benchmark with SparkUtil {
   }
 
   override def tearDownAfterAll(bc: BenchmarkContext): Unit = {
-    val outputFile = bc.scratchDirectory().resolve("output.txt")
-    dumpResult(outputLogisticRegression, outputFile)
+    if (dumpResultsBeforeTearDown && outputLogisticRegression != null) {
+      val outputFile = bc.scratchDirectory().resolve("output.txt")
+      dumpResult(outputLogisticRegression, outputFile)
+    }
 
     tearDownSparkContext()
   }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/NaiveBayes.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/NaiveBayes.scala
@@ -79,8 +79,10 @@ final class NaiveBayes extends Benchmark with SparkUtil {
   }
 
   override def tearDownAfterAll(bc: BenchmarkContext): Unit = {
-    val outputFile = bc.scratchDirectory().resolve("output.txt")
-    dumpResult(outputNaiveBayes, outputFile)
+    if (dumpResultsBeforeTearDown && outputNaiveBayes != null) {
+      val outputFile = bc.scratchDirectory().resolve("output.txt")
+      dumpResult(outputNaiveBayes, outputFile)
+    }
 
     tearDownSparkContext()
   }

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
@@ -69,6 +69,8 @@ trait SparkUtil {
     "org.apache.spark.sql.internal.SharedState" -> Level.ERROR
   )
 
+  protected val dumpResultsBeforeTearDown = false
+
   protected var sparkSession: SparkSession = _
   protected def sparkContext: SparkContext = sparkSession.sparkContext
 


### PR DESCRIPTION
Most (but not all) Spark benchmarks dump the result of the last benchmark operation to disk during benchmark tear-down. This is primarily useful for development, but it's not necessarily something we should do all the time (or by default).

In addition, the current implementation throws a `NullPointerException` in the tear-down phase if the benchmark fails during the first operation (because the operation result will be uninitialized), which ends up masking the exception thrown from the failed benchmark operation.