### PR TITLE
GHA: split into more workflows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,63 @@
+name: Linux
+on: [push, pull_request]
+jobs:
+  linux:
+    strategy:
+      matrix:
+        image:
+          - openjdk8
+          - openjdk9
+          - openjdk10
+          - openjdk11
+          - openjdk12
+          - openjdk13
+          - openjdk14
+          - openjdk15
+          - openjdk16
+          - openj9-openjdk8
+          - openj9-openjdk11
+          - openj9-openjdk16
+    runs-on: ubuntu-latest
+    container: "renaissancebench/buildenv:${{ matrix.image }}"
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Cache SBT
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+            ~/.cache/coursier
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+
+      - name: Environment configuration
+        shell: bash
+        run: "tools/ci/pre-show-env.sh"
+
+      - name: Build base
+        shell: bash
+        run: "tools/ci/build-base.sh"
+
+      - name: Build JMH
+        shell: bash
+        run: "tools/ci/build-jmh.sh"
+
+      - name: Stop SBT
+        shell: bash
+        run: "tools/ci/stop-sbt.sh"
+
+      - name: Check JMH
+        shell: bash
+        run: "tools/ci/check-jmh.sh"
+
+      - name: Run the suite
+        shell: bash
+        run: "tools/ci/bench-base.sh"
+
+      - name: Run the suite with JMH
+        shell: bash
+        run: "tools/ci/bench-jmh.sh"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,52 @@
+name: MacOS (legacy)
+on: [push, pull_request]
+jobs:
+  macos:
+    strategy:
+      matrix:
+        java: [ '8', '11', '13', '15' ]
+    runs-on: macos-latest
+    continue-on-error: true
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup correct Java version
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: ${{ matrix.java }}
+
+      - name: Environment configuration
+        shell: bash
+        run: "tools/ci/pre-show-env.sh"
+
+      - name: Build base
+        shell: bash
+        run: "tools/ci/build-base.sh"
+
+      - name: Build JMH
+        shell: bash
+        run: "tools/ci/build-jmh.sh"
+
+      - name: Stop SBT
+        shell: bash
+        run: "tools/ci/stop-sbt.sh"
+
+      - name: Check JMH
+        shell: bash
+        run: "tools/ci/check-jmh.sh"
+
+      - name: Dummy run and environment configuration
+        shell: bash
+        run: "tools/ci/bench-show-env.sh"
+
+      - name: Run the suite
+        shell: bash
+        run: "tools/ci/bench-base.sh"
+
+      - name: Run the suite with JMH
+        shell: bash
+        run: "tools/ci/bench-jmh.sh"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: build
+name: Main
 on: [push, pull_request]
 jobs:
   checks:
@@ -9,6 +9,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Cache SBT
         uses: actions/cache@v2
         with:
@@ -17,6 +18,7 @@ jobs:
             ~/.sbt
             ~/.cache/coursier
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+
       - name: Check file encoding"
         shell: bash
         run: tools/ci/check-encoding.sh
@@ -42,30 +44,15 @@ jobs:
         run: tools/ci/check-markdown.sh
 
   linux:
-    strategy:
-      matrix:
-        image:
-          - openjdk8
-          - openjdk9
-          - openjdk10
-          - openjdk11
-          - openjdk12
-          - openjdk13
-          - openjdk14
-          - openjdk15
-          - openjdk16
-          - openjdk17
-          - openj9-openjdk8
-          - openj9-openjdk11
-          - openj9-openjdk16
     runs-on: ubuntu-latest
-    container: "renaissancebench/buildenv:${{ matrix.image }}"
+    container: "renaissancebench/buildenv:openjdk17"
     continue-on-error: true
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Cache SBT
         uses: actions/cache@v2
         with:
@@ -104,9 +91,6 @@ jobs:
         run: "tools/ci/bench-jmh.sh"
 
   macos:
-    strategy:
-      matrix:
-        java: [ '8', '11', '13', '15', '17' ]
     runs-on: macos-latest
     continue-on-error: true
     steps:
@@ -114,21 +98,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Setup correct Java version
-        uses: actions/setup-java@v2
-        if: ${{ matrix.java != '17' }}
-        with:
-          distribution: adopt
-          java-version: ${{ matrix.java }}
+
       - name: Fetch JDK 17
-        if: ${{ matrix.java == '17' }}
         run: |
           aria2c -d ${{ runner.temp }} -o openjdk-17_macos-x64_bin.tar.gz https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_macos-x64_bin.tar.gz
+
       - name: Setup JDK 17
         uses: actions/setup-java@v2
-        if: ${{ matrix.java == '17' }}
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 17
           distribution: jdkfile
           jdkFile: ${{ runner.temp }}/openjdk-17_macos-x64_bin.tar.gz
 
@@ -165,9 +143,6 @@ jobs:
         run: "tools/ci/bench-jmh.sh"
 
   windows:
