### PR TITLE
Use GitHub Dependabot for Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+      interval: "weekly"


### PR DESCRIPTION
This setup should ensure that whenever there is a new version of some of the GitHub actions modules (e.g. the one responsible for repository checkout) a bot creates an automated pull request with the new version.