### PR TITLE
CI: use versioned image names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: "renaissancebench/buildenv:openjdk8"
+    container: "renaissancebench/buildenv:v1-openjdk8"
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    container: "renaissancebench/buildenv:openjdk17"
+    container: "renaissancebench/buildenv:v1-openjdk17"
     continue-on-error: true
     steps:
       - name: Git checkout
@@ -180,7 +180,7 @@ jobs:
   plugins:
     runs-on: ubuntu-latest
     needs: linux
-    container: "renaissancebench/buildenv:openjdk8-with-ant-gcc"
+    container: "renaissancebench/buildenv:v1-openjdk8-with-ant-gcc"
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
@@ -233,7 +233,7 @@ jobs:
           - openj9-openjdk16
     runs-on: ubuntu-latest
     continue-on-error: true
-    container: "renaissancebench/buildenv:${{ matrix.image }}"
+    container: "renaissancebench/buildenv:v1-${{ matrix.image }}"
     steps:
       - name: Git checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
So far, images from the `docker.io/renaissancebench/buildenv` were versioned by JDK version only. That makes testing of new images impractical as there is no way to distinguish releases of the images (e.g. the image name does not reflect which Fedora version was used).

Thus pushing new version to DockerHub immediately influences how we build _any_ version of Renaissance here on GitHub CI.

The `v1-` version is a tagged version of existing images and hence the transition should be smooth.

`v2-` would come in a separate PR and would probably introduce images built on Fedora 37 and for newer JDKs too.