### PR TITLE
CI: test on JDK17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
           - openjdk14
           - openjdk15
           - openjdk16
+          - openjdk17
           - openj9-openjdk8
           - openj9-openjdk11
           - openj9-openjdk16

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
   macos:
     strategy:
       matrix:
-        java: [ '8', '11', '13', '15' ]
+        java: [ '8', '11', '13', '15', '17' ]
     runs-on: macos-latest
     continue-on-error: true
     steps:
@@ -116,9 +116,21 @@ jobs:
           fetch-depth: 0
       - name: Setup correct Java version
         uses: actions/setup-java@v2
+        if: ${{ matrix.java != '17' }}
         with:
           distribution: adopt
           java-version: ${{ matrix.java }}
+      - name: Fetch JDK 17
+        if: ${{ matrix.java == '17' }}
+        run: |
+          aria2c -d ${{ runner.temp }} -o openjdk-17_macos-x64_bin.tar.gz https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_macos-x64_bin.tar.gz
+      - name: Setup JDK 17
+        uses: actions/setup-java@v2
+        if: ${{ matrix.java == '17' }}
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: jdkfile
+          jdkFile: ${{ runner.temp }}/openjdk-17_macos-x64_bin.tar.gz
 
       - name: Environment configuration
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,7 @@ jobs:
   windows:
     strategy:
       matrix:
-        java: [ '8', '11' , '13', '15' ]
+        java: [ '8', '11' , '13', '15', '17' ]
     runs-on: windows-latest
     continue-on-error: true
     steps:
@@ -165,9 +165,21 @@ jobs:
           fetch-depth: 0
       - name: Setup correct Java version
         uses: actions/setup-java@v2
+        if: ${{ matrix.java != '17' }}
         with:
           distribution: adopt
           java-version: ${{ matrix.java }}
+      - name: Fetch JDK 17
+        if: ${{ matrix.java == '17' }}
+        run: |
+          aria2c -d ${{ runner.temp }} -o openjdk-17_windows-x64_bin.zip https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_windows-x64_bin.zip
+      - name: Setup JDK 17
+        uses: actions/setup-java@v2
+        if: ${{ matrix.java == '17' }}
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: jdkfile
+          jdkFile: ${{ runner.temp }}/openjdk-17_windows-x64_bin.zip
 
       - name: Environment configuration
         shell: bash

--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -49,7 +49,7 @@ cp_reflink() {
 }
 
 get_jvm_workaround_args() {
-    if [ "$RENAISSANCE_JVM_MAJOR_VERSION" = "16" ]; then
+    if [ "$RENAISSANCE_JVM_MAJOR_VERSION" = "16" -o "$RENAISSANCE_JVM_MAJOR_VERSION" = "17" ]; then
         echo "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
         echo "--add-opens=java.base/java.util=ALL-UNNAMED"
         echo "--add-opens=java.base/java.nio=ALL-UNNAMED"

--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -22,8 +22,10 @@ RENAISSANCE_GIT_VERSION=$(git describe --tags --always --dirty=-SNAPSHOT || echo
 RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}
 
 # Try to guess JVM version (and replace 1.8 with 8)
+# The awful splitting and use of 'NN*' instead of 'N\+' is because
+# we need to support non-GNU sed too
 RENAISSANCE_JVM_MAJOR_VERSION="$( java -version 2>&1 \
-    | sed -n -e '/version[[:blank:]]\+"/ { s/.*version[[:blank:]]\+"\([^"]*\)".*/\1/; s/1[.]8/8/; s/^\([^.]*\)[.].*/\1/; p }' \
+    | sed -n -e '/version[[:blank:]][[:blank:]]*"/{' -e 's/.*version[[:blank:]][[:blank:]]*"\([^"]*\)".*/\1/; s/1[.]8/8/; s/^\([^.]*\)[.].*/\1/; p' -e '}' \
     || echo 8 )"
 
 # The base bundle


### PR DESCRIPTION
Follow-up to PR #297.

JDK17 for Mac and Windows is not yet available, tracked here: actions/setup-java#229
