### PR TITLE
Update benchmarks using Scala 2.13.6 to Scala 2.13.7

### DIFF
--- a/benchmarks/actors-akka/build.sbt
+++ b/benchmarks/actors-akka/build.sbt
@@ -5,7 +5,7 @@ lazy val actorsAkka = (project in file("."))
     name := "actors-akka",
     version := (renaissanceCore / version).value,
     organization := (renaissanceCore / organization).value,
-    scalaVersion := "2.13.6",
+    scalaVersion := "2.13.7",
     libraryDependencies ++= Seq(
       // akka-actor 2.6.x supports Scala 2.12, 2.13
       "com.typesafe.akka" %% "akka-actor" % "2.6.12"

--- a/benchmarks/database/build.sbt
+++ b/benchmarks/database/build.sbt
@@ -5,7 +5,7 @@ lazy val database = (project in file("."))
     name := "database",
     version := (renaissanceCore / version).value,
     organization := (renaissanceCore / organization).value,
-    scalaVersion := "2.13.6",
+    scalaVersion := "2.13.7",
     libraryDependencies ++= Seq(
       "com.github.jnr" % "jnr-posix" % "3.0.29",
       "org.apache.commons" % "commons-math3" % "3.6.1",

--- a/benchmarks/jdk-concurrent/build.sbt
+++ b/benchmarks/jdk-concurrent/build.sbt
@@ -5,7 +5,7 @@ lazy val jdkConcurrent = (project in file("."))
     name := "jdk-concurrent",
     version := (renaissanceCore / version).value,
     organization := (renaissanceCore / organization).value,
-    scalaVersion := "2.13.6",
+    scalaVersion := "2.13.7",
     libraryDependencies ++= Seq(
       "io.jenetics" % "jenetics" % "4.4.0"
     )

--- a/benchmarks/jdk-streams/build.sbt
+++ b/benchmarks/jdk-streams/build.sbt
@@ -5,7 +5,7 @@ lazy val jdkStreams = (project in file("."))
     name := "jdk-streams",
     version := (renaissanceCore / version).value,
     organization := (renaissanceCore / organization).value,
-    scalaVersion := "2.13.6"
+    scalaVersion := "2.13.7"
   )
   .dependsOn(
     renaissanceCore % "provided"

--- a/benchmarks/rx/build.sbt
+++ b/benchmarks/rx/build.sbt
@@ -5,7 +5,7 @@ lazy val rx = (project in file("."))
     name := "rx",
     version := (renaissanceCore / version).value,
     organization := (renaissanceCore / organization).value,
-    scalaVersion := "2.13.6",
+    scalaVersion := "2.13.7",
     libraryDependencies ++= Seq(
       "io.reactivex" % "rxjava" % "1.3.7"
     )

--- a/benchmarks/scala-dotty/build.sbt
+++ b/benchmarks/scala-dotty/build.sbt
@@ -5,7 +5,7 @@ lazy val scalaDotty = (project in file("."))
     name := "scala-dotty",
     version := (renaissanceCore / version).value,
     organization := (renaissanceCore / organization).value,
-    scalaVersion := "2.13.6",
+    scalaVersion := "2.13.7",
     scalacOptions += "-Ytasty-reader",
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala3-compiler_3" % "3.0.0",

--- a/benchmarks/scala-sat/build.sbt
+++ b/benchmarks/scala-sat/build.sbt
@@ -9,7 +9,7 @@ lazy val scalaSAT = (project in file("."))
     name := "scala-sat",
     version := (renaissanceCore / version).value,
     organization := (renaissanceCore / organization).value,
-    scalaVersion := "2.13.6"
+    scalaVersion := "2.13.7"
   )
   .dependsOn(
     renaissanceCore % "provided",

--- a/benchmarks/scala-stdlib/build.sbt
+++ b/benchmarks/scala-stdlib/build.sbt
@@ -5,7 +5,7 @@ lazy val scalaStdlib = (project in file("."))
     name := "scala-stdlib",
     version := (renaissanceCore / version).value,
     organization := (renaissanceCore / organization).value,
-    scalaVersion := "2.13.6"
+    scalaVersion := "2.13.7"
   )
   .dependsOn(
     renaissanceCore % "provided"

--- a/renaissance-harness/build.sbt
+++ b/renaissance-harness/build.sbt
@@ -5,7 +5,8 @@ lazy val renaissanceHarness = (project in file("."))
     name := "renaissance-harness",
     version := (renaissanceCore / version).value,
     organization := (renaissanceCore / organization).value,
-    scalaVersion := "2.13.6",
+    scalaVersion := "2.13.7",
+    scalacOptions ++= Seq("-deprecation"),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     libraryDependencies ++= Seq(
       "com.github.scopt" %% "scopt" % "4.0.0-RC2",


### PR DESCRIPTION
This is just a precursor to moving the `apache-spark` and `twitter-finagle` benchmarks to Scala 2.13.