### PR TITLE
Temporarily restrict supported JVM version in benchmarks broken changes in JDK21

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,35 +67,35 @@ The following is the complete list of benchmarks, separated into groups.
 
 - `als` - Runs the ALS algorithm from the Spark ML library.
   \
-  Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 1.8 - 20
 
 - `chi-square` - Runs the chi-square test from Spark MLlib.
   \
-  Default repetitions: 60; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 60; APACHE2 license, MIT distribution; Supported JVM: 1.8 - 20
 
 - `dec-tree` - Runs the Random Forest algorithm from the Spark ML library.
   \
-  Default repetitions: 40; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 40; APACHE2 license, MIT distribution; Supported JVM: 1.8 - 20
 
 - `gauss-mix` - Computes a Gaussian mixture model using expectation-maximization.
   \
-  Default repetitions: 40; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 40; APACHE2 license, MIT distribution; Supported JVM: 1.8 - 20
 
 - `log-regression` - Runs the Logistic Regression algorithm from the Spark ML library.
   \
-  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 - 20
 
 - `movie-lens` - Recommends movies using the ALS algorithm.
   \
-  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 - 20
 
 - `naive-bayes` - Runs the multinomial Naive Bayes algorithm from the Spark ML library.
   \
-  Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 1.8 - 20
 
 - `page-rank` - Runs a number of PageRank iterations, using RDDs.
   \
-  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 - 20
 
 #### concurrency
 
@@ -147,7 +147,7 @@ The following is the complete list of benchmarks, separated into groups.
 
 - `dotty` - Runs the Dotty compiler on a set of source code files.
   \
-  Default repetitions: 50; BSD3 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 50; BSD3 license, MIT distribution; Supported JVM: 1.8 - 20
 
 - `philosophers` - Solves a variant of the dining philosophers problem using ScalaSTM.
   \

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
@@ -19,6 +19,7 @@ import scala.util.Random
 @Group("apache-spark")
 @Summary("Runs the ALS algorithm from the Spark ML library.")
 @Licenses(Array(License.APACHE2))
+@SupportsJvm("20")
 @Repetitions(30)
 @Parameter(
   name = "spark_thread_limit",

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ChiSquare.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ChiSquare.scala
@@ -20,6 +20,7 @@ import scala.util.Random
 @Group("apache-spark")
 @Summary("Runs the chi-square test from Spark MLlib.")
 @Licenses(Array(License.APACHE2))
+@SupportsJvm("20")
 @Repetitions(60)
 @Parameter(
   name = "spark_thread_limit",

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/DecTree.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/DecTree.scala
@@ -22,6 +22,7 @@ import java.nio.file.Path
 @Group("apache-spark")
 @Summary("Runs the Random Forest algorithm from the Spark ML library.")
 @Licenses(Array(License.APACHE2))
+@SupportsJvm("20")
 @Repetitions(40)
 @Parameter(
   name = "spark_thread_limit",

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/GaussMix.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/GaussMix.scala
@@ -19,6 +19,7 @@ import scala.util.Random
 @Group("apache-spark")
 @Summary("Computes a Gaussian mixture model using expectation-maximization.")
 @Licenses(Array(License.APACHE2))
+@SupportsJvm("20")
 @Repetitions(40)
 @Parameter(
   name = "spark_thread_limit",

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/LogRegression.scala
@@ -18,6 +18,7 @@ import java.nio.file.Path
 @Group("apache-spark")
 @Summary("Runs the Logistic Regression algorithm from the Spark ML library.")
 @Licenses(Array(License.APACHE2))
+@SupportsJvm("20")
 @Repetitions(20)
 @Parameter(
   name = "spark_thread_limit",

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/MovieLens.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/MovieLens.scala
@@ -22,6 +22,7 @@ import scala.collection.Map
 @Group("apache-spark")
 @Summary("Recommends movies using the ALS algorithm.")
 @Licenses(Array(License.APACHE2))
+@SupportsJvm("20")
 @Repetitions(20)
 @Parameter(
   name = "spark_thread_limit",

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/NaiveBayes.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/NaiveBayes.scala
@@ -17,6 +17,7 @@ import java.nio.file.Path
 @Group("apache-spark")
 @Summary("Runs the multinomial Naive Bayes algorithm from the Spark ML library.")
 @Licenses(Array(License.APACHE2))
+@SupportsJvm("20")
 @Repetitions(30)
 @Parameter(
   name = "spark_thread_limit",

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/PageRank.scala
@@ -19,6 +19,7 @@ import scala.io.BufferedSource
 @Group("apache-spark")
 @Summary("Runs a number of PageRank iterations, using RDDs.")
 @Licenses(Array(License.APACHE2))
+@SupportsJvm("20")
 @Repetitions(20)
 @Parameter(
   name = "spark_thread_limit",

--- a/benchmarks/scala-dotty/src/main/scala/org/renaissance/scala/dotty/Dotty.scala
+++ b/benchmarks/scala-dotty/src/main/scala/org/renaissance/scala/dotty/Dotty.scala
@@ -37,6 +37,7 @@ import scala.collection._
 @Group("scala-dotty")
 @Summary("Runs the Dotty compiler on a set of source code files.")
 @Licenses(Array(License.BSD3))
+@SupportsJvm("20")
 @Repetitions(50)
 @Configuration(name = "test")
 @Configuration(name = "jmh")


### PR DESCRIPTION
Changes in JDK21 break apache-spark benchmarks and the scala-dotty benchmark (see #370 and #384). With the apache-spark benchmarks, we are waiting for a fix that is expected to appear in Spark 3.5. With the scala-dotty benchmark, we need to check if the issue is handled upstream. For the time being (to allow including JDK21 in the CI testing matrix), we will restrict the supported JVM in these benchmark to JDK20.