### PR TITLE
Specify plugin class inside plugin JAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Usage: renaissance [options] [benchmark-specification]
                            Execute the measured operation for fixed accumulated operation time (wall-clock).
   --policy <class-path>!<class-name>
                            Use policy plugin to control repetition of measured operation execution.
-  --plugin <class-path>!<class-name>
+  --plugin <class-path>[!<class-name>]
                            Load external plugin. Can appear multiple times.
   --with-arg <value>       Adds an argument to the plugin or policy specified last. Can appear multiple times.
   --csv <csv-file>         Output results as CSV to <csv-file>.
@@ -258,8 +258,10 @@ operation, and will pass the result of the `isLast` method to some other events.
 
 To make the harness use an external plugin, it needs to be specified on the command line.
 The harness can load multiple plugins, and each must be enabled using the
-`--plugin <class-path>!<class-name>` option. The `<class-path>` is the class path on which
-to look for the plugin class, and `<class-name>` is a fully qualified name of the plugin class.
+`--plugin <class-path>[!<class-name>]` option. The `<class-path>` is the class path on which
+to look for the plugin class, and `<class-name>` is a fully qualified name of the plugin class
+(the class-name can be omitted when specified as a `Renaissance-Plugin` property inside
+`META-INF/MANIFEST.MF` of the plugin JAR).
 Custom execution policy must be enabled using the `--policy <class-path>!<class-name>` option.
 The syntax is the same as in case of normal plugins (and the policy is also a plugin, which
 can register for all event types), but this option tells the harness to actually use the

--- a/plugins/jmx-timers/build.sbt
+++ b/plugins/jmx-timers/build.sbt
@@ -13,6 +13,11 @@ lazy val pluginJMXTimers = (project in file("."))
       case PathList("org", "renaissance", _*) => MergeStrategy.discard
       case _ => MergeStrategy.singleOrError
     },
+    packageOptions := Seq(
+      sbt.Package.ManifestAttributes(
+        ("Renaissance-Plugin", "org.renaissance.plugins.jmxtimers.Main")
+      )
+    ),
   )
   .dependsOn(
     renaissanceCore

--- a/plugins/ubench-agent/build.sbt
+++ b/plugins/ubench-agent/build.sbt
@@ -13,6 +13,11 @@ lazy val pluginUbenchAgent = (project in file("."))
       case PathList("org", "renaissance", _*) => MergeStrategy.discard
       case _ => MergeStrategy.singleOrError
     },
