### PR TITLE
Update and unify JNA

### DIFF
--- a/benchmarks/database/build.sbt
+++ b/benchmarks/database/build.sbt
@@ -23,7 +23,7 @@ lazy val database = (project in file("."))
         ExclusionRule("org.slf4j", "slf4j-api")
       ),
       // Force newer JNA to support more platforms/architectures.
-      "net.java.dev.jna" % "jna-platform" % "5.9.0",
+      "net.java.dev.jna" % "jna-platform" % "5.10.0",
       // Add simple binding to silence SLF4J warnings.
       "org.slf4j" % "slf4j-simple" % "1.7.32"
     )

--- a/benchmarks/database/build.sbt
+++ b/benchmarks/database/build.sbt
@@ -21,7 +21,11 @@ lazy val database = (project in file("."))
         ExclusionRule("net.openhft", "chronicle-bytes"),
         ExclusionRule("net.openhft", "chronicle-threads"),
         ExclusionRule("org.slf4j", "slf4j-api")
-      )
+      ),
+      // Force newer JNA to support more platforms/architectures.
+      "net.java.dev.jna" % "jna-platform" % "5.9.0",
+      // Add simple binding to silence SLF4J warnings.
+      "org.slf4j" % "slf4j-simple" % "1.7.32"
     )
   )
   .dependsOn(

--- a/benchmarks/neo4j/build.sbt
+++ b/benchmarks/neo4j/build.sbt
@@ -12,7 +12,7 @@ lazy val neo4j = (project in file("."))
       "org.neo4j" % "neo4j" % "4.2.4",
       "net.liftweb" %% "lift-json" % "3.4.3",
       // Force newer JNA to support more platforms/architectures.
-      "net.java.dev.jna" % "jna" % "5.9.0"
+      "net.java.dev.jna" % "jna" % "5.10.0"
     )
   )
   .dependsOn(

--- a/benchmarks/neo4j/build.sbt
+++ b/benchmarks/neo4j/build.sbt
@@ -10,7 +10,9 @@ lazy val neo4j = (project in file("."))
     libraryDependencies ++= Seq(
       // neo4j 4.2 does not support 2.13
       "org.neo4j" % "neo4j" % "4.2.4",
-      "net.liftweb" %% "lift-json" % "3.4.3"
+      "net.liftweb" %% "lift-json" % "3.4.3",
+      // Force newer JNA to support more platforms/architectures.
+      "net.java.dev.jna" % "jna" % "5.9.0"
     )
   )
   .dependsOn(

--- a/benchmarks/scala-dotty/build.sbt
+++ b/benchmarks/scala-dotty/build.sbt
@@ -10,7 +10,9 @@ lazy val scalaDotty = (project in file("."))
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala3-compiler_3" % "3.0.0",
       // The following is required to compile the workload sources.
-      "org.scala-lang" % "scala-compiler" % scalaVersion.value
+      "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+      // Force newer JNA to support more platforms/architectures.
+      "net.java.dev.jna" % "jna" % "5.9.0"
     )
   )
   .dependsOn(

--- a/benchmarks/scala-dotty/build.sbt
+++ b/benchmarks/scala-dotty/build.sbt
@@ -12,7 +12,7 @@ lazy val scalaDotty = (project in file("."))
       // The following is required to compile the workload sources.
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,
       // Force newer JNA to support more platforms/architectures.
-      "net.java.dev.jna" % "jna" % "5.9.0"
+      "net.java.dev.jna" % "jna" % "5.10.0"
     )
   )
   .dependsOn(


### PR DESCRIPTION
This was primarily triggered by the issues with `db-shootout` on less common CPU/platform combinations (see #153 and #296) and at least part of the cause is that [JNA](https://github.com/java-native-access/jna) version (4.2.1) used in `db-shootout` simply does not support those combinations. So this forces JNA in `db-shotout` to version 5.9.0 ([latest](https://github.com/java-native-access/jna/releases) at the moment) which provides support for currently live combinations and loses a few outdated ones, specifically:
- adds `aix-ppc64`, `darwin-aarch64`, `darwin-x86-64`, `linux-armel`, `linux-mips64el`, `linux-ppc` (32-bit), `linux-riscv64`, `linux-s390x`, and `win32-aarch64`
- removes `darwin` (replaced by `darwin-x86-64` I think), `linux-ppc64` (there is still `linux-ppc64le`), `linux-sparcv9` (there still is `sunos-sparcv9`) and `w32ce-arm`

Given the two issues mentioned, we are mostly interested in getting `darwin-aarch64`, `linux-ppc64le` and `linux-s390x` support which the newer JNA provides.

Also, because the `neo4j` and `scala-dotty`  benchmarks pull in JNA as a (transitive) dependency, I forced them to pull the same (latest) version so that we don't have three different JNA versions each supporting a different set of CPU/platform combinations. I don't know if these benchmarks actually get to executing any code that relies on JNA (not sure about `neo4j`, but `scala-dotty` might pull it in just because some part of Scala wants to use `jline-terminal` and `jline-terminal-jna` for REPL).

Anyway, the benchmarks compile and run on my machine (which is expected), but unfortunately I don't have info about the exotic platforms involved in the original issues.

I created a branch and a special build (including binaries) of `db-shootout` that the original issue posters could use to check if it fixes their problem, but I haven't received any response so far.

So the question is, do we want to merge this and move on?