### PR TITLE
Documentation improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,27 +14,14 @@ This will retrieve all the dependencies, compile all the benchmark projects and 
 bundle the JARs and create the final JAR under the `target` directory.
 
 
-### Code organization and internals
-
-The code is organized into three main parts:
-
-- `renaissance-core`: these are the core APIs that a benchmark needs to work with,
-  such as the runtime configuration, the benchmark base class or the policy.
-- `renaissance-harness`: this is the overall suite project, which is responsible for
-  parsing the arguments, loading the classes, and running the benchmark.
-- a set of projects in the `benchmarks` directory: these are the individual groups of benchmarks
-  that share a common set of dependencies. A group is typically thematic, relating to
-  a particular framework or a JVM language, and benchmarks in different groups depend
-  on a different set of libraries, or even the same libraries with different versions.
-  The bundling mechanism of the suite takes care that the dependencies of the different groups
-  never clash with each other.
-
-
 ### Adding a new benchmark
 
 To add a new benchmark to an existing group, identify the respective project
 in the `benchmarks` directory, and add a new top-level Scala (Java) class
 that extends (implements) the `Benchmark` interface.
+
+We recommend you also consult [Design overview document](documentation/design.md)
+to understand how the whole project is organized.
 
 Here is an example:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,24 @@
 
 ## Contribution Guide
 
