### PR TITLE
Make system info dump more resilient

### DIFF
--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -187,16 +187,14 @@ private final class JsonWriter(val jsonFile: Path) extends ResultWriter {
     os match {
       case unixOs: UnixOperatingSystemMXBean =>
         // Gag possible exceptions.
-        Try(
-          result ++= Seq(
-            "phys_mem_total" -> unixOs.getTotalPhysicalMemorySize.toJson,
-            "phys_mem_free" -> unixOs.getFreePhysicalMemorySize.toJson,
-            "virt_mem_committed" -> unixOs.getCommittedVirtualMemorySize.toJson,
-            "swap_space_total" -> unixOs.getTotalSwapSpaceSize.toJson,
-            "swap_space_free" -> unixOs.getFreeSwapSpaceSize.toJson,
-            "max_fd_count" -> unixOs.getMaxFileDescriptorCount.toJson,
-            "open_fd_count" -> unixOs.getOpenFileDescriptorCount.toJson
-          )
+        result ++= Seq(
+          "phys_mem_total" -> Try(unixOs.getTotalPhysicalMemorySize).toOption.toJson,
+          "phys_mem_free" -> Try(unixOs.getFreePhysicalMemorySize).toOption.toJson,
+          "virt_mem_committed" -> Try(unixOs.getCommittedVirtualMemorySize).toOption.toJson,
+          "swap_space_total" -> Try(unixOs.getTotalSwapSpaceSize).toOption.toJson,
+          "swap_space_free" -> Try(unixOs.getFreeSwapSpaceSize).toOption.toJson,
+          "max_fd_count" -> Try(unixOs.getMaxFileDescriptorCount).toOption.toJson,
+          "open_fd_count" -> Try(unixOs.getOpenFileDescriptorCount).toOption.toJson
         )
 
       // No extra information to collect on non-Unix systems.

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -16,6 +16,7 @@ import java.nio.file.StandardOpenOption
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.TimeZone
+import scala.util.Try
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
@@ -157,7 +158,13 @@ private final class JsonWriter(val jsonFile: Path) extends ResultWriter {
 
   private def systemPropertyAsJson(name: String) = Option(System.getProperty(name)).toJson
 
-  private def pathsAsJson(pathSpec: String) = pathSpec.split(File.pathSeparator).toJson
+  private def pathsAsJson(pathSpec: String) = {
+    if (pathSpec != null) {
+      pathSpec.split(File.pathSeparator).toJson
+    } else {
+      Array.empty[String].toJson
+    }
+  }
 
   private def getEnvironment(normalTermination: Boolean) = {
     Map(
@@ -179,14 +186,17 @@ private final class JsonWriter(val jsonFile: Path) extends ResultWriter {
 
     os match {
       case unixOs: UnixOperatingSystemMXBean =>
-        result ++= Seq(
-          "phys_mem_total" -> unixOs.getTotalPhysicalMemorySize.toJson,
-          "phys_mem_free" -> unixOs.getFreePhysicalMemorySize.toJson,
-          "virt_mem_committed" -> unixOs.getCommittedVirtualMemorySize.toJson,
-          "swap_space_total" -> unixOs.getTotalSwapSpaceSize.toJson,
-          "swap_space_free" -> unixOs.getFreeSwapSpaceSize.toJson,
-          "max_fd_count" -> unixOs.getMaxFileDescriptorCount.toJson,
-          "open_fd_count" -> unixOs.getOpenFileDescriptorCount.toJson
+        // Gag possible exceptions.
+        Try(
+          result ++= Seq(
+            "phys_mem_total" -> unixOs.getTotalPhysicalMemorySize.toJson,
+            "phys_mem_free" -> unixOs.getFreePhysicalMemorySize.toJson,
+            "virt_mem_committed" -> unixOs.getCommittedVirtualMemorySize.toJson,
+            "swap_space_total" -> unixOs.getTotalSwapSpaceSize.toJson,
+            "swap_space_free" -> unixOs.getFreeSwapSpaceSize.toJson,
+            "max_fd_count" -> unixOs.getMaxFileDescriptorCount.toJson,
+            "open_fd_count" -> unixOs.getOpenFileDescriptorCount.toJson
+          )
         )
 
       // No extra information to collect on non-Unix systems.


### PR DESCRIPTION
Substrate VM does not support some of the system info queries we do when dumping JSON.

```
SEVERE: Harness failed with com.oracle.svm.core.jdk.UnsupportedFeatureError: OperatingSystemMXBean methods
	at com.oracle.svm.core.util.VMError.unsupportedFeature(VMError.java:87)
	at com.oracle.svm.core.jdk.management.SubstrateOperatingSystemMXBean.getFreePhysicalMemorySize(SubstrateOperatingSystemMXBean.java:107)
	at org.renaissance.harness.JsonWriter.getOsInfo(ResultWriter.scala:184)
	at org.renaissance.harness.JsonWriter.getEnvironment(ResultWriter.scala:164)
	at org.renaissance.harness.JsonWriter.store(ResultWriter.scala:363)
	at org.renaissance.harness.ResultWriter.org$renaissance$harness$ResultWriter$$storeResults(ResultWriter.scala:63)
	at org.renaissance.harness.ResultWriter.beforeHarnessShutdown(ResultWriter.scala:67)
	at org.renaissance.harness.EventDispatcher.notifyBeforeHarnessShutdown(EventDispatcher.java:76)
	at org.renaissance.harness.RenaissanceSuite$.runBenchmarks(RenaissanceSuite.scala:163)
	at org.renaissance.harness.RenaissanceSuite$.main(RenaissanceSuite.scala:117)
	at org.renaissance.harness.RenaissanceSuite.main(RenaissanceSuite.scala)
	at java.lang.reflect.Method.invoke(Method.java:566)
	at org.renaissance.core.Launcher.loadAndInvokeHarnessClass(Launcher.java:114)
	at org.renaissance.core.Launcher.launchHarnessClass(Launcher.java:73)
	at org.renaissance.core.Launcher.main(Launcher.java:37)
```

The runtime can return some paths as NULL.

```
SEVERE: Harness failed with java.lang.NullPointerException
	at org.renaissance.harness.JsonWriter.pathsAsJson(ResultWriter.scala:161)
	at org.renaissance.harness.JsonWriter.getJreInfo(ResultWriter.scala:241)
	at org.renaissance.harness.JsonWriter.getEnvironment(ResultWriter.scala:167)
	at org.renaissance.harness.JsonWriter.store(ResultWriter.scala:367)
	at org.renaissance.harness.ResultWriter.org$renaissance$harness$ResultWriter$$storeResults(ResultWriter.scala:64)
	at org.renaissance.harness.ResultWriter.beforeHarnessShutdown(ResultWriter.scala:68)
	at org.renaissance.harness.EventDispatcher.notifyBeforeHarnessShutdown(EventDispatcher.java:76)
	at org.renaissance.harness.RenaissanceSuite$.runBenchmarks(RenaissanceSuite.scala:163)
	at org.renaissance.harness.RenaissanceSuite$.main(RenaissanceSuite.scala:117)
	at org.renaissance.harness.RenaissanceSuite.main(RenaissanceSuite.scala)
	at java.lang.reflect.Method.invoke(Method.java:566)
	at org.renaissance.core.Launcher.loadAndInvokeHarnessClass(Launcher.java:114)
	at org.renaissance.core.Launcher.launchHarnessClass(Launcher.java:73)
	at org.renaissance.core.Launcher.main(Launcher.java:37)
```
