### PR TITLE
Bump slf4j to safe version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -135,7 +135,7 @@ val jnaVersion = "5.10.0"
 val nettyVersion = "4.1.72.Final"
 val scalaCollectionCompatVersion = "2.6.0"
 val scalaParallelCollectionsVersion = "1.0.4"
-val slf4jVersion = "1.7.33"
+val slf4jVersion = "1.7.36"
 
 lazy val renaissanceCore = (project in file("renaissance-core"))
   .settings(


### PR DESCRIPTION
Bump slf4j to version that does not ship a vulnerable log4j version (see https://www.slf4j.org/news.html). Version 1.7.36 ships with reload4j instead of the affected log4j.

This essentially prevents security scanners from flagging the renaissance benchmark suite as a security risk.

Fixes  #365