### PR TITLE
Add release notes for the upcoming v0.13.0

### DIFF
--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -16,7 +16,7 @@ ROOT_DIR="$(git rev-parse --show-toplevel || realpath "$( dirname "$0" )/../../"
 CACHE_DIR="$HOME/.prebuilt"
 
 # Raw version as produced by git
-RENAISSANCE_GIT_VERSION=$(git describe --tags --always --dirty=-SNAPSHOT || echo "ci-SNAPSHOT" )
+RENAISSANCE_GIT_VERSION=$(git describe --tags --always --abbrev=7 --dirty=-SNAPSHOT || echo "ci-SNAPSHOT" )
 
 # Strip leading 'v' from the git-produced version
 RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}

--- a/tools/pre-push
+++ b/tools/pre-push
@@ -36,7 +36,7 @@ echo ""
 # Check that README.md is up-to-date.
 echo ":: Running pre-push markdown check ::"
 
-RENAISSANCE_GIT_VERSION=$(git describe --dirty=-SNAPSHOT)
+RENAISSANCE_GIT_VERSION=$(git describe --abbrev=7 --dirty=-SNAPSHOT)
 RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}
 
 java -jar "$ROOT_DIR/target/renaissance-gpl-$RENAISSANCE_VERSION.jar" --readme || \

--- a/tools/renaissance-jmh.sh
+++ b/tools/renaissance-jmh.sh
@@ -2,7 +2,7 @@
 
 BASE_DIR="$(dirname "$0")"
 ROOT_DIR="$(git -C "$BASE_DIR" rev-parse --show-toplevel)"
-RENAISSANCE_GIT_VERSION=$(git -C "$BASE_DIR" describe --dirty=-SNAPSHOT)
+RENAISSANCE_GIT_VERSION=$(git -C "$BASE_DIR" describe --abbrev=7 --dirty=-SNAPSHOT)
 RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}
 
 exec java $JAVA_OPTS -jar "$ROOT_DIR/renaissance-jmh/target/scala-2.12/renaissance-jmh-assembly-$RENAISSANCE_VERSION.jar" "$@"

--- a/tools/renaissance.sh
+++ b/tools/renaissance.sh
@@ -2,7 +2,7 @@
 
 BASE_DIR="$(dirname "$0")"
 ROOT_DIR="$(git -C "$BASE_DIR" rev-parse --show-toplevel)"
