### PR TITLE
Fix: finagle-chirper and finage-http are not working correctly.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -213,7 +213,10 @@ lazy val renaissance: Project = {
     "java.base/java.lang.invoke",
     "java.base/java.util",
     "java.base/java.nio",
-    "java.base/sun.nio.ch"
+    "java.base/sun.nio.ch",
+    "java.management/sun.management",
+    "java.management/sun.management.counter",
+    "java.management/sun.management.counter.perf"
   )
 
   val p = Project("renaissance", file("."))


### PR DESCRIPTION
`finagle-chirper` and `finage-http` are not working correctly. Execution output:

> [2021-11-11T08:16:00.039+0100] com.twitter.jvm.Jvm$ (com.twitter.jvm.Jvm$ liftedTree2$1)
> WARNING: failed to create Hotspot JVM interface, using NilJvm instead
> [2021-11-11T08:16:00.397+0100] com.twitter.finagle (com.twitter.finagle.Init$ $anonfun$once$1)
> INFO: Finagle version 19.4.0 (rev=15ae0aba979a2c11ed4a71774b2e995f5df918b4) built at 20190418-114348
> Master port: 40705
> Cache ports: 44385, 41639, 35635, 43851, 39261, 40521, 36315, 36317, 37231, 46291, 33635, 33083
> ====== finagle-chirper (web) [default], iteration 0 started ======
> Resetting master, feed map size: 5000
> GC before operation: completed in 25.968 ms, heap usage 113.254 MB -> 27.470 MB.
> WARNING: This benchmark provides no result that can be validated.
> There is no way to check that no silent failure occurred.
> ====== finagle-chirper (web) [default], iteration 0 completed (21390.592 ms) ======

The problem is that the JVM fails to create an `Hotspot JVM` interface and fallbacks to the `NilJVM` interface (because of missing exports). This is not intended to happen.
