### PR TITLE
Update primary dependencies in db-shootout benchmark to improve JVM compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The following is the complete list of benchmarks, separated into groups.
 
 - `db-shootout` - Executes a shootout test using several in-memory databases.
   \
-  Default repetitions: 16; APACHE2 license, MIT distribution; Supported JVM: 1.8 - 11
+  Default repetitions: 16; APACHE2 license, MIT distribution; Supported JVM: 1.8 - 18
 
 - `neo4j-analytics` - Executes Neo4J graph queries against a movie database.
   \

--- a/benchmarks/database/src/main/resources/simplelogger.properties
+++ b/benchmarks/database/src/main/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=warn

--- a/benchmarks/database/src/main/scala/org/renaissance/database/DbShootout.scala
+++ b/benchmarks/database/src/main/scala/org/renaissance/database/DbShootout.scala
@@ -14,7 +14,7 @@ import org.renaissance.License
 @Group("database")
 @Summary("Executes a shootout test using several in-memory databases.")
 @Licenses(Array(License.APACHE2))
-@SupportsJvm("11")
+@SupportsJvm("18")
 @Repetitions(16)
 @Parameter(name = "rw_entry_count", defaultValue = "500000")
 @Configuration(name = "test", settings = Array("rw_entry_count = 10000"))

--- a/build.sbt
+++ b/build.sbt
@@ -283,9 +283,9 @@ lazy val databaseBenchmarks = (project in file("benchmarks/database"))
     name := "database",
     commonSettingsScala213,
     libraryDependencies ++= Seq(
-      "com.github.jnr" % "jnr-posix" % "3.0.29",
+      "com.github.jnr" % "jnr-posix" % "3.1.15",
       "org.apache.commons" % "commons-math3" % commonsMath3Version,
-      "org.agrona" % "agrona" % "0.9.7",
+      "org.agrona" % "agrona" % "1.17.1",
       // Database libraries.
       "org.mapdb" % "mapdb" % "3.0.1",
       "com.h2database" % "h2-mvstore" % "1.4.192",
@@ -296,6 +296,7 @@ lazy val databaseBenchmarks = (project in file("benchmarks/database"))
     dependencyOverrides ++= Seq(
       // Force newer JNA to support more platforms/architectures.
       "net.java.dev.jna" % "jna-platform" % jnaVersion,
+      "net.java.dev.jna" % "jna" % jnaVersion,
       // Force common versions of other dependencies.
       "com.google.guava" % "guava" % guavaVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion

--- a/build.sbt
+++ b/build.sbt
@@ -129,6 +129,7 @@ val generateManifestAttributesTask = Def.task {
   val addOpensPackages = Seq(
     "java.base/java.lang",
     "java.base/java.lang.invoke",
+    "java.base/java.lang.reflect",
     "java.base/java.util",
     "java.base/java.nio",
     "java.base/sun.nio.ch",
@@ -287,9 +288,9 @@ lazy val databaseBenchmarks = (project in file("benchmarks/database"))
       "org.apache.commons" % "commons-math3" % commonsMath3Version,
       "org.agrona" % "agrona" % "1.17.1",
       // Database libraries.
-      "org.mapdb" % "mapdb" % "3.0.1",
-      "com.h2database" % "h2-mvstore" % "1.4.192",
-      "net.openhft" % "chronicle-map" % "3.17.0",
+      "org.mapdb" % "mapdb" % "3.0.10",
+      "com.h2database" % "h2-mvstore" % "2.1.214",
+      "net.openhft" % "chronicle-map" % "3.22.9",
       // Add simple binding to silence SLF4J warnings.
       "org.slf4j" % "slf4j-simple" % slf4jVersion
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -286,18 +286,10 @@ lazy val databaseBenchmarks = (project in file("benchmarks/database"))
       "com.github.jnr" % "jnr-posix" % "3.0.29",
       "org.apache.commons" % "commons-math3" % commonsMath3Version,
       "org.agrona" % "agrona" % "0.9.7",
-      "net.openhft" % "zero-allocation-hashing" % "0.6",
+      // Database libraries.
       "org.mapdb" % "mapdb" % "3.0.1",
       "com.h2database" % "h2-mvstore" % "1.4.192",
-      "net.openhft" % "chronicle-core" % "2.17.2",
-      "net.openhft" % "chronicle-bytes" % "2.17.7" exclude ("net.openhft", "chronicle-core"),
-      "net.openhft" % "chronicle-threads" % "2.17.1" exclude ("net.openhft", "chronicle-core"),
-      "net.openhft" % "chronicle-map" % "3.17.0" excludeAll (
-        ExclusionRule("net.openhft", "chronicle-core"),
-        ExclusionRule("net.openhft", "chronicle-bytes"),
-        ExclusionRule("net.openhft", "chronicle-threads"),
-        ExclusionRule("org.slf4j", "slf4j-api")
-      ),
+      "net.openhft" % "chronicle-map" % "3.17.0",
       // Add simple binding to silence SLF4J warnings.
       "org.slf4j" % "slf4j-simple" % slf4jVersion
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -298,7 +298,7 @@ lazy val databaseBenchmarks = (project in file("benchmarks/database"))
       "net.java.dev.jna" % "jna-platform" % jnaVersion,
       // Force common versions of other dependencies.
       "com.google.guava" % "guava" % guavaVersion,
-      "org.slf4j" % "jcl-over-slf4j" % slf4jVersion
+      "org.slf4j" % "slf4j-api" % slf4jVersion
     )
   )
   .dependsOn(renaissanceCore % "provided")

--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -54,6 +54,7 @@ get_jvm_workaround_args() {
     case "$RENAISSANCE_JVM_MAJOR_VERSION" in
         16|17|18|18-ea|19|19-ea|20|21-ea)
             echo "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+            echo "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
             echo "--add-opens=java.base/java.util=ALL-UNNAMED"
             echo "--add-opens=java.base/java.nio=ALL-UNNAMED"
             echo "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"


### PR DESCRIPTION
Updates MapDB version from 3.0.1 to 3.0.10, H2 MVStore from version 1.4.192 to version 2.1.214, and Chronicle Map from version 3.17.0 to version 3.22.9

This makes the `db-shootout` benchmark compatible with JDK 18 (up from 11). 

Starting with JDK 19, the benchmark fails because `chronicle-core` is using reflection to look up the `sun.nio.ch.FileChannelImpl.map0(int,long,long,boolean)` method which is not available in JDK 19 anymore.

Using more recent Chronicle Map (such as 3.23.5 or even 3.24ea3) is currently not an option, because SBT fails to find their `third-party-bom`.
