### PR TITLE
Remove log4j dependencies

### DIFF
--- a/benchmarks/actors-akka/src/main/resources/reference.conf
+++ b/benchmarks/actors-akka/src/main/resources/reference.conf
@@ -1,0 +1,15 @@
+# Override configuration in actors-akka.jar
+
+akka {
+
+  # Log level used by the configured loggers (see "loggers") as soon
+  # as they have been started; before that, see "stdout-loglevel"
+  # Options: OFF, ERROR, WARNING, INFO, DEBUG
+  loglevel = "WARNING"
+
+  # Log level for the very basic logger activated during ActorSystem startup.
+  # This logger prints the log messages to stdout (System.out).
+  # Options: OFF, ERROR, WARNING, INFO, DEBUG
+  stdout-loglevel = "WARNING"
+
+}

--- a/benchmarks/apache-spark/src/main/resources/log4j.properties
+++ b/benchmarks/apache-spark/src/main/resources/log4j.properties
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the console
+log4j.rootCategory=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Set the default spark-shell log level to WARN. When running the spark-shell, the
+# log level for this class is used to overwrite the root logger's log level, so that
+# the user can have different defaults for the shell and regular Spark apps.
+log4j.logger.org.apache.spark.repl.Main=WARN
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.sparkproject.jetty=WARN
+log4j.logger.org.sparkproject.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs
+# in SparkSQL with Hive support
+log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
+log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
+
+# Parquet related logging
+log4j.logger.org.apache.parquet.CorruptStatistics=ERROR
+log4j.logger.parquet.CorruptStatistics=ERROR

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
@@ -1,7 +1,6 @@
 package org.renaissance.apache.spark
 
 import org.apache.log4j.Level
-import org.apache.log4j.LogManager
 import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
