### PR TITLE
Avoid incorrect usage of partially-initialized objects in `reactors` benchmark

### DIFF
--- a/benchmarks/actors-reactors/src/main/scala/org/renaissance/actors/Reactors.scala
+++ b/benchmarks/actors-reactors/src/main/scala/org/renaissance/actors/Reactors.scala
@@ -588,9 +588,10 @@ private object ThreadRing {
           }
         })
       }).toArray
-      ring(0) ! 666
     }
-    new RingInner
+
+    val ring = new RingInner
+    ring.ring(0) ! 666
 
     Validators.simple("ThreadRing", 0, Await.result(done.future, Duration.Inf).longValue)
   }

--- a/benchmarks/actors-reactors/src/main/scala/org/renaissance/actors/Reactors.scala
+++ b/benchmarks/actors-reactors/src/main/scala/org/renaissance/actors/Reactors.scala
@@ -534,8 +534,7 @@ private object Roundabout {
       }
     })
 
-    system.spawn(Reactor[Array[Channel[Int]]] { self =>
-      roundabout ! self.main.channel
+    val roundRobinDistributor = system.spawn(Reactor[Array[Channel[Int]]] { self =>
       self.main.events.onEvent { chs =>
         var i = 0
         while (i < Roundabout.NUM_MESSAGES) {
@@ -545,6 +544,8 @@ private object Roundabout {
         self.main.seal()
       }
     })
+
+    roundabout ! roundRobinDistributor
 
     Validators.simple(
       "Roundabout",


### PR DESCRIPTION
The `PingPong` and `StreamingPingPong` sub-benchmarks use an inner class to work around the circular dependency between the `ping` and `pong` reactors. However, because reactors execute asynchronously with respect to the main thread and because the communication between the two reactors is started before the inner class is fully initialized, the `pong` reactor may actually observe an uninitialized reference (inner class instance variable) to the `ping` reactor (the `pong` reactor's event handler may start executing before the constructor of the inner class finishes). This is most likely what is going on in #359.

Because the reactor initialization mixes code executed synchronously with lambdas that capture environment but execute asynchronously (event handlers), the ordering of things is not immediately obvious. The commits in this PR separate the reactor setup code from the code that starts the communication and make sure that both happen on the main thread to keep them ordered. In the PingPong-style benchmarks, even though the reference to the inner class instance becomes part of the closure of the event handling lambdas, the communication is started only after the inner class instance is fully initialized, which apparently fixes #359.

Similar changes (to start the communication on the main thread) have been made to the `ThreadRing` and `RoundAbout` sub-benchmarks for clarity (no bugs have been reported for those).