+    packageOptions := Seq(
+      sbt.Package.ManifestAttributes(
+        ("Renaissance-Plugin", "org.renaissance.plugins.ubenchagent.Main")
+      )
+    ),
   )
   .dependsOn(
     renaissanceCore

--- a/renaissance-core/src/main/java/org/renaissance/core/BenchmarkSuite.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/BenchmarkSuite.java
@@ -205,10 +205,10 @@ public final class BenchmarkSuite {
   }
 
   /** Loads and instantiates an extension specified in properties with given arguments. */
-  public <T> T createAutoExtension(
+  public <T> T createDescribedExtension(
     List<Path> classPath, String propertyName, Class<T> baseClass, String[] args
   ) throws ModuleLoadingException {
-    final Class<? extends T> extClass = ModuleLoader.loadAutoExtension(
+    final Class<? extends T> extClass = ModuleLoader.loadDescribedExtension(
       classPath, propertyName, baseClass
     );
 

--- a/renaissance-core/src/main/java/org/renaissance/core/BenchmarkSuite.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/BenchmarkSuite.java
@@ -204,6 +204,18 @@ public final class BenchmarkSuite {
     return ModuleLoader.createExtension(extClass, args);
   }
 
+  /** Loads and instantiates an extension specified in properties with given arguments. */
+  public <T> T createAutoExtension(
+    List<Path> classPath, String propertyName, Class<T> baseClass, String[] args
+  ) throws ModuleLoadingException {
+    final Class<? extends T> extClass = ModuleLoader.loadAutoExtension(
+      classPath, propertyName, baseClass
+    );
+
+    return ModuleLoader.createExtension(extClass, args);
+  }
+
+
   // Instance creation
 
   /** Creates a benchmark suite core without parameter overrides. */

--- a/renaissance-core/src/main/java/org/renaissance/core/ModuleLoader.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/ModuleLoader.java
@@ -321,21 +321,33 @@ public final class ModuleLoader {
   static <T> Class<? extends T> loadExtension(
     Collection<Path> classPath, String className, Class<T> baseClass
   ) throws ModuleLoadingException {
-    URL[] classPathUrls = pathsToUrls(classPath);
-    if (logger.isLoggable(Level.CONFIG)) {
-      logger.config(String.format(
-        "Class path for %s: %s", className,
-        Arrays.stream(classPathUrls).map(Object::toString).collect(joining(","))
-      ));
+    ClassLoader loader = createClassLoaderFromPaths(classPath, className);
+    return loadExtensionFromClassLoader(loader, className, baseClass);
+  }
+
+
+  /**
+   * Loads an extension class and casts it to the desired base class.
+   * The class name is read from a given property.
+   */
+  static <T> Class<? extends T> loadDescribedExtension(
+    Collection<Path> classPath, String propertyName, Class<T> baseClass
+  ) throws ModuleLoadingException {
+    ClassLoader loader = createClassLoaderFromPaths(classPath, propertyName);
+    String className = getManifestProperty(loader, propertyName);
+
+    if (className == null) {
+      throw new ModuleLoadingException("classname to load not found in manifests");
     }
 
-    if (classPathUrls.length != classPath.size()) {
-      throw new ModuleLoadingException("malformed URL(s) in classpath specification");
-    }
+    return loadExtensionFromClassLoader(loader, className, baseClass);
+  }
 
+  /** Loads extension from initialized class loader. */
+  private static <T> Class<? extends T> loadExtensionFromClassLoader(
+    ClassLoader loader, String className, Class<T> baseClass
+  ) throws ModuleLoadingException {
     try {
-      ClassLoader parent = ModuleLoader.class.getClassLoader();
-      ClassLoader loader = new URLClassLoader(classPathUrls, parent);
       Class<?> loadedClass = loader.loadClass(className);
       return loadedClass.asSubclass(baseClass);
 
@@ -352,18 +364,15 @@ public final class ModuleLoader {
     }
   }
 
-
-  /**
-   * Loads an extension class and casts it to the desired base class.
-   * The class name is read from a given property.
-   */
-  static <T> Class<? extends T> loadAutoExtension(
-    Collection<Path> classPath, String propertyName, Class<T> baseClass
+  /** Create classloader from list of Path. */
+  private static ClassLoader createClassLoaderFromPaths(
+    Collection<Path> classPath,
+    String name
   ) throws ModuleLoadingException {
     URL[] classPathUrls = pathsToUrls(classPath);
     if (logger.isLoggable(Level.CONFIG)) {
       logger.config(String.format(
-        "Class path for property %s: %s", propertyName,
+        "Class path for %s: %s", name,
         Arrays.stream(classPathUrls).map(Object::toString).collect(joining(","))
       ));
     }
@@ -372,12 +381,15 @@ public final class ModuleLoader {
       throw new ModuleLoadingException("malformed URL(s) in classpath specification");
     }
 
-    String className = null;
+    ClassLoader parent = ModuleLoader.class.getClassLoader();
+    return new URLClassLoader(classPathUrls, parent);
+  }
 
+  /** Read all manifests and find first one having given property.
+   * @returns Property value or null if not found.
+   */
+  private static String getManifestProperty(ClassLoader loader, String property) {
     try {
-      ClassLoader parent = ModuleLoader.class.getClassLoader();
-      ClassLoader loader = new URLClassLoader(classPathUrls, parent);
-
       Enumeration<URL> manifests = loader.getResources("META-INF/MANIFEST.MF");
       while (manifests.hasMoreElements()) {
         try {
@@ -386,39 +398,18 @@ public final class ModuleLoader {
           InputStream manifest = manifestUrl.openStream();
           props.load(manifest);
           manifest.close();
-          if (props.containsKey(propertyName)) {
-            className = props.getProperty(propertyName);
-            break;
+          if (props.containsKey(property)) {
+            return props.getProperty(property);
           }
         } catch (IOException e) {
           continue;
         }
       }
-      if (className == null) {
-        throw new ModuleLoadingException("classname to load not found in manifests");
-      }
-
-      Class<?> loadedClass = loader.loadClass(className);
-      return loadedClass.asSubclass(baseClass);
-
     } catch (IOException e) {
-      // loader.getResources failed, we cannot recover from that
-      throw new ModuleLoadingException(
-        "could not find property %s", propertyName
-      );
-    } catch (ClassNotFoundException e) {
-      // Be a bit more verbose, because the ClassNotFoundException
-      // on OpenJDK only returns the class name as error message.
-      throw new ModuleLoadingException(
-        "could not find class '%s' from property %s", className, propertyName
-      );
-    } catch (ClassCastException e) {
-      throw new ModuleLoadingException(
-        "class '%s' is not a subclass of '%s'", className, baseClass.getName()
-      );
+      // Ignore.
     }
+    return null;
   }
-
 
   //
   // Utility methods to convert things to an array of URLs.

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ConfigParser.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ConfigParser.scala
@@ -48,7 +48,7 @@ private final class ConfigParser(tags: Map[String, String]) {
         .maxOccurs(1)
 
       opt[String]("plugin")
-        .valueName("<class-path>!<class-name>")
+        .valueName("<class-path>[!<class-name>]")
         .text("Load external plugin. Can appear multiple times.")
         .action((v, c) => c.withPlugin(v))
         .unbounded()

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ConfigParser.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ConfigParser.scala
@@ -51,11 +51,6 @@ private final class ConfigParser(tags: Map[String, String]) {
         .valueName("<class-path>!<class-name>")
         .text("Load external plugin. Can appear multiple times.")
         .action((v, c) => c.withPlugin(v))
-        .validate { v =>
-          val splitIndex = v.lastIndexOf('!')
-          if (splitIndex > 0 && (v.length - splitIndex) > 1) success
-          else failure("expected <class-path>!<class-name> in external plugin specification")
-        }
         .unbounded()
 
       opt[String]("with-arg")

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
@@ -374,8 +374,10 @@ operation, and will pass the result of the `isLast` method to some other events.
 
 To make the harness use an external plugin, it needs to be specified on the command line.
 The harness can load multiple plugins, and each must be enabled using the
-`--plugin <class-path>!<class-name>` option. The `<class-path>` is the class path on which
-to look for the plugin class, and `<class-name>` is a fully qualified name of the plugin class.
+`--plugin <class-path>[!<class-name>]` option. The `<class-path>` is the class path on which
+to look for the plugin class, and `<class-name>` is a fully qualified name of the plugin class
+(the class-name can be omitted when specified as a `Renaissance-Plugin` property inside
+`META-INF/MANIFEST.MF` of the plugin JAR).
 Custom execution policy must be enabled using the `--policy <class-path>!<class-name>` option.
 The syntax is the same as in case of normal plugins (and the policy is also a plugin, which
 can register for all event types), but this option tells the harness to actually use the

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
@@ -311,18 +311,30 @@ object RenaissanceSuite {
     val splitIndex = specifier.lastIndexOf("!")
 
     val className = specifier.substring(splitIndex + 1)
-    if (className.isEmpty) {
-      exitWithError("class name is missing")
-    }
 
-    val classPathString = specifier.substring(0, splitIndex)
+    val classPathString =
+      if (splitIndex == -1) specifier else specifier.substring(0, splitIndex)
     val classPath = classPathString.split(File.pathSeparator).map(Paths.get(_)).toList
     classPath.filterNot(Files.isReadable).foreach { path =>
       exitWithError(s"'$path' does not exist or is not readable")
     }
 
     try {
-      suite.createExtension(classPath.asJava, className, classOf[Plugin], args.toArray[String])
+      if (splitIndex != -1) {
+        suite.createExtension(
+          classPath.asJava,
+          className,
+          classOf[Plugin],
+          args.toArray[String]
+        )
+      } else {
+        suite.createAutoExtension(
+          classPath.asJava,
+          "Renaissance-Plugin",
+          classOf[Plugin],
+          args.toArray[String]
+        )
+      }
     } catch {
       case e: ModuleLoadingException => exitWithError(e.getMessage)
     }

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
@@ -328,7 +328,7 @@ object RenaissanceSuite {
           args.toArray[String]
         )
       } else {
-        suite.createAutoExtension(
+        suite.createDescribedExtension(
           classPath.asJava,
           "Renaissance-Plugin",
           classOf[Plugin],

--- a/tools/ci/bench-plugins.sh
+++ b/tools/ci/bench-plugins.sh
@@ -8,8 +8,7 @@ get_plugin_spec() {
     local plugin_name="$( echo "$1" | tr -d - )"
     local plugin_version="$( sed -n 's#.*version[ ]*:=[ ]*"\([^"]*\)".*#\1#p' <"$plugin_dir/build.sbt" )"
     local plugin_jar="${plugin_dir}target/plugin-${plugin_name}-assembly-$plugin_version.jar"
-    local main_class="org.renaissance.plugins.$plugin_name.Main"
-    echo "${plugin_jar}!${main_class}"
+    echo "${plugin_jar}"
 }
 
 java \


### PR DESCRIPTION
Add `Renaissance-Plugin` property to a `MANIFEST.MF` of a plugin describing plugin main class. When the plugin is loaded, the class is automatically read from the manifest. Simplifies the command line, fixes #194.