### PR TITLE
GHA: various small improvements

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.cache/coursier
-          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+          key: ${{ runner.os }}-sbt-${{ hashFiles('build.sbt') }}
 
       - name: Environment configuration
         shell: bash

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,6 +20,7 @@ jobs:
           - openj9-openjdk11
           - openj9-openjdk16
     runs-on: ubuntu-latest
+    continue-on-error: true
     container: "renaissancebench/buildenv:${{ matrix.image }}"
     steps:
       - name: Git checkout

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,8 @@
 name: Linux
-on: [push, pull_request]
+on:
+  workflow_run:
+    workflows: [Main]
+    types: [completed]
 jobs:
   linux:
     strategy:
@@ -20,6 +23,7 @@ jobs:
           - openj9-openjdk11
           - openj9-openjdk16
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     continue-on-error: true
     container: "renaissancebench/buildenv:${{ matrix.image }}"
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,11 +1,15 @@
 name: MacOS (legacy)
-on: [push, pull_request]
+on:
+  workflow_run:
+    workflows: [Main]
+    types: [completed]
 jobs:
   macos:
     strategy:
       matrix:
         java: [ '8', '11', '13', '15' ]
     runs-on: macos-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     continue-on-error: true
     steps:
       - name: Git checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Main
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.cache/coursier
-          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+          key: ${{ runner.os }}-sbt-${{ hashFiles('build.sbt') }}
 
       - name: Check file encoding
         shell: bash
@@ -52,7 +52,7 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.cache/coursier
-          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+          key: ${{ runner.os }}-sbt-${{ hashFiles('build.sbt') }}
 
       - name: Environment configuration
         shell: bash

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -17,7 +17,7 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.cache/coursier
-          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+          key: ${{ runner.os }}-sbt-${{ hashFiles('build.sbt') }}
 
       - name: Environment configuration
         shell: bash

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1,8 +1,12 @@
 name: Plugins
-on: [push, pull_request]
+on:
+  workflow_run:
+    workflows: [Main]
+    types: [completed]
 jobs:
   plugins:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     container: "renaissancebench/buildenv:openjdk8-with-ant-gcc"
     steps:
       - name: Git checkout

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,6 +6,7 @@ jobs:
       matrix:
         java: [ '8', '11' , '13', '15' ]
     runs-on: windows-latest
+    continue-on-error: true
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,11 +1,15 @@
 name: "Windows (legacy)"
-on: [push, pull_request]
+on:
+  workflow_run:
+    workflows: [Main]
+    types: [completed]
 jobs:
   windows:
     strategy:
       matrix:
         java: [ '8', '11' , '13', '15' ]
     runs-on: windows-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     continue-on-error: true
     steps:
       - name: Git checkout

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -12,6 +12,7 @@ import java.io.File
 import java.lang.management.MemoryUsage
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -101,15 +102,19 @@ private abstract class ResultWriter
     } yield (benchName, benchFailed, metricsByName, repetitionCount)
 
   protected final def writeToFile(file: Path, string: String): Unit = {
-    val writer = Files.newBufferedWriter(
-      file,
-      StandardOpenOption.CREATE,
-      StandardOpenOption.TRUNCATE_EXISTING
-    )
-    try {
-      writer.append(string)
-    } finally {
-      writer.close()
+    if (file.equals(Paths.get("-"))) {
+      println(string)
+    } else {
+      val writer = Files.newBufferedWriter(
+        file,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING
+      )
+      try {
+        writer.append(string)
+      } finally {
+        writer.close()
+      }
     }
   }
 

--- a/tools/ci/bench-show-env.sh
+++ b/tools/ci/bench-show-env.sh
@@ -6,4 +6,4 @@ source "$(dirname "$0")/common.sh"
 
 set -x
 
-java -Xms1g -Xmx1g -jar "$RENAISSANCE_JAR" -c test -r 1 --json /dev/stdout dummy-empty
+java -Xms1g -Xmx1g -jar "$RENAISSANCE_JAR" -c test -r 1 --json - dummy-empty


### PR DESCRIPTION
## Base cache id on main sbt only 

No need to recursively scan all directories.

Furthermore, it seems to cause spurious errors with some runners where some of the temp directories were inaccessible.

Actually, using cache id of `{{ os }}-sbt` should be enough as the versions are handled by SBT anyway and there is no need to drop the whole cache when upgrading one package but this is probably safer.

## Continue on errors

Since GitHub allows (finally) to restart a single job, it seems better to allow all jobs to continue (even if one of them fails) as many of the failures are spurious ones anyway.

## Use `-` instead of `/dev/stdout`

Somehow the use of `/dev/stdout` caused hard-to-explain errors on Windows runners (when executing `tools/ci/bench-show-env.sh`). Now the `ResultWriter` explicitly handles `-` to print to standard output (as is usual for many Unix utilities). As an extra benefit, we do not close stdout this way.

## Workflow chaining

Run the `Main` workflow first and run the other ones (more JDKs etc.) only if it succeeds.

This probably would need to be merged first (according to the [second note here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)).

## Reducing CI jobs

The `Main` workflow was reduced to run on `master` branch and PRs only. Therefore, we should not see that for an opened PR there are jobs related to the branch _and_ to the PR that are actually testing exactly the same code.

One can always create a draft PR to check the branch (otherwise, mere `git push` will not trigger a CI).