@@ -147,19 +146,6 @@ trait SparkUtil {
 
   def tearDownSparkContext(): Unit = {
     sparkSession.close()
-  }
-
-  // Used to find sources of log messages.
-  private def printCurrentLoggers() = {
-    import scala.jdk.CollectionConverters._
-
-    println(
-      LogManager.getCurrentLoggers.asScala
-        .map { case l: Logger => l.getName }
-        .toSeq
-        .sorted
-        .mkString("\n")
-    )
   }
 
   /**

--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleChirper.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleChirper.scala
@@ -452,6 +452,8 @@ final class FinagleChirper extends Benchmark {
   private var userNames: Seq[String] = _
 
   override def setUpBeforeAll(c: BenchmarkContext): Unit = {
+    FinagleUtil.setUpLoggers()
+
     requestCountParam = c.parameter("request_count").toPositiveInteger
     val userCountParam = c.parameter("user_count").toPositiveInteger
 

--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleHttp.scala
@@ -100,6 +100,8 @@ final class FinagleHttp extends Benchmark {
   var threadBarrier: CountDownLatch = _
 
   override def setUpBeforeAll(c: BenchmarkContext): Unit = {
+    FinagleUtil.setUpLoggers()
+
     requestCountParam = c.parameter("request_count").toPositiveInteger
     clientCountParam = c.parameter("client_count").toPositiveInteger
 

--- a/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleUtil.scala
+++ b/benchmarks/twitter-finagle/src/main/scala/org/renaissance/twitter/finagle/FinagleUtil.scala
@@ -1,0 +1,38 @@
+package org.renaissance.twitter.finagle
+
+import java.util.logging.Level
+import java.util.logging.Logger
+
+object FinagleUtil {
+
+  /**
+   * Configures log levels of Finagle components to mask info messages. Unfortunately,
+   * Finagle itself currently uses `java.util.logging` through its own `util-logging`
+   * facade, while the included Netty libraries use `org.slf4j`. Because JUL is used
+   * directly (cannot be easily replaced) and only reads the default configuration
+   * from `${java.home}/lib/logging.properties` (which cannot be easily modified), we
+   * set the logging level for a some of the loggers here.
+   */
+  def setUpLoggers(): Unit = {
+    //
+    // Using a custom properties files and triggering JUL reconfiguration through the
+    // LogManager's `readConfiguration()` method also calls the `reset()` method, which
+    // affects everybody using JUL (including the Renaissance harness). Instead, we
+    // configure the log level for a few specific loggers.
+    //
+    // TODO Revisit logging after updating Finagle libraries.
+    //
+    val loggerLevels = Seq(
+      // Parent for `com.twitter.jvm` and `com.twitter.app`.
+      "com.twitter" -> Level.WARNING,
+      // Parent for many loggers below `com.twitter.finagle`.
+      "com.twitter.finagle" -> Level.WARNING,
+      // `com.github.benmanes.caffeine.cache` apparently uses the root logger as parent.
+      "" -> Level.WARNING
+    )
+
+    loggerLevels.foreach {
+      case (name: String, level: Level) => Logger.getLogger(name).setLevel(level)
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -220,9 +220,10 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-core" % sparkVersion,
       "org.apache.spark" %% "spark-sql" % sparkVersion,
-      "org.apache.spark" %% "spark-mllib" % sparkVersion,
-      // Force newer Netty version.
-      // Overrides versions pulled in by dependencies.
+      "org.apache.spark" %% "spark-mllib" % sparkVersion
+    ),
+    dependencyOverrides ++= Seq(
+      // Force common (newer) Netty version.
       "io.netty" % "netty-all" % nettyVersion,
       // Force newer Zookeeper version.
       "org.apache.zookeeper" % "zookeeper" % "3.6.3",
@@ -262,10 +263,12 @@ lazy val databaseBenchmarks = (project in file("benchmarks/database"))
         ExclusionRule("net.openhft", "chronicle-threads"),
         ExclusionRule("org.slf4j", "slf4j-api")
       ),
+      // Add simple binding to silence SLF4J warnings.
+      "org.slf4j" % "slf4j-simple" % slf4jVersion
+    ),
+    dependencyOverrides ++= Seq(
       // Force newer JNA to support more platforms/architectures.
       "net.java.dev.jna" % "jna-platform" % jnaVersion,
-      // Add simple binding to silence SLF4J warnings.
-      "org.slf4j" % "slf4j-simple" % slf4jVersion,
       // Force common versions of other dependencies.
       "com.google.guava" % "guava" % guavaVersion,
       "org.slf4j" % "jcl-over-slf4j" % slf4jVersion
@@ -298,11 +301,21 @@ lazy val neo4jBenchmarks = (project in file("benchmarks/neo4j"))
     libraryDependencies ++= Seq(
       // neo4j 4.4 does not support Scala 2.13 yet.
       "org.neo4j" % "neo4j" % "4.4.2",
-      "net.liftweb" %% "lift-json" % "3.5.0",
+      "net.liftweb" %% "lift-json" % "3.5.0"
+    ),
+    dependencyOverrides ++= Seq(
       // Force newer JNA to support more platforms/architectures.
       "net.java.dev.jna" % "jna" % jnaVersion,
-      // Force common versions of other dependencies.
-      "io.netty" % "netty-all" % nettyVersion,
+      // Force common (newer) Netty version. We need to override specific
+      // packages because the project does not depend on netty-all.
+      "io.netty" % "netty-buffer" % nettyVersion,
+      "io.netty" % "netty-codec-http" % nettyVersion,
+      "io.netty" % "netty-common" % nettyVersion,
+      "io.netty" % "netty-handler" % nettyVersion,
+      "io.netty" % "netty-resolver" % nettyVersion,
+      "io.netty" % "netty-transport" % nettyVersion,
+      "io.netty" % "netty-transport-native-epoll" % nettyVersion,
+      "io.netty" % "netty-transport-native-unix-common" % nettyVersion,
       "org.slf4j" % "slf4j-nop" % slf4jVersion
     )
   )
@@ -326,7 +339,9 @@ lazy val scalaDottyBenchmarks = (project in file("benchmarks/scala-dotty"))
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala3-compiler_3" % "3.0.2",
       // The following is required to compile the workload sources.
-      "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+      "org.scala-lang" % "scala-compiler" % scalaVersion.value
+    ),
+    dependencyOverrides ++= Seq(
       // Force newer JNA to support more platforms/architectures.
       "net.java.dev.jna" % "jna" % jnaVersion
     )