-    strategy:
-      matrix:
-        java: [ '8', '11' , '13', '15', '17' ]
     runs-on: windows-latest
     continue-on-error: true
     steps:
@@ -175,21 +150,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Setup correct Java version
-        uses: actions/setup-java@v2
-        if: ${{ matrix.java != '17' }}
-        with:
-          distribution: adopt
-          java-version: ${{ matrix.java }}
+
       - name: Fetch JDK 17
-        if: ${{ matrix.java == '17' }}
         run: |
           aria2c -d ${{ runner.temp }} -o openjdk-17_windows-x64_bin.zip https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_windows-x64_bin.zip
+
       - name: Setup JDK 17
         uses: actions/setup-java@v2
-        if: ${{ matrix.java == '17' }}
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 17
           distribution: jdkfile
           jdkFile: ${{ runner.temp }}/openjdk-17_windows-x64_bin.zip
 
@@ -220,40 +189,3 @@ jobs:
       - name: Run the suite with JMH
         shell: bash
         run: "tools/ci/bench-jmh.sh"
-
-  plugins:
-    runs-on: ubuntu-latest
-    container: "renaissancebench/buildenv:openjdk8-with-ant-gcc"
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Cache SBT
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.sbt
-            ~/.cache/coursier
-          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
-
-      - name: Environment configuration
-        shell: bash
-        run: "tools/ci/pre-show-env.sh"
-
-      - name: Build base
-        shell: bash
-        run: "tools/ci/build-base.sh"
-
-      - name: Build plugins
-        shell: bash
-        run: "tools/ci/build-plugins.sh"
-
-      - name: Stop SBT
-        shell: bash
-        run: "tools/ci/stop-sbt.sh"
-
-      - name: Run the suite with all plugins
-        shell: bash
-        run: "tools/ci/bench-plugins.sh"

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1,0 +1,40 @@
+name: Plugins
+on: [push, pull_request]
+jobs:
+  plugins:
+    runs-on: ubuntu-latest
+    container: "renaissancebench/buildenv:openjdk8-with-ant-gcc"
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Cache SBT
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+            ~/.cache/coursier
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+
+      - name: Environment configuration
+        shell: bash
+        run: "tools/ci/pre-show-env.sh"
+
+      - name: Build base
+        shell: bash
+        run: "tools/ci/build-base.sh"
+
+      - name: Build plugins
+        shell: bash
+        run: "tools/ci/build-plugins.sh"
+
+      - name: Stop SBT
+        shell: bash
+        run: "tools/ci/stop-sbt.sh"
+
+      - name: Run the suite with all plugins
+        shell: bash
+        run: "tools/ci/bench-plugins.sh"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,47 @@
+name: "Windows (legacy)"
+on: [push, pull_request]
+jobs:
+  windows:
+    strategy:
+      matrix:
+        java: [ '8', '11' , '13', '15' ]
+    runs-on: windows-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup correct Java version
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: ${{ matrix.java }}
+
+      - name: Environment configuration
+        shell: bash
+        run: "tools/ci/pre-show-env.sh"
+
+      - name: Build base
+        shell: bash
+        run: java -jar tools/sbt/bin/sbt-launch.jar assembly
+
+      - name: Build JMH
+        shell: bash
+        run: java -jar tools/sbt/bin/sbt-launch.jar renaissanceJmh/jmh:assembly
+
+      - name: Check JMH
+        shell: bash
+        run: "tools/ci/check-jmh.sh"
+
+      - name: Dummy run and environment configuration
+        shell: bash
+        run: "tools/ci/bench-show-env.sh"
+
+      - name: Run the suite
+        shell: bash
+        run: "tools/ci/bench-base.sh"
+
+      - name: Run the suite with JMH
+        shell: bash
+        run: "tools/ci/bench-jmh.sh"


### PR DESCRIPTION
An attempt for something that we discussed with @lbulej off-line.

Currently, CI using GitHub actions builds everything in one workflow. Unfortunately, unlike GitLab or Travis, one cannot restart individual jobs inside a workflow but only the whole workflow. That means that a single failing job (e.g. because SBT cannot fetch dependencies because of temporary network outage or similar) fails the whole workflow and restarting it is a very costly operation.

Therefore, this PR splits the workflow into the following parts:

* `Main` for building on latest JDK on Linux, Windows and MacOS. This also checks for encoding and coding style issues. This is meant as always-must-be-in-the-green workflow.
* `Plugins` for building and testing plugins (JDK 8 only)
* `Windows (legacy)` is a matrix build for all out-of-the-box supported JDKs on Windows excluding JDK 17.
* `MacOS (legacy)` is just like the above but on Mac.
* `Linux` is a matrix build for JDKs 8 to 16, including also OpenJ9 (8, 11, 16).

This should simplify restarting the jobs and might also simplify identifying the failing job a bit more quickly.

@lbulej Does this initial split somehow seem reasonable to you? I have not yet tackled the idea of sharing builds between individual jobs but it at least solves the issue of restarting smaller units of jobs.
