### PR TITLE
Bump supported JVM in neo4j-analytics to version 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The following is the complete list of benchmarks, separated into groups.
 
 - `neo4j-analytics` - Executes Neo4J graph queries against a movie database.
   \
-  Default repetitions: 20; GPL3 license, GPL3 distribution; Supported JVM: 11 - 15
+  Default repetitions: 20; GPL3 license, GPL3 distribution; Supported JVM: 11 - 20
 
 #### functional
 

--- a/benchmarks/neo4j/src/main/scala/org/renaissance/neo4j/Neo4jAnalytics.scala
+++ b/benchmarks/neo4j/src/main/scala/org/renaissance/neo4j/Neo4jAnalytics.scala
@@ -20,7 +20,7 @@ import scala.io.{Codec, Source}
 @Summary("Executes Neo4J graph queries against a movie database.")
 @Licenses(Array(License.GPL3))
 @RequiresJvm("11")
-@SupportsJvm("15")
+@SupportsJvm("20")
 @Repetitions(20)
 @Parameter(name = "long_query_threads", defaultValue = "2")
 @Parameter(name = "long_query_repeats", defaultValue = "1")


### PR DESCRIPTION
This expands the range of JVM versions supported by `neo4j-analytics` to [11,20] instead of [11,15], but JDK21 is a no-go for now (see #408).