### PR TITLE
Update and commonize some of the dependencies

### DIFF
--- a/benchmarks/scala-dotty/src/main/scala/org/renaissance/scala/dotty/Dotty.scala
+++ b/benchmarks/scala-dotty/src/main/scala/org/renaissance/scala/dotty/Dotty.scala
@@ -46,7 +46,7 @@ final class Dotty extends Benchmark {
    *
    * find . -type f -name '*.tasty'|egrep -v '(Classfile|ByteCode)\.tasty' | LC_ALL=C sort|xargs cat|md5sum
    */
-  private val expectedTastyHash: String = "7376f5f353dea8da455afb6abfee237e"
+  private val expectedTastyHash: String = "af5ff4a3e1d189395c07c187167450ed"
 
   private val excludedTastyFiles = Seq("Classfile.tasty", "ByteCode.tasty")
 

--- a/build.sbt
+++ b/build.sbt
@@ -282,7 +282,7 @@ lazy val neo4jBenchmarks = (project in file("benchmarks/neo4j"))
     libraryDependencies ++= Seq(
       // neo4j 4.2 does not support 2.13
       "org.neo4j" % "neo4j" % "4.2.4",
-      "net.liftweb" %% "lift-json" % "3.4.3",
+      "net.liftweb" %% "lift-json" % "3.5.0",
       // Force newer JNA to support more platforms/architectures.
       "net.java.dev.jna" % "jna" % jnaVersion,
       // Force common versions of other dependencies.

--- a/build.sbt
+++ b/build.sbt
@@ -280,8 +280,8 @@ lazy val neo4jBenchmarks = (project in file("benchmarks/neo4j"))
     name := "neo4j",
     scalaVersion := scalaVersion212,
     libraryDependencies ++= Seq(
-      // neo4j 4.2 does not support 2.13
-      "org.neo4j" % "neo4j" % "4.2.4",
+      // neo4j 4.4 does not support Scala 2.13 yet.
+      "org.neo4j" % "neo4j" % "4.4.0",
       "net.liftweb" %% "lift-json" % "3.5.0",
       // Force newer JNA to support more platforms/architectures.
       "net.java.dev.jna" % "jna" % jnaVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -111,6 +111,7 @@ val generateManifestAttributesTask = Def.task {
 // Subprojects
 //
 
+val guavaVersion = "23.0"
 val scalaCollectionCompatVersion = "2.6.0"
 val scalaParallelCollectionsVersion = "1.0.4"
 
@@ -198,6 +199,7 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
       "org.apache.spark" %% "spark-sql" % sparkVersion,
       "org.apache.spark" %% "spark-mllib" % sparkVersion
       // Force common versions of other dependencies.
+      "com.google.guava" % "guava" % guavaVersion,
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.scala-lang.modules" %% "scala-parallel-collections" % scalaParallelCollectionsVersion,
     )
@@ -231,6 +233,8 @@ lazy val databaseBenchmarks = (project in file("benchmarks/database"))
       "net.java.dev.jna" % "jna-platform" % jnaVersion,
       // Add simple binding to silence SLF4J warnings.
       "org.slf4j" % "slf4j-simple" % slf4jSimpleVersion
+      // Force common versions of other dependencies.
+      "com.google.guava" % "guava" % guavaVersion
     )
   )
   .dependsOn(renaissanceCore % "provided")
@@ -329,11 +333,11 @@ lazy val twitterFinagleBenchmarks = (project in file("benchmarks/twitter-finagle
     scalaVersion := scalaVersion213,
     scalacOptions ++= Seq("-deprecation", "-feature"),
     libraryDependencies := Seq(
+      "com.google.guava" % "guava" % guavaVersion,
       "com.twitter" %% "finagle-http" % finagleVersion,
       "com.twitter" %% "finagle-stats" % finagleVersion,
       "com.twitter" %% "finagle-core" % finagleVersion,
       "com.twitter" %% "util-core" % finagleVersion,
-      "com.google.guava" % "guava" % "19.0",
       "org.scala-lang.modules" %% "scala-parallel-collections" % scalaParallelCollectionsVersion,
       // Add simple binding to silence SLF4J warnings.
       "org.slf4j" % "slf4j-simple" % slf4jSimpleVersion

--- a/build.sbt
+++ b/build.sbt
@@ -179,7 +179,7 @@ lazy val actorsAkkaBenchmarks = (project in file("benchmarks/actors-akka"))
     scalaVersion := scalaVersion213,
     libraryDependencies ++= Seq(
       // akka-actor 2.6.x supports Scala 2.12, 2.13
-      "com.typesafe.akka" %% "akka-actor" % "2.6.12"
+      "com.typesafe.akka" %% "akka-actor" % "2.6.17"
     )
   )
   .dependsOn(renaissanceCore % "provided")

--- a/build.sbt
+++ b/build.sbt
@@ -111,6 +111,7 @@ val generateManifestAttributesTask = Def.task {
 // Subprojects
 //
 
+val commonsMath3Version = "3.6.1"
 val guavaVersion = "23.0"
 val jnaVersion = "5.10.0"
 val nettyVersion = "4.1.72.Final"
@@ -206,6 +207,7 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
       "io.netty" % "netty-all" % nettyVersion,
       // Force common versions of other dependencies.
       "com.google.guava" % "guava" % guavaVersion,
+      "org.apache.commons" % "commons-math3" % commonsMath3Version,
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.scala-lang.modules" %% "scala-parallel-collections" % scalaParallelCollectionsVersion,
       "org.slf4j" % "slf4j-log4j12" % slf4jVersion,
@@ -221,7 +223,7 @@ lazy val databaseBenchmarks = (project in file("benchmarks/database"))
     scalaVersion := scalaVersion213,
     libraryDependencies ++= Seq(
       "com.github.jnr" % "jnr-posix" % "3.0.29",
-      "org.apache.commons" % "commons-math3" % "3.6.1",
+      "org.apache.commons" % "commons-math3" % commonsMath3Version,
       "org.agrona" % "agrona" % "0.9.7",
       "net.openhft" % "zero-allocation-hashing" % "0.6",
       "org.mapdb" % "mapdb" % "3.0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -347,7 +347,7 @@ lazy val scalaStmBenchmarks = (project in file("benchmarks/scala-stm"))
     ) % "compile->compile;compile->test"
   )
 
-val finagleVersion = "21.10.0"
+val finagleVersion = "21.11.0"
 
 lazy val twitterFinagleBenchmarks = (project in file("benchmarks/twitter-finagle"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -297,7 +297,7 @@ lazy val rxBenchmarks = (project in file("benchmarks/rx"))
     name := "rx",
     scalaVersion := scalaVersion213,
     libraryDependencies ++= Seq(
-      "io.reactivex" % "rxjava" % "1.3.7"
+      "io.reactivex" % "rxjava" % "1.3.8"
     )
   )
   .dependsOn(renaissanceCore % "provided")

--- a/build.sbt
+++ b/build.sbt
@@ -308,7 +308,7 @@ lazy val scalaDottyBenchmarks = (project in file("benchmarks/scala-dotty"))
     scalaVersion := scalaVersion213,
     scalacOptions += "-Ytasty-reader",
     libraryDependencies ++= Seq(
-      "org.scala-lang" % "scala3-compiler_3" % "3.0.0",
+      "org.scala-lang" % "scala3-compiler_3" % "3.0.2",
       // The following is required to compile the workload sources.
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,
       // Force newer JNA to support more platforms/architectures.

--- a/build.sbt
+++ b/build.sbt
@@ -115,6 +115,7 @@ val guavaVersion = "23.0"
 val jnaVersion = "5.10.0"
 val scalaCollectionCompatVersion = "2.6.0"
 val scalaParallelCollectionsVersion = "1.0.4"
+val slf4jVersion = "1.7.32"
 
 lazy val renaissanceCore = (project in file("renaissance-core"))
   .settings(
@@ -203,11 +204,12 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
       "com.google.guava" % "guava" % guavaVersion,
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.scala-lang.modules" %% "scala-parallel-collections" % scalaParallelCollectionsVersion,
+      "org.slf4j" % "slf4j-log4j12" % slf4jVersion,
+      "org.slf4j" % "jcl-over-slf4j" % slf4jVersion,
+      "org.slf4j" % "jul-to-slf4j" % slf4jVersion
     )
   )
   .dependsOn(renaissanceCore % "provided")
-
-val slf4jSimpleVersion = "1.7.32"
 
 lazy val databaseBenchmarks = (project in file("benchmarks/database"))
   .settings(
@@ -232,7 +234,7 @@ lazy val databaseBenchmarks = (project in file("benchmarks/database"))
       // Force newer JNA to support more platforms/architectures.
       "net.java.dev.jna" % "jna-platform" % jnaVersion,
       // Add simple binding to silence SLF4J warnings.
-      "org.slf4j" % "slf4j-simple" % slf4jSimpleVersion
+      "org.slf4j" % "slf4j-simple" % slf4jVersion,
       // Force common versions of other dependencies.
       "com.google.guava" % "guava" % guavaVersion
     )
@@ -266,6 +268,8 @@ lazy val neo4jBenchmarks = (project in file("benchmarks/neo4j"))
       "net.liftweb" %% "lift-json" % "3.4.3",
       // Force newer JNA to support more platforms/architectures.
       "net.java.dev.jna" % "jna" % jnaVersion,
+      // Force common versions of other dependencies.
+      "org.slf4j" % "slf4j-nop" % slf4jVersion
     )
   )
   .dependsOn(renaissanceCore % "provided")
@@ -340,7 +344,7 @@ lazy val twitterFinagleBenchmarks = (project in file("benchmarks/twitter-finagle
       "com.twitter" %% "util-core" % finagleVersion,
       "org.scala-lang.modules" %% "scala-parallel-collections" % scalaParallelCollectionsVersion,
       // Add simple binding to silence SLF4J warnings.
-      "org.slf4j" % "slf4j-simple" % slf4jSimpleVersion
+      "org.slf4j" % "slf4j-simple" % slf4jVersion,
       // Force common versions of other dependencies.
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion
     )

--- a/build.sbt
+++ b/build.sbt
@@ -111,6 +111,8 @@ val generateManifestAttributesTask = Def.task {
 // Subprojects
 //
 
+val scalaCollectionCompatVersion = "2.6.0"
+
 lazy val renaissanceCore = (project in file("renaissance-core"))
   .settings(
     commonSettingsNoScala,
@@ -144,7 +146,7 @@ lazy val renaissanceHarness212 = (project in file("renaissance-harness"))
     renaissanceHarnessCommonSettings,
     libraryDependencies ++= Seq(
       // Needed to compile Scala 2.13 collections with Scala 2.12.
-      "org.scala-lang.modules" %% "scala-collection-compat" % "2.6.0"
+      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion
     )
   )
   .dependsOn(renaissanceCore % "provided")
@@ -194,6 +196,8 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
       "org.apache.spark" %% "spark-core" % sparkVersion,
       "org.apache.spark" %% "spark-sql" % sparkVersion,
       "org.apache.spark" %% "spark-mllib" % sparkVersion
+      // Force common versions of other dependencies.
+      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
     )
   )
   .dependsOn(renaissanceCore % "provided")
@@ -331,6 +335,8 @@ lazy val twitterFinagleBenchmarks = (project in file("benchmarks/twitter-finagle
       "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
       // Add simple binding to silence SLF4J warnings.
       "org.slf4j" % "slf4j-simple" % slf4jSimpleVersion
+      // Force common versions of other dependencies.
+      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion
     )
   )
   .dependsOn(renaissanceCore % "provided")

--- a/build.sbt
+++ b/build.sbt
@@ -111,7 +111,11 @@ val generateManifestAttributesTask = Def.task {
 // Subprojects
 //
 
+val commonsIoVersion = "2.11.0"
+val commonsLoggingVersion = "1.2"
+val commonsCompressVersion = "1.21"
 val commonsMath3Version = "3.6.1"
+val commonsTextVersion = "1.9"
 val guavaVersion = "23.0"
 val jnaVersion = "5.10.0"
 val nettyVersion = "4.1.72.Final"
@@ -207,7 +211,11 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
       "io.netty" % "netty-all" % nettyVersion,
       // Force common versions of other dependencies.
       "com.google.guava" % "guava" % guavaVersion,
+      "commons-io" % "commons-io" % commonsIoVersion,
+      "commons-logging" % "commons-logging" % commonsLoggingVersion,
+      "org.apache.commons" % "commons-compress" % commonsCompressVersion,
       "org.apache.commons" % "commons-math3" % commonsMath3Version,
+      "org.apache.commons" % "commons-text" % commonsTextVersion,
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.scala-lang.modules" %% "scala-parallel-collections" % scalaParallelCollectionsVersion,
       "org.slf4j" % "slf4j-log4j12" % slf4jVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -209,6 +209,8 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
       // Force newer Netty version.
       // Overrides versions pulled in by dependencies.
       "io.netty" % "netty-all" % nettyVersion,
+      // Force newer Zookeeper version.
+      "org.apache.zookeeper" % "zookeeper" % "3.6.3",
       // Force common versions of other dependencies.
       "com.google.guava" % "guava" % guavaVersion,
       "commons-io" % "commons-io" % commonsIoVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -262,7 +262,8 @@ lazy val jdkConcurrentBenchmarks = (project in file("benchmarks/jdk-concurrent")
     name := "jdk-concurrent",
     scalaVersion := scalaVersion213,
     libraryDependencies ++= Seq(
-      "io.jenetics" % "jenetics" % "4.4.0"
+      // Jenetics 6.0.0 requires benchmark update.
+      "io.jenetics" % "jenetics" % "5.2.0"
     )
   )
   .dependsOn(renaissanceCore % "provided")

--- a/build.sbt
+++ b/build.sbt
@@ -113,6 +113,7 @@ val generateManifestAttributesTask = Def.task {
 
 val guavaVersion = "23.0"
 val jnaVersion = "5.10.0"
+val nettyVersion = "4.1.72.Final"
 val scalaCollectionCompatVersion = "2.6.0"
 val scalaParallelCollectionsVersion = "1.0.4"
 val slf4jVersion = "1.7.32"
@@ -199,7 +200,10 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-core" % sparkVersion,
       "org.apache.spark" %% "spark-sql" % sparkVersion,
-      "org.apache.spark" %% "spark-mllib" % sparkVersion
+      "org.apache.spark" %% "spark-mllib" % sparkVersion,
+      // Force newer Netty version.
+      // Overrides versions pulled in by dependencies.
+      "io.netty" % "netty-all" % nettyVersion,
       // Force common versions of other dependencies.
       "com.google.guava" % "guava" % guavaVersion,
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
@@ -269,6 +273,7 @@ lazy val neo4jBenchmarks = (project in file("benchmarks/neo4j"))
       // Force newer JNA to support more platforms/architectures.
       "net.java.dev.jna" % "jna" % jnaVersion,
       // Force common versions of other dependencies.
+      "io.netty" % "netty-all" % nettyVersion,
       "org.slf4j" % "slf4j-nop" % slf4jVersion
     )
   )
@@ -346,6 +351,7 @@ lazy val twitterFinagleBenchmarks = (project in file("benchmarks/twitter-finagle
       // Add simple binding to silence SLF4J warnings.
       "org.slf4j" % "slf4j-simple" % slf4jVersion,
       // Force common versions of other dependencies.
+      "io.netty" % "netty-all" % nettyVersion,
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -112,6 +112,7 @@ val generateManifestAttributesTask = Def.task {
 //
 
 val scalaCollectionCompatVersion = "2.6.0"
+val scalaParallelCollectionsVersion = "1.0.4"
 
 lazy val renaissanceCore = (project in file("renaissance-core"))
   .settings(
@@ -198,6 +199,7 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
       "org.apache.spark" %% "spark-mllib" % sparkVersion
       // Force common versions of other dependencies.
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+      "org.scala-lang.modules" %% "scala-parallel-collections" % scalaParallelCollectionsVersion,
     )
   )
   .dependsOn(renaissanceCore % "provided")
@@ -332,7 +334,7 @@ lazy val twitterFinagleBenchmarks = (project in file("benchmarks/twitter-finagle
       "com.twitter" %% "finagle-core" % finagleVersion,
       "com.twitter" %% "util-core" % finagleVersion,
       "com.google.guava" % "guava" % "19.0",
-      "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
+      "org.scala-lang.modules" %% "scala-parallel-collections" % scalaParallelCollectionsVersion,
       // Add simple binding to silence SLF4J warnings.
       "org.slf4j" % "slf4j-simple" % slf4jSimpleVersion
       // Force common versions of other dependencies.

--- a/build.sbt
+++ b/build.sbt
@@ -112,6 +112,7 @@ val generateManifestAttributesTask = Def.task {
 //
 
 val guavaVersion = "23.0"
+val jnaVersion = "5.10.0"
 val scalaCollectionCompatVersion = "2.6.0"
 val scalaParallelCollectionsVersion = "1.0.4"
 
@@ -206,7 +207,6 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
   )
   .dependsOn(renaissanceCore % "provided")
 
-val jnaVersion = "5.10.0"
 val slf4jSimpleVersion = "1.7.32"
 
 lazy val databaseBenchmarks = (project in file("benchmarks/database"))
@@ -265,7 +265,7 @@ lazy val neo4jBenchmarks = (project in file("benchmarks/neo4j"))
       "org.neo4j" % "neo4j" % "4.2.4",
       "net.liftweb" %% "lift-json" % "3.4.3",
       // Force newer JNA to support more platforms/architectures.
-      "net.java.dev.jna" % "jna" % jnaVersion
+      "net.java.dev.jna" % "jna" % jnaVersion,
     )
   )
   .dependsOn(renaissanceCore % "provided")


### PR DESCRIPTION
Updates and commonizes versions for some of the benchmark dependencies.

For **primary** dependencies that are typically unique to a benchmark module, the updated versions affects just the benchmarks in the module and if we use a newer version, some of their transitive dependencies may use a newer versions and can be shared with other modules. For example, updating the `finagle` artifacts leads to newer `zstd-jni`, which can be implicitly shared with `apache-spark`.

For secondary/transitive dependencies, the forced update applies to several benchmarks, but these are mostly support libraries. For example, we shipped 4 different versions of various `netty` artifacts, but now we ship just one, which should avoid issues such as #337.

- *`actors-akka`* benchmarks
    - **`akka-actor`, 2.6.12 -> 2.6.17**
- *`apache-spark`* benchmarks
    - `guava`, 16.0.1 -> 23.0
    - `commons-compress`, 1.20 -> 1.21
    - `commons-io`, 2.8.0 -> 2.11.0
    - `commons-logging`, 1.1.3 -> 1.2
    - `commons-math3`, 3.4.1 -> 3.6.1
    - `commons-text`, 1.6 -> 1.9
    - `netty-all`, 4.1.68.Final -> 4.1.72.Final
        - `netty-buffer`, `netty-codec`, `netty-common`, `netty-handler`, `netty-resolver`, `netty-transport-*`, 4.1.50.Final -> 4.1.72.Final
        - the individual artifacts (with different version) were pulled in by `zookeeper`
    - `scala-collections-compat_2.13`, 2.2.0 -> 2.6.0
    - `scala-parallel-collections_2.13`, 1.0.3 -> 1.0.4
    - `slf4j-api`, `slf4j-log4j12`, `jcl-over-slf4j`, `jul-to-slf4j`, 1.7.30 -> 1.7.32
    - `zookeeper`, 3.6.2 -> 3.6.3
- *`database`* benchmarks
    - `guava`, 19.0 -> 23.0
    - `jcl-over-slf4j`, 1.6.6 -> 1.7.32
    - `jna`, 4.2.1 -> 5.10.0
    - `slf4j-api`, `slf4j-simple`, 1.7.25 -> 1.7.32
    - there are many other primary dependencies that could be updated, but this needs to be handled slowly, because historically this benchmark has been a bit fragile
- *`jdk-concurrent`* benchmarks
    - **`jenetics`, 4.4.0 -> 5.2.0**
        -  version 6.0.0 is available, but would require benchmark update
- *`neo4j`* benchmarks
    - `jna`, 5.6.0 -> 5.10.0
    - **`lift-json`, 3.4.3 -> 3.5.0**
    - **`neo4j`, 4.2.4 -> 4.4.0**
        - still does not support Scala 2.13
    - `netty-all`, 4.1.55.Final -> 4.1.72.Final
    - `slf4j-api`, `slf4j-nop`, 1.7.30 -> 1.7.32
- *`renaissance-harness`* module
    - `scala-collections-compat_2.13`, uses 2.6.0
- *`rx`* benchmarks
    - **`rxjava`, 1.3.7 -> 1.3.8**
- *`scala-dotty`* benchmarks
    - **`scala3-compiler_3`, 3.0.0 -> 3.0.2**
        - updated `expectedTastyHash` in `Dotty.scala`
    - `jna`, 5.3.1 -> 5.10.0
- *`twitter-finagle`* benchmarks
    - **`finagle-core`, `finagle-http`, `finagle-stats`, `util-core`, 21.10.0 -> 21.11.0**
    - **`guava`, 19.0 -> 23.0**
    - `netty-all`, 4.1.66.Final -> 4.1.72.Final
    - `scala-collections-compat_2.13`, 2.4.4 -> 2.6.0
    - **`scala-parallel-collections_2.13`, uses 1.0.4**
    - `slf4j-simple`, keep 1.7.32

Things have been working on my machine, but it would help if somebody else could give it a try.