### PR TITLE
Set length of abbreviated commit id in git describe

### DIFF
--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -16,7 +16,7 @@ ROOT_DIR="$(git rev-parse --show-toplevel || realpath "$( dirname "$0" )/../../"
 CACHE_DIR="$HOME/.prebuilt"
 
 # Raw version as produced by git
-RENAISSANCE_GIT_VERSION=$(git describe --tags --always --dirty=-SNAPSHOT || echo "ci-SNAPSHOT" )
+RENAISSANCE_GIT_VERSION=$(git describe --tags --always --abbrev=7 --dirty=-SNAPSHOT || echo "ci-SNAPSHOT" )
 
 # Strip leading 'v' from the git-produced version
 RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}

--- a/tools/pre-push
+++ b/tools/pre-push
@@ -36,7 +36,7 @@ echo ""
 # Check that README.md is up-to-date.
 echo ":: Running pre-push markdown check ::"
 
-RENAISSANCE_GIT_VERSION=$(git describe --dirty=-SNAPSHOT)
+RENAISSANCE_GIT_VERSION=$(git describe --abbrev=7 --dirty=-SNAPSHOT)
 RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}
 
 java -jar "$ROOT_DIR/target/renaissance-gpl-$RENAISSANCE_VERSION.jar" --readme || \

--- a/tools/renaissance-jmh.sh
+++ b/tools/renaissance-jmh.sh
@@ -2,7 +2,7 @@
 
 BASE_DIR="$(dirname "$0")"
 ROOT_DIR="$(git -C "$BASE_DIR" rev-parse --show-toplevel)"
-RENAISSANCE_GIT_VERSION=$(git -C "$BASE_DIR" describe --dirty=-SNAPSHOT)
+RENAISSANCE_GIT_VERSION=$(git -C "$BASE_DIR" describe --abbrev=7 --dirty=-SNAPSHOT)
 RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}
 
 exec java $JAVA_OPTS -jar "$ROOT_DIR/renaissance-jmh/target/scala-2.12/renaissance-jmh-assembly-$RENAISSANCE_VERSION.jar" "$@"

--- a/tools/renaissance.sh
+++ b/tools/renaissance.sh
@@ -2,7 +2,7 @@
 
 BASE_DIR="$(dirname "$0")"
 ROOT_DIR="$(git -C "$BASE_DIR" rev-parse --show-toplevel)"
-RENAISSANCE_GIT_VERSION=$(git -C "$BASE_DIR" describe --dirty=-SNAPSHOT)
+RENAISSANCE_GIT_VERSION=$(git -C "$BASE_DIR" describe --abbrev=7 --dirty=-SNAPSHOT)
 RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}
 
 exec java $JAVA_OPTS -jar "$ROOT_DIR/target/renaissance-gpl-$RENAISSANCE_VERSION.jar" "$@"


### PR DESCRIPTION
This seems to be needed because the command (as used in various scripts) suddenly started returning commit id with one extra
character, resulting in a mismatch between `git describe` and the git-described version produced by the `sbt-git` plugin (at least on my machine with git 2.31.1). Due to this, the pre-push readme check fails to find the right JAR and aborts the push.