### PR TITLE
Introduce Scala 3 variant of the harness

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,7 @@ ThisBuild / git.useGitDescribe := true
 val javaRelease = "8"
 val scalaVersion212 = "2.12.15"
 val scalaVersion213 = "2.13.8"
+val scalaVersion3 = "3.3.1"
 
 // Explicitly target a specific JDK release.
 ThisBuild / javacOptions ++= Seq("-source", javaRelease, "-target", javaRelease)
@@ -81,6 +82,10 @@ lazy val commonSettingsScala212 = Seq(
 
 lazy val commonSettingsScala213 = Seq(
   scalaVersion := scalaVersion213
+)
+
+lazy val commonSettingsScala3 = Seq(
+  scalaVersion := scalaVersion3
 )
 
 //
@@ -169,6 +174,14 @@ val renaissanceHarnessCommonSettings = Seq(
   Compile / mainClass := Some(harnessMainClass),
   Compile / packageBin / packageOptions += generateManifestAttributesTask.value
 )
+
+lazy val renaissanceHarness3 = (project in file("renaissance-harness"))
+  .settings(
+    name := "renaissance-harness_3",
+    commonSettingsScala3,
+    renaissanceHarnessCommonSettings
+  )
+  .dependsOn(renaissanceCore % "provided")
 
 lazy val renaissanceHarness213 = (project in file("renaissance-harness"))
   .settings(
@@ -473,7 +486,7 @@ val renaissanceBenchmarks: Seq[Project] = Seq(
  * 'clean' task on the [[renaissance]] (root) project would break the build.
  */
 val aggregateProjects =
-  renaissanceBenchmarks :+ renaissanceHarness213 :+ renaissanceHarness212
+  renaissanceBenchmarks :+ renaissanceHarness3 :+ renaissanceHarness213 :+ renaissanceHarness212
 
 /**
  * The [[renaissanceModules]] collection contains projects that represent

--- a/renaissance-core/src/main/java/org/renaissance/core/BenchmarkSuite.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/BenchmarkSuite.java
@@ -215,7 +215,7 @@ public final class BenchmarkSuite {
   }
 
 
-  public final class SuiteBenchmarkContext implements BenchmarkContext {
+  public static final class SuiteBenchmarkContext implements BenchmarkContext {
     private final Path scratchDir;
     private final Configuration configuration;
 

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
@@ -211,31 +211,35 @@ object RenaissanceSuite {
 
     var nanosDiffMin = Long.MaxValue
     var streakLength = 0
-    do {
-      var nanosBefore = 0L
-      var currentMillis = 0L
+    while ({
+      {
+        var nanosBefore = 0L
+        var currentMillis = 0L
 
-      val lastMillis = System.currentTimeMillis()
-      var nanosAfter = System.nanoTime()
+        val lastMillis = System.currentTimeMillis()
+        var nanosAfter = System.nanoTime()
 
-      do {
-        nanosBefore = nanosAfter
-        currentMillis = System.currentTimeMillis()
-        nanosAfter = System.nanoTime()
-      } while (currentMillis == lastMillis)
+        while ({
+          {
+            nanosBefore = nanosAfter
+            currentMillis = System.currentTimeMillis()
+            nanosAfter = System.nanoTime()
+          }; currentMillis == lastMillis
+        }) ()
 
-      streakLength += 1
+        streakLength += 1
 
-      val nanosDiff = nanosAfter - nanosBefore
-      if (nanosDiff < nanosDiffMin) {
-        nanosDiffMin = nanosDiff
-        streakLength = 0
+        val nanosDiff = nanosAfter - nanosBefore
+        if (nanosDiff < nanosDiffMin) {
+          nanosDiffMin = nanosDiff
+          streakLength = 0
 
-        // Record the corresponding nanoTime() estimate.
-        syncNanos = (nanosBefore + nanosAfter) / 2
-        syncMillis = currentMillis
-      }
-    } while (streakLength < streakLengthMax)
+          // Record the corresponding nanoTime() estimate.
+          syncNanos = (nanosBefore + nanosAfter) / 2
+          syncMillis = currentMillis
+        }
+      }; streakLength < streakLengthMax
+    }) ()
 
     //
     // Approximate nanoTime() value at VM start based on the millisecond
@@ -395,11 +399,11 @@ object RenaissanceSuite {
       case PolicyType.FIXED_OP_COUNT =>
         val countProvider: ToIntFunction[String] = if (config.repetitions.isDefined) {
           // Global repetition count is set, overrides benchmark defaults
-          _: String =>
+          (_: String) =>
             config.repetitions.get
         } else {
           // Global repetition count is unset, get default value from benchmark
-          name: String =>
+          (name: String) =>
             benchmarks.find(info => info.name == name).get.repetitions()
         }
 

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/RenaissanceSuite.scala
@@ -367,8 +367,10 @@ object RenaissanceSuite {
   ): Either[String, Plugin] = {
     // Ensure that class path elements are readable (files or directories).
     val paths = specifier.paths.map(Paths.get(_))
-    paths.filterNot(Files.isReadable).foreach { path =>
-      return Left(s"path element '$path' does not exist or is not readable")
+    paths.find(!Files.isReadable(_)) match {
+      case Some(unreadablePath) =>
+        return Left(s"path element '${unreadablePath}' does not exist or is not readable")
+      case _ =>
     }
 
     val classPath = paths.asJava


### PR DESCRIPTION
Requires a few tweaks to allow cross-compiling between Scala 2.12, 2.13 and 3.3. This is needed to enable gradual migration of (some) benchmarks to Scala 3. This is needed by a subsequent update to `dotty` to avoid incompatibility with JDK21.