### PR TITLE
Avoid using iterator to access ArrayBuffer that can be modified during iteration

### DIFF
--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleChirper.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleChirper.scala
@@ -53,17 +53,22 @@ final class FinagleChirper extends Benchmark {
     var requestCount = 0
     var postCount = 0
 
-    def analyze[T](feed: SeqView[String], zero: T, f: String => T, op: (T, T) => T): T = {
+    def analyze[T](
+      feed: IndexedSeqView[String],
+      zero: T,
+      f: String => T,
+      op: (T, T) => T
+    ): T = {
       val a = new Accumulator(zero)(op)
       for (msg <- feed) a.accumulate(f(msg))
       a.get()
     }
 
-    def longestMessageInFeed(feed: SeqView[String]): String = {
+    def longestMessageInFeed(feed: IndexedSeqView[String]): String = {
       analyze[String](feed, "", x => x, (x, y) => if (x.length > y.length) x else y)
     }
 
-    def longestMessageInAllFeeds(allFeeds: Seq[SeqView[String]]): String = {
+    def longestMessageInAllFeeds(allFeeds: Seq[IndexedSeqView[String]]): String = {
       var result = ""
       for (feed <- allFeeds) {
         val r = longestMessageInFeed(feed)
@@ -87,7 +92,7 @@ final class FinagleChirper extends Benchmark {
       result
     }
 
-    def longestRechirpInAllFeeds(allFeeds: Seq[SeqView[String]]): String = {
+    def longestRechirpInAllFeeds(allFeeds: Seq[IndexedSeqView[String]]): String = {
       var result = ""
       for (feed <- allFeeds) {
         val s = analyze[String](
@@ -105,7 +110,7 @@ final class FinagleChirper extends Benchmark {
       result
     }
 
-    def mostRechirpsInAllFeeds(allFeeds: Seq[(String, SeqView[String])]): Long = {
+    def mostRechirpsInAllFeeds(allFeeds: Seq[(String, IndexedSeqView[String])]): Long = {
       val counts = ConcurrentHashMultiset.create[String]()
       allFeeds.par.foreach {
         case (username, feed) =>

--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleChirper.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleChirper.scala
@@ -118,7 +118,7 @@ final class FinagleChirper extends Benchmark {
       counts
         .entrySet()
         .parallelStream()
-        .map[Integer]((t: Entry[String]) => t.getCount)
+        .map[Integer] { t: Entry[String] => t.getCount }
         .max(Comparator.naturalOrder[Integer]())
         .get
         .toLong

--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ val scalaVersion213 = "2.13.8"
 val modulesPropertiesName = "modules.properties"
 val benchmarksPropertiesName = "benchmarks.properties"
 val harnessMainClass = "org.renaissance.harness.RenaissanceSuite"
+val launcherMainClass = "org.renaissance.core.Launcher"
 
 lazy val commonSettingsNoScala = Seq(
   // Don't add Scala version to JAR name.
@@ -139,7 +140,8 @@ val slf4jVersion = "1.7.33"
 lazy val renaissanceCore = (project in file("renaissance-core"))
   .settings(
     commonSettingsNoScala,
-    name := "renaissance-core"
+    name := "renaissance-core",
+    Compile / mainClass := Some(launcherMainClass)
   )
 
 val renaissanceHarnessCommonSettings = Seq(


### PR DESCRIPTION
The switch to Scala 2.13 apparently unearthed an issue that has been present in `finagle-chirper` all the time. The code changes in `finagle-chirper` between Renaissance 0.13 and Renaissance 0.14 were only meant to "port" it to Scala 2.13 and required changing the signature of various methods that compute feed stats to accept a `SeqView` instead of `Seq` (because in Scala 2.13, a non-strict `SeqView` is no longer a subtype of a strict `Seq`), but even in Scala 2.12, the `view` method of an `ArrayBuffer` returned a `SeqView`.

The main cause appears to be the fact that the `analyze()` method accesses an `ArrayBuffer` (representing a per-user feed) without a lock. The feed is appended to under a lock in the `Master`, but no lock is held when calculating stats on individual feeds (in a `Future`). When processing a request for feed stats, the lock is held while creating a read only snapshot of the trie that holds all user feeds and a view is created for each feed (which essentially snapshots the number of items in the feed), but the view is processed later.

The `analyze()` function running as part of the future evaluation uses an iterator to go over chirps in a feed, but the underlying ArrayBuffer can be modified (appended to) in the meantime. In Scala 2.13 this results in the `ConcurrentModificationException`. I tested the same code in Scala 2.12 (with the same libraries) and I was not able to reproduce the problem.

Now, I believe that the race is intentional and should be benign (similar to updating profiling counters in hotspot), so to keep it the way it was, I just changed the `analyze()` method to avoid using an iterator and instead iterate over a `Range` and then access the `ArrayBuffer` elements by index. This should be "safe" even if the `ArrayBuffer` is expanded (and the backing array changed) because the `ArrayBuffer` is only appended to. Using a direct index should either fetch the element from an old array or the new array, but the returned item should be the same &mdash; assuming the implementation updates the reference to the backing array **after** it has copied the contents of the old array to the new array.

* Strictly speaking, I'm not sure whether even this would hold under the memory model, but I understand the desire to avoid locking for these computations &mdash; the whole point of the stats is to provide some reasonable numbers at some point in time and if some updates come in between, they will be included in the next stats call.

Fixes #354 (as long as keeping the race can be considered a fix)