### PR TITLE
Avoid using the formatted() method in CafeSAT

### DIFF
--- a/benchmarks/scala-sat/cafesat/src/main/scala/cafesat/theories/adt/AdtSolver.scala
+++ b/benchmarks/scala-sat/cafesat/src/main/scala/cafesat/theories/adt/AdtSolver.scala
@@ -817,7 +817,7 @@ class AdtSolver {
 
   def dumpTerms(): String =
     (terms.zipWithIndex map { case (term, i) =>
-      val strI = i.formatted("%2d")
+      val strI = "%2d".format(i)
       s"   $strI: $term"
     }).mkString("Terms:\n", "\n", "")
 


### PR DESCRIPTION
This is just a tiny fix to use the `format()` method on the format string, because in Java 15 and later, the `formatted()` resolves to the new method in `String` which has reversed parameters. I not aware of Java 15 related bugs because of that (that particular code might not be even used), but I noticed the compiler complaining about it after the 0.14 release and it kept nagging at me. If we are to make a bugfix release, I guess we can sneak this in as well.