### PR TITLE
Streamline CI

### DIFF
--- a/.github/workflows/ea-jdk.yml
+++ b/.github/workflows/ea-jdk.yml
@@ -1,0 +1,53 @@
+name: EA JDK
+on:
+  push:
+  schedule:
+    - cron: "17 23 17 * *"
+
+jobs:
+  linux-ea:
+    runs-on: ubuntu-latest
+    container: "fedora:34"
+    steps:
+      - name: Install base requirements
+        shell: bash
+        run: dnf install -y ca-certificates git unzip
+
+      - name: Git checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch latest EA JDK
+        run: tools/ci/get-latest-ea-jdk.sh $RUNNER_TEMP/jdk-ea-linux.tar.gz
+
+      - name: Setup EA JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: 99-ea
+          distribution: jdkfile
+          jdkFile: ${{ runner.temp }}/jdk-ea-linux.tar.gz
+
+      - name: Environment configuration
+        shell: bash
+        run: tools/ci/pre-show-env.sh
+
+      - name: Build both base & JMH bundles
+        shell: bash
+        run: tools/ci/build-both.sh
+
+      - name: Check JMH bundle
+        shell: bash
+        run: tools/ci/check-jmh.sh
+
+      - name: Run the suite
+        shell: bash
+        run: tools/ci/bench-base.sh
+
+      - name: Run the suite in standalone mode
+        shell: bash
+        run: tools/ci/bench-standalone.sh
+
+      - name: Run the suite with JMH
+        shell: bash
+        run: tools/ci/bench-jmh.sh

--- a/.github/workflows/ea-jdk.yml
+++ b/.github/workflows/ea-jdk.yml
@@ -1,8 +1,5 @@
 name: EA JDK
-on:
-  push:
-  schedule:
-    - cron: "17 23 17 * *"
+on: workflow_dispatch
 
 jobs:
   linux-ea:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: "renaissancebench/buildenv:v4-openjdk8"
+    container: "renaissancebench/buildenv:v5-openjdk8"
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    container: "renaissancebench/buildenv:v4-openjdk17"
+    container: "renaissancebench/buildenv:v5-openjdk17"
     continue-on-error: true
     steps:
       - name: Git checkout
@@ -196,7 +196,7 @@ jobs:
   plugins:
     runs-on: ubuntu-latest
     needs: linux
-    container: "renaissancebench/buildenv:v4-openjdk8-with-ant-gcc"
+    container: "renaissancebench/buildenv:v5-openjdk8-with-ant-gcc"
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -245,7 +245,7 @@ jobs:
           - openj9-openjdk16
     runs-on: ubuntu-latest
     continue-on-error: true
-    container: "renaissancebench/buildenv:v4-${{ matrix.image }}"
+    container: "renaissancebench/buildenv:v5-${{ matrix.image }}"
     steps:
       - name: Git checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -238,16 +238,7 @@ jobs:
       matrix:
         image:
           - openjdk8
-          - openjdk9
-          - openjdk10
           - openjdk11
-          - openjdk12
-          - openjdk13
-          - openjdk14
-          - openjdk15
-          - openjdk16
-          - openjdk18
-          - openjdk19
           - openjdk20
           - openj9-openjdk8
           - openj9-openjdk11
@@ -303,7 +294,7 @@ jobs:
     needs: windows
     strategy:
       matrix:
-        java: [ '8', '11' , '13', '15' ]
+        java: [ '8', '11' ]
     runs-on: windows-latest
     continue-on-error: true
     steps:
@@ -354,7 +345,7 @@ jobs:
     needs: macos
     strategy:
       matrix:
-        java: [ '8', '11', '13', '15' ]
+        java: [ '8', '11' ]
     runs-on: macos-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -242,7 +242,7 @@ jobs:
           - openjdk20
           - openj9-openjdk8
           - openj9-openjdk11
-          - openj9-openjdk16
+          - openj9-openjdk17
     runs-on: ubuntu-latest
     continue-on-error: true
     container: "renaissancebench/buildenv:v5-${{ matrix.image }}"

--- a/tools/ci/get-latest-ea-jdk.sh
+++ b/tools/ci/get-latest-ea-jdk.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Fail the script if any command fails
+set -ueo errexit
+
+msg() {
+    echo "$( date '+[%Y-%m-%d %H:%M:%S]:' )" "$@" >&2
+}
+
+get_latest_version() {
+    curl --silent https://jdk.java.net/ \
+        | sed -n '/[Ee]arly/s#.*href="\([/0-9]*\)".*#\1#p' \
+        | tr -d /
+}
+
+get_linux_tarball() {
+    curl --silent "https://jdk.java.net/$1/" \
+        | sed -n 's#.*href="\(https://download.java.net/.*openjdk.*linux-x64_bin.tar.gz\)".*#\1#p'
+}
+
+tarball_name="$1"
+mkdir -p "$( dirname "${tarball_name}" )"
+
+latest_version="$( get_latest_version )"
+msg "Detected latest early-access JDK to be ${latest_version}"
+
+tarball_url="$( get_linux_tarball "${latest_version}" )"
+msg "Will download tarball from ${tarball_url}"
+
+curl --progress-bar "${tarball_url}" -o "${tarball_name}"
+msg "Done, stored as ${tarball_name}"


### PR DESCRIPTION
Three major changes:

* CI runs only on LTS and latest JDK
  * Not JDK21-ea as we need to upgrade SBT and perhaps something else too?
* Switch to `v5` of the Docker images (new rebuilds, added OpenJ9 for 17, new Ant etc.)
* Make build on latest EA JDK on-demand only (not fully tested, these jobs can be executed only on master)

Overall, this should reduce CI time significantly while still keeping a wide range of tested JDK versions.