### PR TITLE
Keep masking warnings from com.github.fommil.netlib

### DIFF
--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
@@ -69,6 +69,12 @@ trait SparkUtil {
     //   "(via SPARK_LOCAL_DIRS in mesos/standalone/kubernetes and LOCAL_DIRS in YARN)."
     "org.apache.spark.SparkConf" -> Level.ERROR,
     // Masks the following warnings:
+    //   "Failed to load implementation from: com.github.fommil.netlib.NativeSystemBLAS"
+    //   "Failed to load implementation from: com.github.fommil.netlib.NativeRefBLAS"
+    //   "Failed to load implementation from: com.github.fommil.netlib.NativeSystemLAPACK"
+    //   "Failed to load implementation from: com.github.fommil.netlib.NativeRefLAPACK"
+    "com.github.fommil.netlib" -> Level.ERROR,
+    // Masks the following warnings:
     //   "Failed to load implementation from: dev.ludovic.netlib.blas.JNIBLAS"
     //   "Failed to load implementation from: dev.ludovic.netlib.blas.ForeignLinkerBLAS"
     //   "Failed to load implementation from: dev.ludovic.netlib.lapack.JNILAPACK"


### PR DESCRIPTION
Francois @farquet noticed that even though Spark 3.2.0 uses `dev.ludovic.netlib`, the old logger still pops up, so we will set the log level in both for now. Let's see if we can clean this up next Spark update.