### PR TITLE
Update scala3-compiler to version 3.3.1 and migrate scala-dotty to Scala 3

### DIFF
--- a/benchmarks/scala-dotty/src/main/scala/org/renaissance/scala/dotty/Dotty.scala
+++ b/benchmarks/scala-dotty/src/main/scala/org/renaissance/scala/dotty/Dotty.scala
@@ -33,8 +33,8 @@ import java.util.zip.ZipInputStream
 import scala.collection._
 
 @Name("dotty")
-@Group("scala")
 @Group("scala-dotty")
+@Group("scala") // With Scala 3, the primary group goes last.
 @Summary("Runs the Dotty compiler on a set of source code files.")
 @Licenses(Array(License.BSD3))
 @Repetitions(50)
@@ -51,7 +51,7 @@ final class Dotty extends Benchmark {
    *
    * find . -type f -name '*.tasty'|egrep -v '(Classfile|ByteCode)\.tasty' | LC_ALL=C sort|xargs cat|md5sum
    */
-  private val expectedTastyHash: String = "af5ff4a3e1d189395c07c187167450ed"
+  private val expectedTastyHash: String = "cda4bf9f729d30c97ec7b793c54039d1"
 
   private val excludedTastyFiles = Seq("Classfile.tasty", "ByteCode.tasty")
 

--- a/build.sbt
+++ b/build.sbt
@@ -376,12 +376,14 @@ lazy val rxBenchmarks = (project in file("benchmarks/rx"))
 lazy val scalaDottyBenchmarks = (project in file("benchmarks/scala-dotty"))
   .settings(
     name := "scala-dotty",
-    commonSettingsScala213,
-    scalacOptions += "-Ytasty-reader",
+    commonSettingsScala3,
     libraryDependencies ++= Seq(
-      "org.scala-lang" % "scala3-compiler_3" % "3.0.2",
+      // Version 3.1.2 was the last to compile with Scala 2.13.11. Version 3.1.3-RC2
+      // broke compilation due to "Unsupported Scala 3 union in parameter value".
+      // Compiling with Scala 3.1.0+ avoids compatibility issues.
+      "org.scala-lang" % "scala3-compiler_3" % "3.3.1",
       // The following is required to compile the workload sources.
-      "org.scala-lang" % "scala-compiler" % scalaVersion.value
+      "org.scala-lang" % "scala-compiler" % scalaVersion213
     ),
     dependencyOverrides ++= Seq(
       // Force newer JNA to support more platforms/architectures.


### PR DESCRIPTION
This should avoid issues with using Scala 3 code (scala3-compiler_3) from Scala 2. This broke with version 3.1.3 of scala3-compiler when Scala 2.13 compiler started to complain about "Unsupported Scala 3 union in parameter value" (3.1.2 was the last to work).

For compatibility with JDK21 (see #384), we need fixes to Tasty reader which was broken by changes to javac in JDK21-b21 (see JDK-8292275), which only made it into version 3.3.1-RC1.

Using reflection would probably fix the problem, as might a Java-based bridge method, but switching to Scala 3 seems to work as well and paves the way to introducing more Scala 3 benchmarks in the future.

Fixes #384.