### PR TITLE
CI: add JDK 20, test on Fedora 37

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     container: "renaissancebench/buildenv:v3-openjdk8"
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -44,7 +44,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -134,7 +134,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -183,7 +183,7 @@ jobs:
     container: "renaissancebench/buildenv:v3-openjdk8-with-ant-gcc"
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -238,7 +238,7 @@ jobs:
     container: "renaissancebench/buildenv:v3-${{ matrix.image }}"
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -285,7 +285,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -332,7 +332,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: "renaissancebench/buildenv:v3-openjdk8"
+    container: "renaissancebench/buildenv:v4-openjdk8"
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    container: "renaissancebench/buildenv:v3-openjdk17"
+    container: "renaissancebench/buildenv:v4-openjdk17"
     continue-on-error: true
     steps:
       - name: Git checkout
@@ -196,7 +196,7 @@ jobs:
   plugins:
     runs-on: ubuntu-latest
     needs: linux
-    container: "renaissancebench/buildenv:v3-openjdk8-with-ant-gcc"
+    container: "renaissancebench/buildenv:v4-openjdk8-with-ant-gcc"
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -254,7 +254,7 @@ jobs:
           - openj9-openjdk16
     runs-on: ubuntu-latest
     continue-on-error: true
-    container: "renaissancebench/buildenv:v3-${{ matrix.image }}"
+    container: "renaissancebench/buildenv:v4-${{ matrix.image }}"
     steps:
       - name: Git checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: "renaissancebench/buildenv:v1-openjdk8"
+    container: "renaissancebench/buildenv:v3-openjdk8"
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    container: "renaissancebench/buildenv:v1-openjdk17"
+    container: "renaissancebench/buildenv:v3-openjdk17"
     continue-on-error: true
     steps:
       - name: Git checkout
@@ -180,7 +180,7 @@ jobs:
   plugins:
     runs-on: ubuntu-latest
     needs: linux
-    container: "renaissancebench/buildenv:v1-openjdk8-with-ant-gcc"
+    container: "renaissancebench/buildenv:v3-openjdk8-with-ant-gcc"
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
@@ -233,7 +233,7 @@ jobs:
           - openj9-openjdk16
     runs-on: ubuntu-latest
     continue-on-error: true
-    container: "renaissancebench/buildenv:v1-${{ matrix.image }}"
+    container: "renaissancebench/buildenv:v3-${{ matrix.image }}"
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fix Git safe directory
+        shell: bash
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
       - name: Cache SBT
         uses: actions/cache@v2
         with:
@@ -47,6 +51,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Fix Git safe directory
+        shell: bash
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - name: Cache SBT
         uses: actions/cache@v2
@@ -89,6 +97,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Fix Git safe directory
+        shell: bash
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - name: Fetch JDK 17
         run: |
@@ -138,6 +150,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fix Git safe directory
+        shell: bash
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
       - name: Fetch JDK 17
         run: |
           aria2c -d ${{ runner.temp }} -o openjdk-17_windows-x64_bin.zip https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_windows-x64_bin.zip
@@ -186,6 +202,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Fix Git safe directory
+        shell: bash
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - name: Cache SBT
         uses: actions/cache@v2
@@ -242,6 +262,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fix Git safe directory
+        shell: bash
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
       - name: Cache SBT
         uses: actions/cache@v2
         with:
@@ -289,6 +313,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fix Git safe directory
+        shell: bash
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
       - name: Setup correct Java version
         uses: actions/setup-java@v2
         with:
@@ -335,6 +363,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Fix Git safe directory
+        shell: bash
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - name: Setup correct Java version
         uses: actions/setup-java@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -226,8 +226,10 @@ jobs:
           - openjdk14
           - openjdk15
           - openjdk16
-          - openjdk18-ea
-          - openjdk19-ea
+          - openjdk18
+          - openjdk19
+          - openjdk20
+          - openjdk21-ea
           - openj9-openjdk8
           - openj9-openjdk11
           - openj9-openjdk16

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,7 +249,6 @@ jobs:
           - openjdk18
           - openjdk19
           - openjdk20
-          - openjdk21-ea
           - openj9-openjdk8
           - openj9-openjdk11
           - openj9-openjdk16

--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -52,7 +52,7 @@ cp_reflink() {
 
 get_jvm_workaround_args() {
     case "$RENAISSANCE_JVM_MAJOR_VERSION" in
-        16|17|18-ea|19-ea)
+        16|17|18|18-ea|19|19-ea|20|21-ea)
             echo "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
             echo "--add-opens=java.base/java.util=ALL-UNNAMED"
             echo "--add-opens=java.base/java.nio=ALL-UNNAMED"


### PR DESCRIPTION
Overall a small change for CI, mostly covered by changes in the Docker images used for the testing.

* Added JDK 20 image
  * 21-ea blocked by #370 
* Use 18 and 19 releases (instead of early access builds)
* Moved to Fedora 37 as the base image
* Bypass issue with Git unsafe directory (see https://github.com/actions/checkout/issues/760)
  * Not sure why the extra call is still needed though (updating to newer `actions/checkout` did not help)

There are still appearing spurious issues when building JMH image (when list of benchmarks is empty) and sometimes even some concurrent exception is raised by SBT itself. Seems that they are not caused by this change and I was unable to reproduce them locally.