@@ -378,9 +393,22 @@ lazy val twitterFinagleBenchmarks = (project in file("benchmarks/twitter-finagle
       "com.twitter" %% "util-core" % finagleVersion,
       "org.scala-lang.modules" %% "scala-parallel-collections" % scalaParallelCollectionsVersion,
       // Add simple binding to silence SLF4J warnings.
-      "org.slf4j" % "slf4j-simple" % slf4jVersion,
-      // Force common versions of other dependencies.
-      "io.netty" % "netty-all" % nettyVersion,
+      "org.slf4j" % "slf4j-simple" % slf4jVersion
+    ),
+    dependencyOverrides ++= Seq(
+      // Force common (newer) Netty version. We need to override specific
+      // packages because the project does not depend on netty-all.
+      "io.netty" % "netty-buffer" % nettyVersion,
+      "io.netty" % "netty-codec" % nettyVersion,
+      "io.netty" % "netty-codec-http" % nettyVersion,
+      "io.netty" % "netty-codec-http2" % nettyVersion,
+      "io.netty" % "netty-common" % nettyVersion,
+      "io.netty" % "netty-handler" % nettyVersion,
+      "io.netty" % "netty-handler-proxy" % nettyVersion,
+      "io.netty" % "netty-resolver" % nettyVersion,
+      "io.netty" % "netty-transport" % nettyVersion,
+      "io.netty" % "netty-transport-native-epoll" % nettyVersion,
+      "io.netty" % "netty-transport-native-unix-common" % nettyVersion,
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -126,7 +126,6 @@ val generateManifestAttributesTask = Def.task {
 //
 
 val commonsIoVersion = "2.11.0"
-val commonsLoggingVersion = "1.2"
 val commonsCompressVersion = "1.21"
 val commonsMath3Version = "3.6.1"
 val commonsTextVersion = "1.9"
@@ -222,6 +221,14 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
       "org.apache.spark" %% "spark-sql" % sparkVersion,
       "org.apache.spark" %% "spark-mllib" % sparkVersion
     ),
+    // Exclude legacy logging libraries.
+    excludeDependencies ++= Seq(
+      // Replaced by the jcl-over-slf4j logging bridge.
+      ExclusionRule("commons-logging", "commons-logging"),
+      // Replaced by reload4j pulled in by recent slf4j-log4j12.
+      ExclusionRule("log4j", "log4j")
+    ),
+    // Override versions pulled in by dependencies.
     dependencyOverrides ++= Seq(
       // Force common (newer) Netty version.
       "io.netty" % "netty-all" % nettyVersion,
@@ -230,15 +237,17 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
       // Force common versions of other dependencies.
       "com.google.guava" % "guava" % guavaVersion,
       "commons-io" % "commons-io" % commonsIoVersion,
-      "commons-logging" % "commons-logging" % commonsLoggingVersion,
       "org.apache.commons" % "commons-compress" % commonsCompressVersion,
       "org.apache.commons" % "commons-math3" % commonsMath3Version,
       "org.apache.commons" % "commons-text" % commonsTextVersion,
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.scala-lang.modules" %% "scala-parallel-collections" % scalaParallelCollectionsVersion,
+      // Starting with version 1.7.36, slf4j-log4j12 pulls in slf4j-reload4j to replace log4j.
       "org.slf4j" % "slf4j-log4j12" % slf4jVersion,
       "org.slf4j" % "jcl-over-slf4j" % slf4jVersion,
-      "org.slf4j" % "jul-to-slf4j" % slf4jVersion
+      "org.slf4j" % "jul-to-slf4j" % slf4jVersion,
+      // Force newer reload4j version.
+      "ch.qos.reload4j" % "reload4j" % "1.2.24"
     )
   )
   .dependsOn(renaissanceCore % "provided")


### PR DESCRIPTION
Attempt to completely remove `log4j` from `apache-spark` dependencies. Complements #365 which updated `slf4j-log4j12` to pull in `reload4j`, but did not remove direct the Spark dependency on `log4j`.  With `log4j` removed, there seem to be some rough edges (missing appenders), probably configuration related. If this can be sorted out, we can do a minimal-change maintenance release, otherwise we'll see if the problems go away on its own after updating most of the dependencies.