### PR TITLE
Adding CI check for the standalone mode.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -50,6 +50,10 @@ jobs:
         shell: bash
         run: tools/ci/bench-base.sh
 
+      - name: Run the suite in standalone mode
+        shell: bash
+        run: tools/ci/bench-standalone.sh
+
       - name: Run the suite with JMH
         shell: bash
         run: tools/ci/bench-jmh.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,6 +39,10 @@ jobs:
         shell: bash
         run: tools/ci/bench-base.sh
 
+      - name: Run the suite in standalone mode
+        shell: bash
+        run: tools/ci/bench-standalone.sh
+
       - name: Run the suite with JMH
         shell: bash
         run: tools/ci/bench-jmh.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,10 @@ jobs:
         shell: bash
         run: tools/ci/bench-base.sh
 
+      - name: Run the suite in standalone mode
+        shell: bash
+        run: tools/ci/bench-standalone.sh
+
       - name: Run the suite with JMH
         shell: bash
         run: tools/ci/bench-jmh.sh
@@ -114,6 +118,10 @@ jobs:
         shell: bash
         run: tools/ci/bench-base.sh
 
+      - name: Run the suite in standalone mode
+        shell: bash
+        run: tools/ci/bench-standalone.sh
+
       - name: Run the suite with JMH
         shell: bash
         run: tools/ci/bench-jmh.sh
@@ -157,6 +165,10 @@ jobs:
       - name: Run the suite
         shell: bash
         run: tools/ci/bench-base.sh
+
+      - name: Run the suite in standalone mode
+        shell: bash
+        run: tools/ci/bench-standalone.sh
 
       - name: Run the suite with JMH
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,6 +38,10 @@ jobs:
         shell: bash
         run: tools/ci/bench-base.sh
 
+      - name: Run the suite in standalone mode
+        shell: bash
+        run: tools/ci/bench-standalone.sh
+
       - name: Run the suite with JMH
         shell: bash
         run: tools/ci/bench-jmh.sh

--- a/tools/ci/bench-standalone.sh
+++ b/tools/ci/bench-standalone.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+source "$(dirname "$0")/common.sh"
+
+# Test benchmarks under Renaissance harness
+java -jar "$RENAISSANCE_JAR" --raw-list > list.txt
+
+unzip "$RENAISSANCE_JAR" -d "extracted-renaissance"
+
+for BENCH in $(cat list.txt); do
+	echo "====> $BENCH"
+	java -Xms2500M -Xmx2500M -jar "./extracted-renaissance/single/$BENCH.jar" -c test -r 1 --csv output.csv --json output.json "$BENCH" || exit 1
+done


### PR DESCRIPTION
It exhibits a problem with `dotty` which looks like a JDK compatibility issue:

```
====> dotty
Benchmark 'dotty' failed with exception:
java.lang.ClassCastException: class jdk.internal.loader.ClassLoaders$AppClassLoader cannot be cast to class java.net.URLClassLoader (jdk.internal.loader.ClassLoaders$AppClassLoader and java.net.URLClassLoader are in module java.base of loader 'bootstrap')
	at org.renaissance.scala.dotty.Dotty.setUpBeforeAll(Dotty.scala:106)
	at org.renaissance.harness.ExecutionDriver.executeBenchmark(ExecutionDriver.java:82)
	at org.renaissance.harness.RenaissanceSuite$.$anonfun$runBenchmarks$1(RenaissanceSuite.scala:163)
	at org.renaissance.harness.RenaissanceSuite$.$anonfun$runBenchmarks$1$adapted(RenaissanceSuite.scala:159)
	at scala.collection.immutable.List.foreach(List.scala:333)
	at org.renaissance.harness.RenaissanceSuite$.runBenchmarks(RenaissanceSuite.scala:159)
	at org.renaissance.harness.RenaissanceSuite$.main(RenaissanceSuite.scala:132)
	at org.renaissance.harness.RenaissanceSuite.main(RenaissanceSuite.scala)
The following benchmarks failed: dotty
```