### PR TITLE
CI: test on more JDKs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           - openjdk9
           - openjdk10
           - openjdk11
-          #- openjdk12
+          - openjdk12
           - openj9-openjdk8
           - openj9-openjdk11
           #- openj9-openjdk16

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
           - openjdk12
           - openjdk13
           - openjdk14
+          - openjdk15
           - openj9-openjdk8
           - openj9-openjdk11
           #- openj9-openjdk16

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           - openjdk16
           - openj9-openjdk8
           - openj9-openjdk11
-          #- openj9-openjdk16
+          - openj9-openjdk16
     runs-on: ubuntu-latest
     container: "renaissancebench/buildenv:${{ matrix.image }}"
     continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
           - openjdk10
           - openjdk11
           - openjdk12
+          - openjdk13
           - openj9-openjdk8
           - openj9-openjdk11
           #- openj9-openjdk16

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
   windows:
     strategy:
       matrix:
-        java: [ '8', '11' ] #, '13', '15' ]
+        java: [ '8', '11' , '13', '15' ]
     runs-on: windows-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
   macos:
     strategy:
       matrix:
-        java: [ '8', '11' ] #, '13', '15' ]
+        java: [ '8', '11', '13', '15' ]
     runs-on: macos-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
           - openjdk13
           - openjdk14
           - openjdk15
+          - openjdk16
           - openj9-openjdk8
           - openj9-openjdk11
           #- openj9-openjdk16

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
           - openjdk11
           - openjdk12
           - openjdk13
+          - openjdk14
           - openj9-openjdk8
           - openj9-openjdk11
           #- openj9-openjdk16

--- a/tools/ci/bench-jmh.sh
+++ b/tools/ci/bench-jmh.sh
@@ -6,6 +6,7 @@ source "$(dirname "$0")/common.sh"
 
 java -jar "$RENAISSANCE_JMH_JAR" \
 	-jvmArgs -Xms2500M -jvmArgs -Xmx2500m \
+	$( for arg in $( get_jvm_workaround_args ); do echo "-jvmArgs" "$arg"; done ) \
 	-jvmArgs -Dorg.renaissance.jmh.configuration=test \
 	-jvmArgs -Dorg.renaissance.jmh.fakeIncompatible=true \
 	-wi 0 -i 1 -f 1 -foe true

--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -21,6 +21,12 @@ RENAISSANCE_GIT_VERSION=$(git describe --tags --always --dirty=-SNAPSHOT || echo
 # Strip leading 'v' from the git-produced version
 RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}
 
+# Try to guess JVM version
+RENAISSANCE_JVM_MAJOR_VERSION="$( java -XshowSettings:properties -version 2>&1 \
+    | sed -n -e 's#^[ \t]*java.version[ ]*=[ ]\(.*\)#\1#p' \
+    | sed -e 's#1\.8#8#' -e 's#\([^.]*\).*#\1#' \
+    || echo 8 )"
+
 # The base bundle
 RENAISSANCE_DIR="target"
 RENAISSANCE_JAR_NAME="renaissance-gpl-${RENAISSANCE_VERSION}.jar"
@@ -41,6 +47,15 @@ ci_sbt() {
 cp_reflink() {
 	[ "$OSTYPE" = "linux-gnu" ] && local REFLINK="--reflink=auto"
 	cp $REFLINK "$@"
+}
+
+get_jvm_workaround_args() {
+    if [ "$RENAISSANCE_JVM_MAJOR_VERSION" = "16" ]; then
+        echo "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+        echo "--add-opens=java.base/java.util=ALL-UNNAMED"
+        echo "--add-opens=java.base/java.nio=ALL-UNNAMED"
+        echo "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+    fi
 }
 
 

--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -21,10 +21,9 @@ RENAISSANCE_GIT_VERSION=$(git describe --tags --always --dirty=-SNAPSHOT || echo
 # Strip leading 'v' from the git-produced version
 RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}
 
-# Try to guess JVM version
-RENAISSANCE_JVM_MAJOR_VERSION="$( java -XshowSettings:properties -version 2>&1 \
-    | sed -n -e 's#^[ \t]*java.version[ ]*=[ ]\(.*\)#\1#p' \
-    | sed -e 's#1\.8#8#' -e 's#\([^.]*\).*#\1#' \
+# Try to guess JVM version (and replace 1.8 with 8)
+RENAISSANCE_JVM_MAJOR_VERSION="$( java -version 2>&1 \
+    | sed -n -e '/version[[:blank:]]\+"/ { s/.*version[[:blank:]]\+"\([^"]*\)".*/\1/; s/1[.]8/8/; s/^\([^.]*\)[.].*/\1/; p }' \
     || echo 8 )"
 
 # The base bundle


### PR DESCRIPTION
Added more environments to be tested on GitHub Actions CI.

It now runs on

 * Linux: all JDKs from 8 to 16
 * Linux with OpenJ9: 8, 11, 16
 * MacOS: 8, 11, 13, 15
 * Windows: 8, 11, 13, 15

Also added `--add-opens` to JMH runs for JDK 16 (see #241).