+This document provides a high-level overview of how to contribute to
+Renaissance Benchmark Suite.
+Details are described in standalone files in the `documentation`
+subdirectory inside project repository (tarball).
+
+We would also like to point you to the
+[Renaissance Code of Conduct](https://github.com/renaissance-benchmarks/renaissance/blob/master/CODE-OF-CONDUCT.md). As a member
+of the Renaissance community, make sure that you follow it to guarantee an enjoyable experience for every member of
+the community.
+
+
+### Setting up your environment
+
+Renaissance Benchmark Suite is built via SBT and is written in both
+Java and Scala.
+Several tips on how to setup your IDE are in `documentation/ide.md`.
+
+
 ### Building the suite
 
 To build the suite and create the so-called fat JAR (or super JAR), you only
@@ -14,74 +32,11 @@ This will retrieve all the dependencies, compile all the benchmark projects and 
 bundle the JARs and create the final JAR under the `target` directory.
 
 
-### Adding a new benchmark
+### Making a contribution
 
-To add a new benchmark to an existing group, identify the respective project
-in the `benchmarks` directory, and add a new top-level Scala (Java) class
-that extends (implements) the `Benchmark` interface.
-
-We recommend you also consult [Design overview document](documentation/design.md)
-to understand how the whole project is organized.
-
-Here is an example:
-
-```scala
-import org.renaissance._
-import org.renaissance.Benchmark._
-
-@Summary("Runs some performance-critical Java code.")
-final class MyJavaBenchmark extends Benchmark {
-  override def run(context: BenchmarkContext): BenchmarkResult = {
-    // This is the benchmark body, which in this case calls some Java code.
-    JavaCode.runSomeJavaCode()
-    // Return object for later validation of the operation result.
-    return new MyJavaBenchmarkResult()
-  }
-}
-```
-
-Above, the name of the benchmark will be automatically generated from the class name.
-In this case, the name will be `my-java-benchmark`.
-
-To create a new group of benchmarks (for example, benchmarks that depend on a new framework),
-create an additional `sbt` project in the `benchmarks` directory,
-using an existing project, such as `scala-stdlib`, as an example.
-The project will be automatically picked up by the build system
-and included into the Renaissance distribution.
-
-Once the benchmark has been added, one needs to make sure to be compliant with the code
-formatting of the project (rules defined in `.scalafmt.conf`).
-A convenient sbt task can do that check:
-```
-$ tools/sbt/bin/sbt renaissanceFormatCheck
-```
-
-Another one can directly update the source files to match the desired format:
-```
-$ tools/sbt/bin/sbt renaissanceFormat
-```
-
-Moreover, the contents of the `README.md` file is automatically generated
-from the codebase. Updating those files can be done with the `--readme` command-line flag.
-Using sbt, one would do:
-
-```
-$ tools/sbt/bin/sbt runMain org.renaissance.core.Launcher --readme
-```
-
-### IDE development
-
-#### IntelliJ
-
-In order to work on the project with IntelliJ, one needs to install the following plugins :
-  - `Scala` : part of the codebase uses Scala and Renaissance is organized in sbt projects.
-  - `scalafmt` (optional) : adds an action that can be triggered with `Code -> Reformat with scalafmt`
-  which will reformat the code according to the formatting rule defined in `.scalafmt.conf`
-  (same as the `renaissanceFormat` sbt task).
-
-Then, the root of this repository can be opened as an IntelliJ project.
-
-### Benchmark evaluation and release process
+Contribution to Renaissance Benchmark Suite is not only about adding new benchmarks.
+We welcome authors of new plugins, testers of not-so-common platforms and we are
+open to general discussion about improving the suite too.
 
 In the open-source spirit, anyone can propose an additional benchmark by opening a pull request.
 The code is then inspected by the community -- typically, the suite maintainers are involved
@@ -92,8 +47,15 @@ the benchmark could be improved.
 Before submitting a pull request, it is recommendable to open an issue first,
 and discuss the benchmark proposal with the maintainers.
 
+More details about the actual source code organization and guides can be found in the following
+files.
 
-#### Benchmark criteria
+ * Overall suite design: `documentation/design.md`
+ * Adding a new benchmark: `documentation/adding-benchmark.md`
+ * Adding a plugin: `documentation/plugins.md`
+
+
+### Benchmark evaluation and release process
 
 Here is some of the quality criteria that a new benchmark should satisfy:
 
@@ -129,12 +91,7 @@ Here is some of the quality criteria that a new benchmark should satisfy:
 - *Open-source*: the benchmark must consist of open-source code, with well-defined licenses.
 
 
-#### Code of Conduct
 
-We would also like to point you to the
-[Renaissance Code of Conduct](https://github.com/renaissance-benchmarks/renaissance/blob/master/CODE-OF-CONDUCT.md). As a member
-of the Renaissance community, make sure that you follow it to guarantee an enjoyable experience for every member of
-the community.
 
 #### Release process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,19 @@
 
 ## Contribution Guide
 
+### Building the suite
+
+To build the suite and create the so-called fat JAR (or super JAR), you only
+need to run `sbt` build tool as follows:
+
+```
+$ tools/sbt/bin/sbt assembly
+```
+
+This will retrieve all the dependencies, compile all the benchmark projects and the harness,
+bundle the JARs and create the final JAR under the `target` directory.
+
+
 ### Code organization and internals
 
 The code is organized into three main parts:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,9 +61,10 @@ Another one can directly update the source files to match the desired format:
 $ tools/sbt/bin/sbt renaissanceFormat
 ```
 
-Moreover, the contents of the `README.md` and `CONTRIBUTING.md` files are automatically generated
+Moreover, the contents of the `README.md` file is automatically generated
 from the codebase. Updating those files can be done with the `--readme` command-line flag.
 Using sbt, one would do:
+
 ```
 $ tools/sbt/bin/sbt runMain org.renaissance.core.Launcher --readme
 ```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ execution can be achieved by providing the harness with a plugin implementing a 
 policy (see [below](#plugins) for details).
 
 
+### Licensing
+
+The Renaissance Suite comes in two distributions,
+and is available under both the MIT license and the GPL3 license.
+The GPL distribution with all the benchmarks is licensed under the GPL3 license,
+while the MIT distribution includes only those benchmarks that themselves
+have less restrictive licenses.
+
+Depending on your needs, you can use either of the two distributions.
+
+The list below contains the licensing information (and JVM version requirements)
+for each benchmark.
+
+
+
 #### Complete list of command-line options
 
 The following is a complete list of command-line options.
@@ -89,65 +104,90 @@ The following is the complete list of benchmarks, separated into groups.
 
 #### apache-spark
 
-- `als` - Runs the ALS algorithm from the Spark ML library. (default repetitions: 30)
+- `als` - Runs the ALS algorithm from the Spark ML library.
+  Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
-- `chi-square` - Runs the chi-square test from Spark MLlib. (default repetitions: 60)
+- `chi-square` - Runs the chi-square test from Spark MLlib.
+  Default repetitions: 60; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
-- `dec-tree` - Runs the Random Forest algorithm from the Spark ML library. (default repetitions: 40)
+- `dec-tree` - Runs the Random Forest algorithm from the Spark ML library.
+  Default repetitions: 40; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
-- `gauss-mix` - Computes a Gaussian mixture model using expectation-maximization. (default repetitions: 40)
+- `gauss-mix` - Computes a Gaussian mixture model using expectation-maximization.
+  Default repetitions: 40; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
-- `log-regression` - Runs the Logistic Regression algorithm from the Spark ML library. (default repetitions: 20)
+- `log-regression` - Runs the Logistic Regression algorithm from the Spark ML library.
+  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
-- `movie-lens` - Recommends movies using the ALS algorithm. (default repetitions: 20)
+- `movie-lens` - Recommends movies using the ALS algorithm.
+  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
-- `naive-bayes` - Runs the multinomial Naive Bayes algorithm from the Spark ML library. (default repetitions: 30)
+- `naive-bayes` - Runs the multinomial Naive Bayes algorithm from the Spark ML library.
+  Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
-- `page-rank` - Runs a number of PageRank iterations, using RDDs. (default repetitions: 20)
+- `page-rank` - Runs a number of PageRank iterations, using RDDs.
+  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
 #### concurrency
 
-- `akka-uct` - Runs the Unbalanced Cobwebbed Tree actor workload in Akka. (default repetitions: 24)
+- `akka-uct` - Runs the Unbalanced Cobwebbed Tree actor workload in Akka.
+  Default repetitions: 24; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
-- `fj-kmeans` - Runs the k-means algorithm using the fork/join framework. (default repetitions: 30)
+- `fj-kmeans` - Runs the k-means algorithm using the fork/join framework.
+  Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
-- `reactors` - Runs benchmarks inspired by the Savina microbenchmark workloads in a sequence on Reactors.IO. (default repetitions: 10)
+- `reactors` - Runs benchmarks inspired by the Savina microbenchmark workloads in a sequence on Reactors.IO.
+  Default repetitions: 10; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
 #### database
 
-- `db-shootout` - Executes a shootout test using several in-memory databases. (default repetitions: 16)
+- `db-shootout` - Executes a shootout test using several in-memory databases.
+  Default repetitions: 16; APACHE2 license, MIT distribution; Supported JVM: 1.8 - 11
 
-- `neo4j-analytics` - Executes Neo4J graph queries against a movie database. (default repetitions: 20)
+- `neo4j-analytics` - Executes Neo4J graph queries against a movie database.
+  Default repetitions: 20; GPL3 license, GPL3 distribution; Supported JVM: 11 - 15
 
 #### functional
 
-- `future-genetic` - Runs a genetic algorithm using the Jenetics library and futures. (default repetitions: 50)
+- `future-genetic` - Runs a genetic algorithm using the Jenetics library and futures.
+  Default repetitions: 50; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
-- `mnemonics` - Solves the phone mnemonics problem using JDK streams. (default repetitions: 16)
+- `mnemonics` - Solves the phone mnemonics problem using JDK streams.
+  Default repetitions: 16; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
-- `par-mnemonics` - Solves the phone mnemonics problem using parallel JDK streams. (default repetitions: 16)
+- `par-mnemonics` - Solves the phone mnemonics problem using parallel JDK streams.
+  Default repetitions: 16; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
-- `rx-scrabble` - Solves the Scrabble puzzle using the Rx streams. (default repetitions: 80)
+- `rx-scrabble` - Solves the Scrabble puzzle using the Rx streams.
+  Default repetitions: 80; GPL2 license, GPL3 distribution; Supported JVM: 1.8 and later
 
-- `scrabble` - Solves the Scrabble puzzle using JDK Streams. (default repetitions: 50)
+- `scrabble` - Solves the Scrabble puzzle using JDK Streams.
+  Default repetitions: 50; GPL2 license, GPL3 distribution; Supported JVM: 1.8 and later
 
 #### scala
 
-- `dotty` - Runs the Dotty compiler on a set of source code files. (default repetitions: 50)
+- `dotty` - Runs the Dotty compiler on a set of source code files.
+  Default repetitions: 50; BSD3 license, MIT distribution; Supported JVM: 1.8 and later
 
-- `philosophers` - Solves a variant of the dining philosophers problem using ScalaSTM. (default repetitions: 30)
+- `philosophers` - Solves a variant of the dining philosophers problem using ScalaSTM.
+  Default repetitions: 30; BSD3 license, MIT distribution; Supported JVM: 1.8 and later
 
-- `scala-doku` - Solves Sudoku Puzzles using Scala collections. (default repetitions: 20)
+- `scala-doku` - Solves Sudoku Puzzles using Scala collections.
+  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
-- `scala-kmeans` - Runs the K-Means algorithm using Scala collections. (default repetitions: 50)
+- `scala-kmeans` - Runs the K-Means algorithm using Scala collections.
+  Default repetitions: 50; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
-- `scala-stm-bench7` - Runs the stmbench7 benchmark using ScalaSTM. (default repetitions: 60)
+- `scala-stm-bench7` - Runs the stmbench7 benchmark using ScalaSTM.
+  Default repetitions: 60; BSD3, GPL2 license, GPL3 distribution; Supported JVM: 1.8 and later
 
 #### web
 
-- `finagle-chirper` - Simulates a microblogging service using Twitter Finagle. (default repetitions: 90)
+- `finagle-chirper` - Simulates a microblogging service using Twitter Finagle.
+  Default repetitions: 90; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
-- `finagle-http` - Sends many small Finagle HTTP requests to a Finagle HTTP server and awaits response. (default repetitions: 12)
+- `finagle-http` - Sends many small Finagle HTTP requests to a Finagle HTTP server and awaits response.
+  Default repetitions: 12; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
 
 
@@ -156,17 +196,23 @@ purposes:
 
 #### dummy
 
-- `dummy-empty` - A dummy benchmark which only serves to test the harness. (default repetitions: 20)
+- `dummy-empty` - A dummy benchmark which only serves to test the harness.
+  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
-- `dummy-failing` - A dummy benchmark for testing the harness (fails during iteration). (default repetitions: 20)
+- `dummy-failing` - A dummy benchmark for testing the harness (fails during iteration).
+  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
-- `dummy-param` - A dummy benchmark for testing the harness (test configurable parameters). (default repetitions: 20)
+- `dummy-param` - A dummy benchmark for testing the harness (test configurable parameters).
+  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
-- `dummy-setup-failing` - A dummy benchmark for testing the harness (fails during setup). (default repetitions: 20)
+- `dummy-setup-failing` - A dummy benchmark for testing the harness (fails during setup).
+  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
-- `dummy-teardown-failing` - A dummy benchmark for testing the harness (fails during teardown). (default repetitions: 20)
+- `dummy-teardown-failing` - A dummy benchmark for testing the harness (fails during teardown).
+  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
-- `dummy-validation-failing` - A dummy benchmark for testing the harness (fails during validation). (default repetitions: 20)
+- `dummy-validation-failing` - A dummy benchmark for testing the harness (fails during validation).
+  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
 
 
@@ -242,47 +288,6 @@ $ java -jar 'renaissance-jmh/target/scala-2.12/renaissance-jmh-assembly-0.12.0.j
 ### Contributing
 
 Please see the [contribution guide](CONTRIBUTING.md) for a description of the contribution process.
-
-
-### Licensing
-
-The Renaissance Suite comes in two distributions,
-and is available under both the MIT license and the GPL3 license.
-The GPL distribution with all the benchmarks is licensed under the GPL3 license,
-while the MIT distribution includes only those benchmarks that themselves
-have less restrictive licenses.
-
-Depending on your needs, you can use either of the two distributions.
-The following table contains the licensing information (and JVM version
-requirements) for all the benchmarks:
-
-| Benchmark        | Licenses   | Distro | JVM required (min) | JVM supported (max) |
-| :--------------- | :--------- | :----: | :----------------: | :-----------------: |
-| akka-uct | MIT | MIT | 1.8 |  |
-| als | APACHE2 | MIT | 1.8 |  |
-| chi-square | APACHE2 | MIT | 1.8 |  |
-| db-shootout | APACHE2 | MIT | 1.8 | 11 |
-| dec-tree | APACHE2 | MIT | 1.8 |  |
-| dotty | BSD3 | MIT | 1.8 |  |
-| finagle-chirper | APACHE2 | MIT | 1.8 |  |
-| finagle-http | APACHE2 | MIT | 1.8 |  |
-| fj-kmeans | APACHE2 | MIT | 1.8 |  |
-| future-genetic | APACHE2 | MIT | 1.8 |  |
-| gauss-mix | APACHE2 | MIT | 1.8 |  |
-| log-regression | APACHE2 | MIT | 1.8 |  |
-| mnemonics | MIT | MIT | 1.8 |  |
-| movie-lens | APACHE2 | MIT | 1.8 |  |
-| naive-bayes | APACHE2 | MIT | 1.8 |  |
-| neo4j-analytics | GPL3 | GPL3 | 11 | 15 |
-| page-rank | APACHE2 | MIT | 1.8 |  |
-| par-mnemonics | MIT | MIT | 1.8 |  |
-| philosophers | BSD3 | MIT | 1.8 |  |
-| reactors | MIT | MIT | 1.8 |  |
-| rx-scrabble | GPL2 | GPL3 | 1.8 |  |
-| scala-doku | MIT | MIT | 1.8 |  |
-| scala-kmeans | MIT | MIT | 1.8 |  |
-| scala-stm-bench7 | BSD3, GPL2 | GPL3 | 1.8 |  |
-| scrabble | GPL2 | GPL3 | 1.8 |  |
 
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -59,45 +59,6 @@ The list below contains the licensing information (and JVM version requirements)
 for each benchmark.
 
 
-
-#### Complete list of command-line options
-
-The following is a complete list of command-line options.
-
-```
-Renaissance Benchmark Suite, version 0.12.0
-Usage: renaissance [options] [benchmark-specification]
-
-  -h, --help               Prints this usage text.
-  -r, --repetitions <count>
-                           Execute the measured operation a fixed number of times.
-  -t, --run-seconds <seconds>
-                           Execute the measured operation for fixed time (wall-clock).
-  --operation-run-seconds <seconds>
-                           Execute the measured operation for fixed accumulated operation time (wall-clock).
-  --policy <class-path>!<class-name>
-                           Use policy plugin to control repetition of measured operation execution.
-  --plugin <class-path>[!<class-name>]
-                           Load external plugin. Can appear multiple times.
-  --with-arg <value>       Adds an argument to the plugin or policy specified last. Can appear multiple times.
-  --csv <csv-file>         Output results as CSV to <csv-file>.
-  --json <json-file>       Output results as JSON to <json-file>.
-  -c, --configuration <conf-name>
-                           Use benchmark parameters from configuration <conf-name>.
-  -o, --override <name>=<value>
-                           Override the value of a configuration parameter <name> to <value>.
-  --scratch-base <dir>     Create scratch directories in <dir>. Defaults to current directory.
-  --keep-scratch           Keep the scratch directories after VM exit. Defaults to deleting scratch directories.
-  --no-forced-gc           Do not force garbage collection before each measured operation. Defaults to forced GC.
-  --no-jvm-check           Do not check benchmark JVM version requirements (for execution or raw-list).
-  --list                   Print the names and descriptions of all benchmarks.
-  --raw-list               Print the names of benchmarks compatible with this JVM (one per line).
-  --group-list             Print the names of all benchmark groups (one per line).
-  benchmark-specification  List of benchmarks (or groups) to execute (or 'all').
-
-```
-
-
 ### List of benchmarks
 
 The following is the complete list of benchmarks, separated into groups.
@@ -268,6 +229,44 @@ given using the `--with-arg <arg>` option, which appends `<arg>` to the list of 
 the plugin (or policy) that was last mentioned on the command line. Whenever a `--plugin`
 (or `--policy`) option is encountered, the subsequent `--with-arg` options will append
 arguments to that plugin (or policy).
+
+
+#### Complete list of command-line options
+
+The following is a complete list of command-line options.
+
+```
+Renaissance Benchmark Suite, version 0.12.0
+Usage: renaissance [options] [benchmark-specification]
+
+  -h, --help               Prints this usage text.
+  -r, --repetitions <count>
+                           Execute the measured operation a fixed number of times.
+  -t, --run-seconds <seconds>
+                           Execute the measured operation for fixed time (wall-clock).
+  --operation-run-seconds <seconds>
+                           Execute the measured operation for fixed accumulated operation time (wall-clock).
+  --policy <class-path>!<class-name>
+                           Use policy plugin to control repetition of measured operation execution.
+  --plugin <class-path>[!<class-name>]
+                           Load external plugin. Can appear multiple times.
+  --with-arg <value>       Adds an argument to the plugin or policy specified last. Can appear multiple times.
+  --csv <csv-file>         Output results as CSV to <csv-file>.
+  --json <json-file>       Output results as JSON to <json-file>.
+  -c, --configuration <conf-name>
+                           Use benchmark parameters from configuration <conf-name>.
+  -o, --override <name>=<value>
+                           Override the value of a configuration parameter <name> to <value>.
+  --scratch-base <dir>     Create scratch directories in <dir>. Defaults to current directory.
+  --keep-scratch           Keep the scratch directories after VM exit. Defaults to deleting scratch directories.
+  --no-forced-gc           Do not force garbage collection before each measured operation. Defaults to forced GC.
+  --no-jvm-check           Do not check benchmark JVM version requirements (for execution or raw-list).
+  --list                   Print the names and descriptions of all benchmarks.
+  --raw-list               Print the names of benchmarks compatible with this JVM (one per line).
+  --group-list             Print the names of all benchmark groups (one per line).
+  benchmark-specification  List of benchmarks (or groups) to execute (or 'all').
+
+```
 
 
 ### JMH support

--- a/README.md
+++ b/README.md
@@ -327,3 +327,10 @@ Apart from documentation embedded directly in the source code, further
 information about design and internals of the suite can be found in the
 `documentation` folder of this project.
 
+
+### Support
+
+When you find a bug in the suite, when you want to propose a new benchmark or
+ask for help, please, open an [Issue](https://github.com/renaissance-benchmarks/renaissance/issues)
+at the project page at GitHub.
+

--- a/README.md
+++ b/README.md
@@ -285,75 +285,9 @@ requirements) for all the benchmarks:
 | scrabble | GPL2 | GPL3 | 1.8 |  |
 
 
-### Design overview
+### Documentation
 
-The Renaissance benchmark suite is organized into several `sbt` projects:
+Apart from documentation embedded directly in the source code, further
+information about design and internals of the suite can be found in the
+`documentation` folder of this project.
 
-- the `renaissance-core` folder that contains a set of *core* classes
-  (common interfaces and a harness launcher)
-- the `renaissance-harness` folder that contains the actual harness
-- the `benchmarks` folder contains a set of *subprojects*, each containing a set of benchmarks
-  for a specific domain (and having a separate set of dependencies)
-
-The *core* project is written in pure Java, and it contains the basic benchmark API.
-Its most important elements are the `Benchmark` interface,
-which must be implemented by each benchmark, and the annotations in the
-`Benchmark` interface name space, which are used to provide
-benchmark meta data, such as a summary or a detailed description.
-Consequently, each *subproject* depends on the *core* project.
-
-Classes from the *core* are loaded (when Renaissance is started) by the default
-classloader. Classes from other projects (including the harness and individual benchmarks)
-and external plugins or execution policies are loaded by separate classloaders. This
-separation helps ensure that there are no clashes between dependencies of different
-projects (each benchmark may depend on different versions of external libraries).
-
-The *harness* project implements the functionality necessary to parse the input
-arguments, to run the benchmarks, to generate documentation, and so on. The *harness*
-is written in a mix of Java and Scala, and is loaded by the *core* in a separate classloader
-to ensure clean environment for running the benchmarks.
-
-The JARs of the subprojects (benchmarks and harness) are copied as generated
-*resources* and embedded into the resulting JAR artifact.
-
-```
-renaissance-core
-  ^
-  | (classpath dependencies)
-  |
-  |-- renaissance harness
-  |
-  |-- benchmark one
-  | `-- dependencies for benchmark one
-  |
-  |-- ...
-  |
-  `-- benchmark n
-```
-
-When the harness is started, it uses the input arguments to select the benchmark,
-and then unpacks the JARs of the corresponding benchmark group into a temporary directory.
-The harness then creates a classloader that searches the unpacked JARs and loads the
-benchmark group. The class loader is created directly below the default class loader.
-Because the default class loader contains only base JRE classes and common interfaces
-of *core*, it ensures that dependencies of a benchmark are never mixed with any
-dependencies of any other benchmark or the harness.
-
-```
-        boot class loader (JDK)
-                   ^
-                   |
-          system class loader
-                (core)
-         ^                   ^
-         |                   |
-  URL class loader    URL class loader
-     (harness)          (benchmark)
-```
-
-We need to do this to, e.g., avoid accidentally resolving the wrong class
-by going through the system class loader (this can easily happen with,
-e.g. Apache Spark and Scala, due to the way that Spark internally resolves some classes).
-
-You can find further details in the top-level `build.sbt` file, and in the source code of
-the `RenaissanceSuite` and `ModuleLoader` classes.

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ the plugin (or policy) that was last mentioned on the command line. Whenever a `
 arguments to that plugin (or policy).
 
 
-#### Complete list of command-line options
+### Complete list of command-line options
 
 The following is a complete list of command-line options.
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ This repository contains two such plugins: one that uses a native agent built wi
 [PAPI](https://icl.utk.edu/papi/) to collect information from hardware counters and
 a plugin for collecting information from a
 [CompilationMXBean](https://docs.oracle.com/javase/8/docs/api/java/lang/management/CompilationMXBean.html).
+See their respective READMEs under the `plugin` directory for more information.
 
 If you wish to create your own plugin, please consult
 [documentation/plugins.md](documentation/plugins.md) for more details.

--- a/README.md
+++ b/README.md
@@ -188,76 +188,26 @@ you will need to be able to tell the harness when to keep executing the benchmar
 stop.
 
 To this end, the suite provides hooks for plugins which can subscribe to events related to
-harness state and benchmark execution. A plugin is a user-defined class which must implement
-the `Plugin` marker interface and provide at least a default (parameter-less)
-constructor. However, such a minimal plugin would not receive any notifications. To receive
-notifications, the plugin class must implement interfaces from the `Plugin`
-interface name space depending on the type of events it wants to receive, or services it wants
-to provide. This is demonstrated in the following example:
+harness state and benchmark execution.
 
-```scala
-class SimplePlugin extends Plugin
-  with AfterHarnessInitListener
-  with AfterOperationSetUpListener
-  with BeforeOperationTearDownListener {
+This repository contains two such plugins: one that uses a native agent built with
+[PAPI](https://icl.utk.edu/papi/) to collect information from hardware counters and
+a plugin for collecting information from a
+[CompilationMXBean](https://docs.oracle.com/javase/8/docs/api/java/lang/management/CompilationMXBean.html).
 
-  override def afterHarnessInit() = {
-    // Initialize the plugin after the harness finished initializing
-  }
-
-  override def afterOperationSetUp(benchmark: String, index: Int) = {
-    // Notify the tool that the measured operation is about to start.
-  }
-
-  override def beforeOperationTearDown(benchmark: String, index: Int) = {
-    // Notify the tool that the measured operations has finished.
-  }
-}
-```
-
-The following interfaces provide common (paired) event types which allow a plugin to hook
-into a specific point in the benchmark execution sequence. They are analogous to common
-annotations known from testing frameworks such as JUnit. Harness-level events occur only
-once per the whole execution, benchmark-level events occur once for each benchmark
-executed, and operation-level events occur once for each execution of the measured
-operation.
-- `AfterHarnessInitListener`, `BeforeHarnessShutdownListener`
-- `BeforeBenchmarkSetUpListener`, `AfterBenchmarkTearDownListener`
-- `AfterBenchmarkSetUpListener`, `BeforeBenchmarkTearDownListener`
-- `AfterOperationSetUpListener`, `BeforeOperationTearDownListener`
-
-The following interfaces provide special non-paired event types:
-- `MeasurementResultListener`, intended for plugins that want to receive
-measurements results (perhaps to store them in a custom format). The harness calls the
-`onMeasurementResult` method with the name of the metric and its value, but only if the
-benchmark operation produces a valid result.
-- `BenchmarkFailureListener`, which indicates that the benchmark execution
-has either failed in some way (the benchmark triggered an exception), or that the benchmark
-operation produced a result which failed validation. This means that no measurements results
-will be received.
-
-And finally the following interfaces are used by the harness to request
-services from plugins:
-- `MeasurementResultPublisher`, intended for plugins that want to collect
-values of additional metrics around the execution of the benchmark operation. The harness
-calls the `onMeasurementResultsRequested` method with an instance of event dispatcher which
-the plugin is supposed to use to notify other result listeners about custom measurement results.
-- `ExecutionPolicy`, intended for plugins that want to control the execution
-of the benchmark's measured operation. Such a plugin should implement other interfaces to
-get enough information to determine, per-benchmark, whether to execute the measured operation
-or not. The harness calls the `canExecute` method before executing the benchmark's measured
-operation, and will pass the result of the `isLast` method to some other events.
+If you wish to create your own plugin, please consult
+[documentation/plugins.md](documentation/plugins.md) for more details.
 
 To make the harness use an external plugin, it needs to be specified on the command line.
 The harness can load multiple plugins, and each must be enabled using the
 `--plugin <class-path>[!<class-name>]` option. The `<class-path>` is the class path on which
-to look for the plugin class, and `<class-name>` is a fully qualified name of the plugin class
-(the class-name can be omitted when specified as a `Renaissance-Plugin` property inside
-`META-INF/MANIFEST.MF` of the plugin JAR).
+to look for the plugin class (optionally, you may add `<class-name>` to specify a fully
+qualified name of the plugin class).
+
 Custom execution policy must be enabled using the `--policy <class-path>!<class-name>` option.
 The syntax is the same as in case of normal plugins (and the policy is also a plugin, which
 can register for all event types), but this option tells the harness to actually use the
-plugin to control benchmark execution. Other than that, policy is treated the same was as
+plugin to control benchmark execution. Other than that, policy is treated the same way as a
 plugin.
 
 When registering plugins for pair events (harness init/shutdown, benchmark set up/tear down,
@@ -271,10 +221,7 @@ Plugins (and policies) can receive additional command line arguments. Each argum
 given using the `--with-arg <arg>` option, which appends `<arg>` to the list of arguments for
 the plugin (or policy) that was last mentioned on the command line. Whenever a `--plugin`
 (or `--policy`) option is encountered, the subsequent `--with-arg` options will append
-arguments to that plugin (or policy). A plugin that wants to receive command line arguments
-must define a constructor which takes an array of strings (`String[]`) or a string vararg
-(`String...`) as parameter. The harness tries to use this constructor first and falls back
-to the default (parameter-less) constructor.
+arguments to that plugin (or policy).
 
 
 ### JMH support

--- a/README.md
+++ b/README.md
@@ -14,30 +14,22 @@ It is intended to be an open-source, collaborative project,
 in which the community can propose and improve benchmark workloads.
 
 
-### Building the suite
+### Running the suite
 
-To build the suite and create the so-called fat JAR (or super JAR), you only
-need to run `sbt` build tool as follows:
-
-```
-$ tools/sbt/bin/sbt assembly
-```
-
-This will retrieve all the dependencies, compile all the benchmark projects and the harness,
-bundle the JARs and create the final JAR under the `target` directory.
-
-
-### Running the benchmarks
+To run the suite, you will need to download a Renaissance Suite JAR
+from <https://renaissance.dev/download>.
+If you wish to build it yourself, please, consult [CONTRIBUTING.md](CONTRIBUTING.md)
+for instructions on building.
 
 To run a Renaissance benchmark, you need to have a JRE installed.
 This allows you to execute the following `java` command:
 
+
 ```
-$ java -jar '<renaissance-home>/target/renaissance-gpl-0.12.0.jar' <benchmarks>
+$ java -jar 'renaissance-gpl-0.12.0.jar' <benchmarks>
 ```
 
-Above, the `<renaissance-home>` is the path to the root directory of the Renaissance distribution,
-and `<benchmarks>` is the list of benchmarks that you wish to run.
+Above, `<benchmarks>` is the list of benchmarks that you wish to run.
 For example, you can specify `scala-kmeans` as the benchmark.
 
 The suite generally executes the benchmark's measured operation multiple times. By default,

--- a/README.md
+++ b/README.md
@@ -66,88 +66,113 @@ The following is the complete list of benchmarks, separated into groups.
 #### apache-spark
 
 - `als` - Runs the ALS algorithm from the Spark ML library.
+  \
   Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
 - `chi-square` - Runs the chi-square test from Spark MLlib.
+  \
   Default repetitions: 60; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
 - `dec-tree` - Runs the Random Forest algorithm from the Spark ML library.
+  \
   Default repetitions: 40; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
 - `gauss-mix` - Computes a Gaussian mixture model using expectation-maximization.
+  \
   Default repetitions: 40; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
 - `log-regression` - Runs the Logistic Regression algorithm from the Spark ML library.
+  \
   Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
 - `movie-lens` - Recommends movies using the ALS algorithm.
+  \
   Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
 - `naive-bayes` - Runs the multinomial Naive Bayes algorithm from the Spark ML library.
+  \
   Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
 - `page-rank` - Runs a number of PageRank iterations, using RDDs.
+  \
   Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
 #### concurrency
 
 - `akka-uct` - Runs the Unbalanced Cobwebbed Tree actor workload in Akka.
+  \
   Default repetitions: 24; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
 - `fj-kmeans` - Runs the k-means algorithm using the fork/join framework.
+  \
   Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
 - `reactors` - Runs benchmarks inspired by the Savina microbenchmark workloads in a sequence on Reactors.IO.
+  \
   Default repetitions: 10; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
 #### database
 
 - `db-shootout` - Executes a shootout test using several in-memory databases.
+  \
   Default repetitions: 16; APACHE2 license, MIT distribution; Supported JVM: 1.8 - 11
 
 - `neo4j-analytics` - Executes Neo4J graph queries against a movie database.
+  \
   Default repetitions: 20; GPL3 license, GPL3 distribution; Supported JVM: 11 - 15
 
 #### functional
 
 - `future-genetic` - Runs a genetic algorithm using the Jenetics library and futures.
+  \
   Default repetitions: 50; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
 - `mnemonics` - Solves the phone mnemonics problem using JDK streams.
+  \
   Default repetitions: 16; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
 - `par-mnemonics` - Solves the phone mnemonics problem using parallel JDK streams.
+  \
   Default repetitions: 16; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
 - `rx-scrabble` - Solves the Scrabble puzzle using the Rx streams.
+  \
   Default repetitions: 80; GPL2 license, GPL3 distribution; Supported JVM: 1.8 and later
 
 - `scrabble` - Solves the Scrabble puzzle using JDK Streams.
+  \
   Default repetitions: 50; GPL2 license, GPL3 distribution; Supported JVM: 1.8 and later
 
 #### scala
 
 - `dotty` - Runs the Dotty compiler on a set of source code files.
+  \
   Default repetitions: 50; BSD3 license, MIT distribution; Supported JVM: 1.8 and later
 
 - `philosophers` - Solves a variant of the dining philosophers problem using ScalaSTM.
+  \
   Default repetitions: 30; BSD3 license, MIT distribution; Supported JVM: 1.8 and later
 
 - `scala-doku` - Solves Sudoku Puzzles using Scala collections.
+  \
   Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
 - `scala-kmeans` - Runs the K-Means algorithm using Scala collections.
+  \
   Default repetitions: 50; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
 - `scala-stm-bench7` - Runs the stmbench7 benchmark using ScalaSTM.
+  \
   Default repetitions: 60; BSD3, GPL2 license, GPL3 distribution; Supported JVM: 1.8 and later
 
 #### web
 
 - `finagle-chirper` - Simulates a microblogging service using Twitter Finagle.
+  \
   Default repetitions: 90; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
 - `finagle-http` - Sends many small Finagle HTTP requests to a Finagle HTTP server and awaits response.
+  \
   Default repetitions: 12; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
 
 
@@ -158,21 +183,27 @@ purposes:
 #### dummy
 
 - `dummy-empty` - A dummy benchmark which only serves to test the harness.
+  \
   Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
 - `dummy-failing` - A dummy benchmark for testing the harness (fails during iteration).
+  \
   Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
 - `dummy-param` - A dummy benchmark for testing the harness (test configurable parameters).
+  \
   Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
 - `dummy-setup-failing` - A dummy benchmark for testing the harness (fails during setup).
+  \
   Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
 - `dummy-teardown-failing` - A dummy benchmark for testing the harness (fails during teardown).
+  \
   Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
 - `dummy-validation-failing` - A dummy benchmark for testing the harness (fails during validation).
+  \
   Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
 
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -3,6 +3,7 @@
 Further documentation is available in the following files.
 
  * [design.md](design.md) - overall design of the suite and build system setup
- * [jar-bundle.md](jar-bundle.md) - contents of the fat JAR with the suite
+ * [adding-benchmark.md](adding-benchmark.md) - guide for creating a new benchmark
  * [plugins.md](plugins.md) - plugin internals and quick how-to on writing your own
-
+ * [ide.md](ide.md) - tips for setting-up your IDE
+ * [jar-bundle.md](jar-bundle.md) - contents of the fat JAR with the suite

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,8 @@
+# Renaissance benchmark suite documentation
+
+Further documentation is available in the following files.
+
+ * [design.md](design.md) - overall design of the suite and build system setup
+ * [jar-bundle.md](jar-bundle.md) - contents of the fat JAR with the suite
+ * [plugins.md](plugins.md) - plugin internals and quick how-to on writing your own
+

--- a/documentation/adding-benchmark.md
+++ b/documentation/adding-benchmark.md
@@ -1,0 +1,54 @@
+# Adding a new benchmark
+
+To add a new benchmark to an existing group, identify the respective project
+in the `benchmarks` directory, and add a new top-level Scala (Java) class
+that extends (implements) the `Benchmark` interface.
+
+We recommend you also consult [Design overview document](documentation/design.md)
+to understand how the whole project is organized.
+
+Here is an example:
+
+```scala
+import org.renaissance._
+import org.renaissance.Benchmark._
+
+@Summary("Runs some performance-critical Java code.")
+final class MyJavaBenchmark extends Benchmark {
+  override def run(context: BenchmarkContext): BenchmarkResult = {
+    // This is the benchmark body, which in this case calls some Java code.
+    JavaCode.runSomeJavaCode()
+    // Return object for later validation of the operation result.
+    return new MyJavaBenchmarkResult()
+  }
+}
+```
+
+Above, the name of the benchmark will be automatically generated from the class name.
+In this case, the name will be `my-java-benchmark`.
+
+To create a new group of benchmarks (for example, benchmarks that depend on a new framework),
+create an additional `sbt` project in the `benchmarks` directory,
+using an existing project, such as `scala-stdlib`, as an example.
+The project will be automatically picked up by the build system
+and included into the Renaissance distribution.
+
+Once the benchmark has been added, one needs to make sure to be compliant with the code
+formatting of the project (rules defined in `.scalafmt.conf`).
+A convenient sbt task can do that check:
+```
+$ tools/sbt/bin/sbt renaissanceFormatCheck
+```
+
+Another one can directly update the source files to match the desired format:
+```
+$ tools/sbt/bin/sbt renaissanceFormat
+```
+
+Moreover, the contents of the `README.md` file is automatically generated
+from the codebase. Updating those files can be done with the `--readme` command-line flag.
+Using sbt, one would do:
+
+```
+$ tools/sbt/bin/sbt runMain org.renaissance.core.Launcher --readme
+```

--- a/documentation/design.md
+++ b/documentation/design.md
@@ -1,0 +1,72 @@
+# Design overview
+
+The Renaissance benchmark suite is organized into several `sbt` projects:
+
+- the `renaissance-core` folder that contains a set of *core* classes
+  (common interfaces and a harness launcher)
+- the `renaissance-harness` folder that contains the actual harness
+- the `benchmarks` folder contains a set of *subprojects*, each containing a set of benchmarks
+  for a specific domain (and having a separate set of dependencies)
+
+The *core* project is written in pure Java, and it contains the basic benchmark API.
+Its most important elements are the `Benchmark` interface,
+which must be implemented by each benchmark, and the annotations in the
+`Benchmark` interface name space, which are used to provide
+benchmark meta data, such as a summary or a detailed description.
+Consequently, each *subproject* depends on the *core* project.
+
+Classes from the *core* are loaded (when Renaissance is started) by the default
+classloader. Classes from other projects (including the harness and individual benchmarks)
+and external plugins or execution policies are loaded by separate classloaders. This
+separation helps ensure that there are no clashes between dependencies of different
+projects (each benchmark may depend on different versions of external libraries).
+
+The *harness* project implements the functionality necessary to parse the input
+arguments, to run the benchmarks, to generate documentation, and so on. The *harness*
+is written in a mix of Java and Scala, and is loaded by the *core* in a separate classloader
+to ensure clean environment for running the benchmarks.
+
+The JARs of the subprojects (benchmarks and harness) are copied as generated
+*resources* and embedded into the resulting JAR artifact.
+
+```
+renaissance-core
+  ^
+  | (classpath dependencies)
+  |
+  |-- renaissance harness
+  |
+  |-- benchmark one
+  | `-- dependencies for benchmark one
+  |
+  |-- ...
+  |
+  `-- benchmark n
+```
+
+When the harness is started, it uses the input arguments to select the benchmark,
+and then unpacks the JARs of the corresponding benchmark group into a temporary directory.
+The harness then creates a classloader that searches the unpacked JARs and loads the
+benchmark group. The class loader is created directly below the default class loader.
+Because the default class loader contains only base JRE classes and common interfaces
+of *core*, it ensures that dependencies of a benchmark are never mixed with any
+dependencies of any other benchmark or the harness.
+
+```
+        boot class loader (JDK)
+                   ^
+                   |
+          system class loader
+                (core)
+         ^                   ^
+         |                   |
+  URL class loader    URL class loader
+     (harness)          (benchmark)
+```
+
+We need to do this to, e.g., avoid accidentally resolving the wrong class
+by going through the system class loader (this can easily happen with,
+e.g. Apache Spark and Scala, due to the way that Spark internally resolves some classes).
+
+You can find further details in the top-level `build.sbt` file, and in the source code of
+the `RenaissanceSuite` and `ModuleLoader` classes.

--- a/documentation/design.md
+++ b/documentation/design.md
@@ -14,6 +14,8 @@ which must be implemented by each benchmark, and the annotations in the
 `Benchmark` interface name space, which are used to provide
 benchmark meta data, such as a summary or a detailed description.
 Consequently, each *subproject* depends on the *core* project.
+The *core* project also provides APIs that a benchmark needs to work with,
+such as the runtime configuration or the policy.
 
 Classes from the *core* are loaded (when Renaissance is started) by the default
 classloader. Classes from other projects (including the harness and individual benchmarks)
@@ -25,6 +27,13 @@ The *harness* project implements the functionality necessary to parse the input
 arguments, to run the benchmarks, to generate documentation, and so on. The *harness*
 is written in a mix of Java and Scala, and is loaded by the *core* in a separate classloader
 to ensure clean environment for running the benchmarks.
+
+The set of subprojects in the `benchmarks` directory are the individual groups of benchmarks
+that share a common set of dependencies. A group is typically thematic, relating to
+a particular framework or a JVM language, and benchmarks in different groups depend
+on a different set of libraries, or even the same libraries with different versions.
+The bundling mechanism of the suite takes care that the dependencies of the different groups
+never clash with each other.
 
 The JARs of the subprojects (benchmarks and harness) are copied as generated
 *resources* and embedded into the resulting JAR artifact.

--- a/documentation/ide.md
+++ b/documentation/ide.md
@@ -1,0 +1,11 @@
+# IDE development
+
+## IntelliJ
+
+In order to work on the project with IntelliJ, one needs to install the following plugins :
+  - `Scala` : part of the codebase uses Scala and Renaissance is organized in sbt projects.
+  - `scalafmt` (optional) : adds an action that can be triggered with `Code -> Reformat with scalafmt`
+  which will reformat the code according to the formatting rule defined in `.scalafmt.conf`
+  (same as the `renaissanceFormat` sbt task).
+
+Then, the root of the repository can be opened as an IntelliJ project.

--- a/documentation/jar-bundle.md
+++ b/documentation/jar-bundle.md
@@ -1,0 +1,32 @@
+# Renaissance JAR bundle content
+
+This document describes the structure of the JAR file with the benchmark
+(e.g., `target/renaissance-gpl-0.12.0-2-SNAPSHOT.jar`).
+
+Directly inside the JAR are classes from the `renaissance-core` subproject
+that also contain the launcher. This also ensures that these classes are
+always available when constructing a class loader with a default parent.
+
+`META-INF/MANIFEST.MF` contains -- apart from standard information -- also
+details about Git commit and Renaissance version it was built from
+(see main `build.sbt` for details).
+
+Because harness is loaded as a separate module, its JARs are stored inside
+`renaissance-harness` subdirectory as standalone files.
+
+Individual benchmark groups have separate subdirectory under `benchmarks`.
+These contain all the required JARs for one benchmark group (including Scala
+runtime libraries).
+
+The list of JARs for each benchmark group is provided inside
+`modules.properties`. Special group `renaissance-harness` contains list of JARs
+for the harness.
+
+The most complex file is `benchmarks.properties` that contains meta information
+for each benchmark. This includes the following:
+
+ * main class of the benchmark
+ * supported version of JVM (min, max)
+ * default number of iterations
+ * licensing information
+ * list of parameters and configurations (e.g., test for smaller workloads)

--- a/documentation/plugins.md
+++ b/documentation/plugins.md
@@ -1,0 +1,87 @@
+# Plugins for the Renaissance benchmarking suite
+
+The suite provides hooks for plugins which can subscribe to events related to
+harness state and benchmark execution.
+
+A plugin is a user-defined class which must implement the `Plugin` marker interface
+and provide at least a default (parameter-less) constructor.
+However, such a minimal plugin would not receive any notifications. To receive
+notifications, the plugin class must implement interfaces from the `Plugin`
+interface name space depending on the type of events it wants to receive, or services it wants
+to provide. This is demonstrated in the following example:
+
+```scala
+class SimplePlugin extends Plugin
+  with AfterHarnessInitListener
+  with AfterOperationSetUpListener
+  with BeforeOperationTearDownListener {
+
+  override def afterHarnessInit() = {
+    // Initialize the plugin after the harness finished initializing
+  }
+
+  override def afterOperationSetUp(benchmark: String, index: Int) = {
+    // Notify the tool that the measured operation is about to start.
+  }
+
+  override def beforeOperationTearDown(benchmark: String, index: Int) = {
+    // Notify the tool that the measured operations has finished.
+  }
+}
+```
+
+## Listeners
+
+The following interfaces provide common (paired) event types which allow a plugin to hook
+into a specific point in the benchmark execution sequence. They are analogous to common
+annotations known from testing frameworks such as JUnit. Harness-level events occur only
+once per the whole execution, benchmark-level events occur once for each benchmark
+executed, and operation-level events occur once for each execution of the measured
+operation.
+
+- `AfterHarnessInitListener`, `BeforeHarnessShutdownListener`
+- `BeforeBenchmarkSetUpListener`, `AfterBenchmarkTearDownListener`
+- `AfterBenchmarkSetUpListener`, `BeforeBenchmarkTearDownListener`
+- `AfterOperationSetUpListener`, `BeforeOperationTearDownListener`
+
+The following interfaces provide special non-paired event types:
+
+- `MeasurementResultListener`, intended for plugins that want to receive
+measurements results (perhaps to store them in a custom format). The harness calls the
+`onMeasurementResult` method with the name of the metric and its value, but only if the
+benchmark operation produces a valid result.
+- `BenchmarkFailureListener`, which indicates that the benchmark execution
+has either failed in some way (the benchmark triggered an exception), or that the benchmark
+operation produced a result which failed validation. This means that no measurements results
+will be received.
+
+## Services
+
+And the following interfaces are used by the harness to request
+services from plugins:
+
+- `MeasurementResultPublisher`, intended for plugins that want to collect
+values of additional metrics around the execution of the benchmark operation. The harness
+calls the `onMeasurementResultsRequested` method with an instance of event dispatcher which
+the plugin is supposed to use to notify other result listeners about custom measurement results.
+- `ExecutionPolicy`, intended for plugins that want to control the execution
+of the benchmark's measured operation. Such a plugin should implement other interfaces to
+get enough information to determine, per-benchmark, whether to execute the measured operation
+or not. The harness calls the `canExecute` method before executing the benchmark's measured
+operation, and will pass the result of the `isLast` method to some other events.
+
+## Arguments
+
+A plugin that wants to receive command line arguments (via `--with-arg`) must define
+a constructor which takes an array of strings (`String[]`) or a string vararg
+(`String...`) as parameter. The harness tries to use this constructor first and falls back
+to the default (parameter-less) constructor.
+
+
+## Packaging
+
+The plugin shall be packaged in a standard JAR, the interface classes (e.g. `Plugin`)
+are provided by the suite and shall not be part of the plugin JAR.
+
+The main class of the plugin shall be specified as a `Renaissance-Plugin` property inside
+`META-INF/MANIFEST.MF` of the plugin JAR.

--- a/plugins/jmx-timers/README.md
+++ b/plugins/jmx-timers/README.md
@@ -1,0 +1,50 @@
+# jmx-timers plugin for Renaissance suite
+
+This plugin collects information about JIT compilation times via
+[CompilationMXBean](https://docs.oracle.com/javase/7/docs/api/java/lang/management/CompilationMXBean.html).
+
+## Building
+
+To build the plugin run the following command:
+
+```shell
+../../tools/sbt/bin/sbt assembly
+```
+
+The plugin shall be available as `target/plugin-jmxtimers-assembly-VER.jar`.
+
+## Using the plugin
+
+To use the plugin, simply add it with the `--plugin` option when
+starting the suite.
+Note that we specify an output file as the counters are not visible on the
+standard output.
+
+```shell
+java renaissance-gpl-0.12.0.jar \
+  --plugin plugin-jmxtimers-assembly-0.0.1.jar\
+  --json results.json \
+  ...
+```
+
+The results in the JSON file will have the following form.
+Note that the `total` might be increasing even when the per-loop
+time stays at `0` because some compilation may happen between loops
+(i.e., outside of the measured operation).
+
+```json
+{
+  ...
+  "data": {
+    "BENCHMARK": {
+      "results": [
+        {
+          "duration_ns": 3693019,
+          ...
+          "jmx_timers_compilation_time_ms": 6,
+          "jmx_timers_compilation_total_ms": 473,
+        },
+        ...
+  ...
+}
+```

--- a/plugins/ubench-agent/README.md
+++ b/plugins/ubench-agent/README.md
@@ -1,0 +1,60 @@
+# ubench-agent plugin for Renaissance suite
+
+This plugin collects values of arbitrary hardware performance counters.
+It uses a [microbenchmarking agent](https://github.com/d-iii-s/java-ubench-agent)
+to access the counters through [PAPI](https://icl.utk.edu/papi/).
+
+## Building
+
+To build the plugin, you also need to build the native agent for JVM.
+Start by building the agent:
+
+```shell
+./build-ubench-agent.sh
+```
+
+This will fetch a supported version of the agent and build the shared
+library (it will also print a path to it to pass to JVM).
+
+Then continue building the plugin itself:
+
+```shell
+../../tools/sbt/bin/sbt assembly
+```
+
+The plugin shall be available as `target/plugin-ubenchagent-assembly-VER.jar`.
+
+## Using the plugin
+
+To use the plugin, you need to add the native agent to the JVM and register
+the plugin with the Renaissance suite (update the path according to your setup,
+i.e., whether you have built the suite and/or the agent yourself).
+Specify the events as a plugin argument.
+Note that we specify an output file as the counters are not visible on the
+standard output.
+
+```shell
+java -agentpath:libubench-agent.so-jar -jar renaissance-gpl-0.12.0.jar \
+  --plugin plugin-ubenchagent-assembly-0.0.1.jar --with-arg PAPI_L1_DCM,PAPI_L2_DCM \
+  --json results.json \
+  ...
+```
+
+The results in the JSON file will have the following form:
+
+```json
+{
+  ...
+  "data": {
+    "BENCHMARK": {
+      "results": [
+        {
+          "duration_ns": 3693019,
+          ...
+          "ubench_agent_PAPI_L1_DCM": 171866,
+          "ubench_agent_PAPI_L2_DCM": 410758
+        },
+        ...
+  ...
+}
+```

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
@@ -235,30 +235,22 @@ It is intended to be an open-source, collaborative project,
 in which the community can propose and improve benchmark workloads.
 
 
-### Building the suite
+### Running the suite
 
-To build the suite and create the so-called fat JAR (or super JAR), you only
-need to run `sbt` build tool as follows:
-
-```
-$$ tools/sbt/bin/sbt assembly
-```
-
-This will retrieve all the dependencies, compile all the benchmark projects and the harness,
-bundle the JARs and create the final JAR under the `target` directory.
-
-
-### Running the benchmarks
+To run the suite, you will need to download a Renaissance Suite JAR
+from <https://renaissance.dev/download>.
+If you wish to build it yourself, please, consult [CONTRIBUTING.md](CONTRIBUTING.md)
+for instructions on building.
 
 To run a Renaissance benchmark, you need to have a JRE installed.
 This allows you to execute the following `java` command:
 
+
 ```
-$$ java -jar '<renaissance-home>/target/renaissance-gpl-${tags("renaissanceVersion")}.jar' <benchmarks>
+$$ java -jar 'renaissance-gpl-${tags("renaissanceVersion")}.jar' <benchmarks>
 ```
 
-Above, the `<renaissance-home>` is the path to the root directory of the Renaissance distribution,
-and `<benchmarks>` is the list of benchmarks that you wish to run.
+Above, `<benchmarks>` is the list of benchmarks that you wish to run.
 For example, you can specify `scala-kmeans` as the benchmark.
 
 The suite generally executes the benchmark's measured operation multiple times. By default,
@@ -517,6 +509,19 @@ the `${tags("renaissanceSuiteClass")}` and `${tags("moduleLoaderClass")}` classe
 
     s"""
 ## Contribution Guide
+
+### Building the suite
+
+To build the suite and create the so-called fat JAR (or super JAR), you only
+need to run `sbt` build tool as follows:
+
+```
+$$ tools/sbt/bin/sbt assembly
+```
+
+This will retrieve all the dependencies, compile all the benchmark projects and the harness,
+bundle the JARs and create the final JAR under the `target` directory.
+
 
 ### Code organization and internals
 

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
@@ -335,7 +335,7 @@ the plugin (or policy) that was last mentioned on the command line. Whenever a `
 arguments to that plugin (or policy).
 
 
-#### Complete list of command-line options
+### Complete list of command-line options
 
 The following is a complete list of command-line options.
 

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
@@ -187,7 +187,7 @@ object MarkdownGenerator {
 
   private def formatBenchmarkListMarkdown(benchmarks: Seq[BenchmarkDescriptor]) = {
     def formatItem(b: BenchmarkDescriptor) = {
-      s"- `${b.name}` - ${b.summary}\n  " +
+      s"- `${b.name}` - ${b.summary}\n  \\\n  " +
         s"Default repetitions: ${b.repetitions}; " +
         s"${b.licenses.asScala.mkString(", ")} license, ${b.distro} distribution; " +
         s"Supported JVM: ${b.jvmVersionMin.map[String](_.toString).orElse("1.8")} " +

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
@@ -304,76 +304,26 @@ you will need to be able to tell the harness when to keep executing the benchmar
 stop.
 
 To this end, the suite provides hooks for plugins which can subscribe to events related to
-harness state and benchmark execution. A plugin is a user-defined class which must implement
-the `${tags("pluginClass")}` marker interface and provide at least a default (parameter-less)
-constructor. However, such a minimal plugin would not receive any notifications. To receive
-notifications, the plugin class must implement interfaces from the `${tags("pluginClass")}`
-interface name space depending on the type of events it wants to receive, or services it wants
-to provide. This is demonstrated in the following example:
+harness state and benchmark execution.
 
-```scala
-class SimplePlugin extends ${tags("pluginClass")}
-  with ${tags("afterHarnessInitListenerClass")}
-  with ${tags("afterOperationSetUpListenerClass")}
-  with ${tags("beforeOperationTearDownListenerClass")} {
+This repository contains two such plugins: one that uses a native agent built with
+[PAPI](https://icl.utk.edu/papi/) to collect information from hardware counters and
+a plugin for collecting information from a
+[CompilationMXBean](https://docs.oracle.com/javase/8/docs/api/java/lang/management/CompilationMXBean.html).
 
-  override def afterHarnessInit() = {
-    // Initialize the plugin after the harness finished initializing
-  }
-
-  override def afterOperationSetUp(benchmark: String, index: Int) = {
-    // Notify the tool that the measured operation is about to start.
-  }
-
-  override def beforeOperationTearDown(benchmark: String, index: Int) = {
-    // Notify the tool that the measured operations has finished.
-  }
-}
-```
-
-The following interfaces provide common (paired) event types which allow a plugin to hook
-into a specific point in the benchmark execution sequence. They are analogous to common
-annotations known from testing frameworks such as JUnit. Harness-level events occur only
-once per the whole execution, benchmark-level events occur once for each benchmark
-executed, and operation-level events occur once for each execution of the measured
-operation.
-- `${tags("afterHarnessInitListenerClass")}`, `${tags("beforeHarnessShutdownListenerClass")}`
-- `${tags("beforeBenchmarkSetUpListenerClass")}`, `${tags("afterBenchmarkTearDownListenerClass")}`
-- `${tags("afterBenchmarkSetUpListenerClass")}`, `${tags("beforeBenchmarkTearDownListenerClass")}`
-- `${tags("afterOperationSetUpListenerClass")}`, `${tags("beforeOperationTearDownListenerClass")}`
-
-The following interfaces provide special non-paired event types:
-- `${tags("measurementResultListenerClass")}`, intended for plugins that want to receive
-measurements results (perhaps to store them in a custom format). The harness calls the
-`onMeasurementResult` method with the name of the metric and its value, but only if the
-benchmark operation produces a valid result.
-- `${tags("benchmarkFailureListenerClass")}`, which indicates that the benchmark execution
-has either failed in some way (the benchmark triggered an exception), or that the benchmark
-operation produced a result which failed validation. This means that no measurements results
-will be received.
-
-And finally the following interfaces are used by the harness to request
-services from plugins:
-- `${tags("measurementResultPublisherClass")}`, intended for plugins that want to collect
-values of additional metrics around the execution of the benchmark operation. The harness
-calls the `onMeasurementResultsRequested` method with an instance of event dispatcher which
-the plugin is supposed to use to notify other result listeners about custom measurement results.
-- `${tags("policyClass")}`, intended for plugins that want to control the execution
-of the benchmark's measured operation. Such a plugin should implement other interfaces to
-get enough information to determine, per-benchmark, whether to execute the measured operation
-or not. The harness calls the `canExecute` method before executing the benchmark's measured
-operation, and will pass the result of the `isLast` method to some other events.
+If you wish to create your own plugin, please consult
+[documentation/plugins.md](documentation/plugins.md) for more details.
 
 To make the harness use an external plugin, it needs to be specified on the command line.
 The harness can load multiple plugins, and each must be enabled using the
 `--plugin <class-path>[!<class-name>]` option. The `<class-path>` is the class path on which
-to look for the plugin class, and `<class-name>` is a fully qualified name of the plugin class
-(the class-name can be omitted when specified as a `Renaissance-Plugin` property inside
-`META-INF/MANIFEST.MF` of the plugin JAR).
+to look for the plugin class (optionally, you may add `<class-name>` to specify a fully
+qualified name of the plugin class).
+
 Custom execution policy must be enabled using the `--policy <class-path>!<class-name>` option.
 The syntax is the same as in case of normal plugins (and the policy is also a plugin, which
 can register for all event types), but this option tells the harness to actually use the
-plugin to control benchmark execution. Other than that, policy is treated the same was as
+plugin to control benchmark execution. Other than that, policy is treated the same way as a
 plugin.
 
 When registering plugins for pair events (harness init/shutdown, benchmark set up/tear down,
@@ -387,10 +337,7 @@ Plugins (and policies) can receive additional command line arguments. Each argum
 given using the `--with-arg <arg>` option, which appends `<arg>` to the list of arguments for
 the plugin (or policy) that was last mentioned on the command line. Whenever a `--plugin`
 (or `--policy`) option is encountered, the subsequent `--with-arg` options will append
-arguments to that plugin (or policy). A plugin that wants to receive command line arguments
-must define a constructor which takes an array of strings (`String[]`) or a string vararg
-(`String...`) as parameter. The harness tries to use this constructor first and falls back
-to the default (parameter-less) constructor.
+arguments to that plugin (or policy).
 
 
 ### JMH support

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
@@ -269,16 +269,6 @@ The list below contains the licensing information (and JVM version requirements)
 for each benchmark.
 
 
-
-#### Complete list of command-line options
-
-The following is a complete list of command-line options.
-
-```
-${tags("harnessUsage")}
-```
-
-
 ### List of benchmarks
 
 The following is the complete list of benchmarks, separated into groups.
@@ -342,6 +332,15 @@ given using the `--with-arg <arg>` option, which appends `<arg>` to the list of 
 the plugin (or policy) that was last mentioned on the command line. Whenever a `--plugin`
 (or `--policy`) option is encountered, the subsequent `--with-arg` options will append
 arguments to that plugin (or policy).
+
+
+#### Complete list of command-line options
+
+The following is a complete list of command-line options.
+
+```
+${tags("harnessUsage")}
+```
 
 
 ### JMH support

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
@@ -377,78 +377,12 @@ requirements) for all the benchmarks:
 ${tags("benchmarksTable")}
 
 
-### Design overview
+### Documentation
 
-The Renaissance benchmark suite is organized into several `sbt` projects:
+Apart from documentation embedded directly in the source code, further
+information about design and internals of the suite can be found in the
+`documentation` folder of this project.
 
-- the `renaissance-core` folder that contains a set of *core* classes
-  (common interfaces and a harness launcher)
-- the `renaissance-harness` folder that contains the actual harness
-- the `benchmarks` folder contains a set of *subprojects*, each containing a set of benchmarks
-  for a specific domain (and having a separate set of dependencies)
-
-The *core* project is written in pure Java, and it contains the basic benchmark API.
-Its most important elements are the `${tags("benchmarkClass")}` interface,
-which must be implemented by each benchmark, and the annotations in the
-`${tags("benchmarkClass")}` interface name space, which are used to provide
-benchmark meta data, such as a summary or a detailed description.
-Consequently, each *subproject* depends on the *core* project.
-
-Classes from the *core* are loaded (when Renaissance is started) by the default
-classloader. Classes from other projects (including the harness and individual benchmarks)
-and external plugins or execution policies are loaded by separate classloaders. This
-separation helps ensure that there are no clashes between dependencies of different
-projects (each benchmark may depend on different versions of external libraries).
-
-The *harness* project implements the functionality necessary to parse the input
-arguments, to run the benchmarks, to generate documentation, and so on. The *harness*
-is written in a mix of Java and Scala, and is loaded by the *core* in a separate classloader
-to ensure clean environment for running the benchmarks.
-
-The JARs of the subprojects (benchmarks and harness) are copied as generated
-*resources* and embedded into the resulting JAR artifact.
-
-```
-renaissance-core
-  ^
-  | (classpath dependencies)
-  |
-  |-- renaissance harness
-  |
-  |-- benchmark one
-  | `-- dependencies for benchmark one
-  |
-  |-- ...
-  |
-  `-- benchmark n
-```
-
-When the harness is started, it uses the input arguments to select the benchmark,
-and then unpacks the JARs of the corresponding benchmark group into a temporary directory.
-The harness then creates a classloader that searches the unpacked JARs and loads the
-benchmark group. The class loader is created directly below the default class loader.
-Because the default class loader contains only base JRE classes and common interfaces
-of *core*, it ensures that dependencies of a benchmark are never mixed with any
-dependencies of any other benchmark or the harness.
-
-```
-        boot class loader (JDK)
-                   ^
-                   |
-          system class loader
-                (core)
-         ^                   ^
-         |                   |
-  URL class loader    URL class loader
-     (harness)          (benchmark)
-```
-
-We need to do this to, e.g., avoid accidentally resolving the wrong class
-by going through the system class loader (this can easily happen with,
-e.g. Apache Spark and Scala, due to the way that Spark internally resolves some classes).
-
-You can find further details in the top-level `build.sbt` file, and in the source code of
-the `${tags("renaissanceSuiteClass")}` and `${tags("moduleLoaderClass")}` classes.
 """
   }
 

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
@@ -398,27 +398,14 @@ This will retrieve all the dependencies, compile all the benchmark projects and 
 bundle the JARs and create the final JAR under the `target` directory.
 
 
-### Code organization and internals
-
-The code is organized into three main parts:
-
-- `renaissance-core`: these are the core APIs that a benchmark needs to work with,
-  such as the runtime configuration, the benchmark base class or the policy.
-- `renaissance-harness`: this is the overall suite project, which is responsible for
-  parsing the arguments, loading the classes, and running the benchmark.
-- a set of projects in the `benchmarks` directory: these are the individual groups of benchmarks
-  that share a common set of dependencies. A group is typically thematic, relating to
-  a particular framework or a JVM language, and benchmarks in different groups depend
-  on a different set of libraries, or even the same libraries with different versions.
-  The bundling mechanism of the suite takes care that the dependencies of the different groups
-  never clash with each other.
-
-
 ### Adding a new benchmark
 
 To add a new benchmark to an existing group, identify the respective project
 in the `benchmarks` directory, and add a new top-level Scala (Java) class
 that extends (implements) the `${tags("benchmarkClass")}` interface.
+
+We recommend you also consult [Design overview document](documentation/design.md)
+to understand how the whole project is organized.
 
 Here is an example:
 

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
@@ -109,7 +109,6 @@ object MarkdownGenerator {
     // Don't list dummy benchmarks in the benchmark table to reduce clutter.
     val realBenchmarks = selectBenchmarks(!_.groups().contains("dummy"))
     tags("benchmarksList") = formatBenchmarkListMarkdown(realBenchmarks)
-    tags("benchmarksTable") = formatBenchmarkTableMarkdown(realBenchmarks)
 
     // List dummy benchmarks separately.
     val dummyBenchmarks = selectBenchmarks(_.groups().contains("dummy"))
@@ -188,7 +187,11 @@ object MarkdownGenerator {
 
   private def formatBenchmarkListMarkdown(benchmarks: Seq[BenchmarkDescriptor]) = {
     def formatItem(b: BenchmarkDescriptor) = {
-      s"- `${b.name}` - ${b.summary} (default repetitions: ${b.repetitions})"
+      s"- `${b.name}` - ${b.summary}\n  " +
+        s"Default repetitions: ${b.repetitions}; " +
+        s"${b.licenses.asScala.mkString(", ")} license, ${b.distro} distribution; " +
+        s"Supported JVM: ${b.jvmVersionMin.map[String](_.toString).orElse("1.8")} " +
+          s"${b.jvmVersionMax.map[String]("- " + _.toString).orElse("and later")}"
     }
 
     val result = new StringBuffer
@@ -202,20 +205,6 @@ object MarkdownGenerator {
     }
 
     result.toString
-  }
-
-  private def formatBenchmarkTableMarkdown(benchmarks: Seq[BenchmarkDescriptor]) = {
-    def formatRow(b: BenchmarkDescriptor) = {
-      s"| ${b.name} | ${b.licenses.asScala.mkString(", ")} | ${b.distro} " +
-        s"| ${b.jvmVersionMin.map[String](_.toString).orElse("")} " +
-        s"| ${b.jvmVersionMax.map[String](_.toString).orElse("")} |"
-    }
-
-    // Don't list dummy benchmarks in the benchmark table to reduce clutter.
-    benchmarks
-      .sortBy(_.name())
-      .map(formatRow)
-      .mkString("\n")
   }
 
   def formatReadme(tags: Map[String, String]): String = {
@@ -264,6 +253,21 @@ times or executed for a long time. The number of repetitions and the execution t
 set for all benchmarks using the `-r` or `-t` options. More fine-grained control over benchmark
 execution can be achieved by providing the harness with a plugin implementing a custom execution
 policy (see [below](#plugins) for details).
+
+
+### Licensing
+
+The Renaissance Suite comes in two distributions,
+and is available under both the MIT license and the GPL3 license.
+The GPL distribution with all the benchmarks is licensed under the GPL3 license,
+while the MIT distribution includes only those benchmarks that themselves
+have less restrictive licenses.
+
+Depending on your needs, you can use either of the two distributions.
+
+The list below contains the licensing information (and JVM version requirements)
+for each benchmark.
+
 
 
 #### Complete list of command-line options
@@ -358,23 +362,6 @@ $$ java -jar '${tags("jmhTargetPath")}/${tags("jmhJarPrefix")}-${tags("renaissan
 ### Contributing
 
 Please see the [contribution guide](CONTRIBUTING.md) for a description of the contribution process.
-
-
-### Licensing
-
-The Renaissance Suite comes in two distributions,
-and is available under both the MIT license and the GPL3 license.
-The GPL distribution with all the benchmarks is licensed under the GPL3 license,
-while the MIT distribution includes only those benchmarks that themselves
-have less restrictive licenses.
-
-Depending on your needs, you can use either of the two distributions.
-The following table contains the licensing information (and JVM version
-requirements) for all the benchmarks:
-
-| Benchmark        | Licenses   | Distro | JVM required (min) | JVM supported (max) |
-| :--------------- | :--------- | :----: | :----------------: | :-----------------: |
-${tags("benchmarksTable")}
 
 
 ### Documentation

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
@@ -191,7 +191,7 @@ object MarkdownGenerator {
         s"Default repetitions: ${b.repetitions}; " +
         s"${b.licenses.asScala.mkString(", ")} license, ${b.distro} distribution; " +
         s"Supported JVM: ${b.jvmVersionMin.map[String](_.toString).orElse("1.8")} " +
-          s"${b.jvmVersionMax.map[String]("- " + _.toString).orElse("and later")}"
+        s"${b.jvmVersionMax.map[String]("- " + _.toString).orElse("and later")}"
     }
 
     val result = new StringBuffer

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
@@ -304,6 +304,7 @@ This repository contains two such plugins: one that uses a native agent built wi
 [PAPI](https://icl.utk.edu/papi/) to collect information from hardware counters and
 a plugin for collecting information from a
 [CompilationMXBean](https://docs.oracle.com/javase/8/docs/api/java/lang/management/CompilationMXBean.html).
+See their respective READMEs under the `plugin` directory for more information.
 
 If you wish to create your own plugin, please consult
 [documentation/plugins.md](documentation/plugins.md) for more details.

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
@@ -370,6 +370,13 @@ Apart from documentation embedded directly in the source code, further
 information about design and internals of the suite can be found in the
 `documentation` folder of this project.
 
+
+### Support
+
+When you find a bug in the suite, when you want to propose a new benchmark or
+ask for help, please, open an [Issue](https://github.com/renaissance-benchmarks/renaissance/issues)
+at the project page at GitHub.
+
 """
   }
 

--- a/tools/ci/check-markdown.sh
+++ b/tools/ci/check-markdown.sh
@@ -2,4 +2,4 @@
 source "$(dirname "$0")/common.sh"
 
 # Check that the generated markdown files are up-to-date
-java -jar "$RENAISSANCE_JAR" --readme && git diff --exit-code -- :/README.md :/CONTRIBUTING.md
+java -jar "$RENAISSANCE_JAR" --readme && git diff --exit-code -- :/README.md

--- a/tools/pre-push
+++ b/tools/pre-push
@@ -33,7 +33,7 @@ echo "Format check passed."
 echo ""
 
 
-# Check that README.md and CONTRIBUTING.md are up-to-date.
+# Check that README.md is up-to-date.
 echo ":: Running pre-push markdown check ::"
 
 RENAISSANCE_GIT_VERSION=$(git describe --dirty=-SNAPSHOT)
@@ -42,8 +42,8 @@ RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}
 java -jar "$ROOT_DIR/target/renaissance-gpl-$RENAISSANCE_VERSION.jar" --readme || \
 	abort_push "Check failed: unable to launch Renaissance!"
 
-git diff --exit-code -- README.md CONTRIBUTING.md || \
-	abort_push "Check failed: README.md or CONTRIBUTING.md is outdated!"
+git diff --exit-code -- README.md || \
+	abort_push "Check failed: README.md is outdated!"
 
 echo "Markdown check passed."
 echo ""


### PR DESCRIPTION
Various bits of missing documentation (not ready for merging, opening PR to track progress).

I was also wondering whether not to split a bit more README.md and CONTRIBUTING.md. The README now is quite long and mixes things for users as well as for developers. I would rather have the README shorter with instructions on how to run it (assuming the user downloaded a release) and keep separate documents for building and about the design.