-RENAISSANCE_GIT_VERSION=$(git -C "$BASE_DIR" describe --dirty=-SNAPSHOT)
+RENAISSANCE_GIT_VERSION=$(git -C "$BASE_DIR" describe --abbrev=7 --dirty=-SNAPSHOT)
 RENAISSANCE_VERSION=${RENAISSANCE_GIT_VERSION#v}
 
 exec java $JAVA_OPTS -jar "$ROOT_DIR/target/renaissance-gpl-$RENAISSANCE_VERSION.jar" "$@"

--- a/website/_posts/2021-07-07-renaissance-0-12-0.md
+++ b/website/_posts/2021-07-07-renaissance-0-12-0.md
@@ -6,13 +6,12 @@ author: Lubomír Bulej
 ---
 
 We are pleased to announce a new release of the Renaissance benchmark
-suite.
-
-Apart from a number of internal cleanups, most changes in this release
-focused on improving compatibility with modern platforms. Most notably,
-we have moved away from Scala 2.11, Scala 2.12, and Spark 2 towards
-Scala 2.12, Scala 2.13 and Spark 3. Some benchmarks were unaffected,
-some needed just dependency updates, and some needed a bit more work.
+suite. Apart from a number of internal cleanups, most changes in this
+release focused on improving compatibility with modern platforms. Most
+notably, we have moved away from Scala 2.11, Scala 2.12, and Spark 2
+towards Scala 2.12, Scala 2.13 and Spark 3. Some benchmarks were
+unaffected, some needed just dependency updates, and some needed a bit
+more work.
 
 The workloads, as implemented by the benchmarks, are largely unchanged,
 but the code being executed as a result of the benchmark workload may
@@ -93,8 +92,8 @@ notable changes in some of them:
 - `rx-scrabble` (Java)
 - `scala-kmeans` (previously Scala 2.12.8)
 - `scala-doku` (previously Scala 2.11.7)
-  - Bundled `cafesat` dependency updated (0.01 -> (0.01-28-gd0edeaa)[https://github.com/renaissance-benchmarks/dependency-cafesat/tree/renaissance/export]) and cleaned up for Scala 2.13
-  - Bundled `scala-smtlib` dependency updated (0.1 -> (0.2.1-52-ga71d6b0)[https://github.com/renaissance-benchmarks/dependency-scala-smtlib/tree/renaissance/export]) and cleaned up for Scala 2.13
+  - Bundled `cafesat` dependency updated (0.01 -> [0.01-28-gd0edeaa](https://github.com/renaissance-benchmarks/dependency-cafesat/tree/renaissance/export)) and cleaned up for Scala 2.13
+  - Bundled `scala-smtlib` dependency updated (0.1 -> [0.2.1-52-ga71d6b0]([https://github.com/renaissance-benchmarks/dependency-scala-smtlib/tree/renaissance/export)) and cleaned up for Scala 2.13
 
 
 ### Benchmarks using Scala 2.12.14
@@ -110,6 +109,6 @@ notable changes in some them:
   - Requires JVM versions between 11 and 15, inclusive (Neo4J requirements).
 - `philosophers`, `scala-stm-bench7` (previously Scala 2.12.3)
 - `reactors` (previously Scala 2.11.8)
-  - `io.reactors.reactors-core` updated (0.7 -> (0.9-e605e145-60-g9838414)[https://github.com/renaissance-benchmarks/dependency-reactors/tree/renaissance/export]) and cleaned up for Scala 2.12
+  - `io.reactors.reactors-core` updated (0.7 -> [0.9-e605e145-60-g9838414](https://github.com/renaissance-benchmarks/dependency-reactors/tree/renaissance/export)) and cleaned up for Scala 2.12
 - Spark workloads (previously Scala 2.11.8)
-  - See **Spark benchmark changes** above.
+  - See [Spark benchmark changes](#spark-benchmark-changes) above.

--- a/website/_posts/2021-09-16-renaissance-0-13-0.md
+++ b/website/_posts/2021-09-16-renaissance-0-13-0.md
@@ -1,0 +1,35 @@
+---
+layout: mainpost
+projectname: Renaissance Suite
+title:  "Renaissance 0.13 Released"
+author: Lubomír Bulej
+---
+
+We are pleased to announce a new release of the Renaissance benchmark
+suite. This release is primarily a **JDK compatibility update**, introducing
+support for the newly released JDK17. The Renaissance suite now supports
+the complete set of LTS releases of the JDK (JDK8, JDK11, and JDK17) on
+Linux, MacOS X, and Windows. A few benchmarks have dependencies that limit
+their compatibility to a particular range of JDK versions and these are 
+automatically excluded when running the suite on an unsupported JDK.
+
+The changes in this release are minimal. The most important one just brings
+the Scala 2.12 benchmarks over to Scala 2.12.15, which now properly supports
+JDK17 -- we merely pass on the compatibility improvements provided by the
+Scala community! This change affects the following benchmarks, which were
+previously using Scala 2.12.14:
+
+- `finagle-chirper`, `finagle-http`
+- `neo4j-analytics`
+- `philosophers`, `scala-stm-bench7`
+- `reactors`
+- all `apache-spark` workloads
+
+Here we just want to note that *no benchmark code has been changed* in this
+release, only project documentation and parts of the harness responsible for
+plugin loading (plugin main class can be now specified in its manifest).
+
+
+We welcome any comments and contributions.
+
+Happy benchmarking!


### PR DESCRIPTION
There is also a draft of GitHub release (shorter) that you should be able to see. If we are fine with this, I'll go ahead with the release.
Note: this is built on top of #299 so that I can push to GitHub.