### PR TITLE
Use Scala 3 version of the harness by default and in Java-only benchmarks

### DIFF
--- a/benchmarks/jdk-concurrent/src/main/scala/org/renaissance/jdk/concurrent/FjKmeans.scala
+++ b/benchmarks/jdk-concurrent/src/main/scala/org/renaissance/jdk/concurrent/FjKmeans.scala
@@ -8,8 +8,8 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("fj-kmeans")
-@Group("concurrency")
 @Group("jdk-concurrent")
+@Group("concurrency") // With Scala 3, the primary group goes last.
 @Summary("Runs the k-means algorithm using the fork/join framework.")
 @Licenses(Array(License.APACHE2))
 @Repetitions(30)

--- a/benchmarks/jdk-concurrent/src/main/scala/org/renaissance/jdk/concurrent/FutureGenetic.scala
+++ b/benchmarks/jdk-concurrent/src/main/scala/org/renaissance/jdk/concurrent/FutureGenetic.scala
@@ -8,8 +8,8 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("future-genetic")
-@Group("functional")
 @Group("jdk-concurrent")
+@Group("functional") // With Scala 3, the primary group goes last.
 @Summary("Runs a genetic algorithm using the Jenetics library and futures.")
 @Licenses(Array(License.APACHE2))
 @Repetitions(50)

--- a/benchmarks/jdk-streams/src/main/scala/org/renaissance/jdk/streams/Mnemonics.scala
+++ b/benchmarks/jdk-streams/src/main/scala/org/renaissance/jdk/streams/Mnemonics.scala
@@ -8,8 +8,8 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("mnemonics")
-@Group("functional")
 @Group("jdk-streams")
+@Group("functional") // With Scala 3, the primary group goes last.
 @Summary("Solves the phone mnemonics problem using JDK streams.")
 @Licenses(Array(License.MIT))
 @Repetitions(16)

--- a/benchmarks/jdk-streams/src/main/scala/org/renaissance/jdk/streams/ParMnemonics.scala
+++ b/benchmarks/jdk-streams/src/main/scala/org/renaissance/jdk/streams/ParMnemonics.scala
@@ -8,8 +8,8 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("par-mnemonics")
-@Group("functional")
 @Group("jdk-streams")
+@Group("functional") // With Scala 3, the primary group goes last.
 @Summary("Solves the phone mnemonics problem using parallel JDK streams.")
 @Licenses(Array(License.MIT))
 @Repetitions(16)

--- a/benchmarks/jdk-streams/src/main/scala/org/renaissance/jdk/streams/Scrabble.scala
+++ b/benchmarks/jdk-streams/src/main/scala/org/renaissance/jdk/streams/Scrabble.scala
@@ -10,8 +10,8 @@ import org.renaissance.License
 import scala.jdk.CollectionConverters._
 
 @Name("scrabble")
-@Group("functional")
 @Group("jdk-streams")
+@Group("functional") // With Scala 3, the primary group goes last.
 @Summary("Solves the Scrabble puzzle using JDK Streams.")
 @Licenses(Array(License.GPL2))
 @Repetitions(50)

--- a/benchmarks/rx/src/main/scala/org/renaissance/rx/RxScrabble.scala
+++ b/benchmarks/rx/src/main/scala/org/renaissance/rx/RxScrabble.scala
@@ -8,8 +8,8 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("rx-scrabble")
-@Group("functional")
 @Group("rx")
+@Group("functional") // With Scala 3, the primary group goes last.
 @Summary("Solves the Scrabble puzzle using the Rx streams.")
 @Licenses(Array(License.GPL2))
 @Repetitions(80)

--- a/build.sbt
+++ b/build.sbt
@@ -73,8 +73,8 @@ lazy val commonSettingsNoScala = Seq(
   crossPaths := false,
   // Don't include Scala library as dependency.
   autoScalaLibrary := false,
-  // Override default Scala version to use Scala 2.13 harness.
-  scalaVersion := scalaVersion213
+  // Override default Scala version to use Scala 3 harness.
+  scalaVersion := scalaVersion3
 )
 
 lazy val commonSettingsScala212 = Seq(
@@ -282,7 +282,7 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
 lazy val databaseBenchmarks = (project in file("benchmarks/database"))
   .settings(
     name := "database",
-    commonSettingsScala213,
+    commonSettingsScala3,
     libraryDependencies ++= Seq(
       "com.github.jnr" % "jnr-posix" % "3.1.15",
       "org.apache.commons" % "commons-math3" % commonsMath3Version,
@@ -308,7 +308,7 @@ lazy val databaseBenchmarks = (project in file("benchmarks/database"))
 lazy val jdkConcurrentBenchmarks = (project in file("benchmarks/jdk-concurrent"))
   .settings(
     name := "jdk-concurrent",
-    commonSettingsScala213,
+    commonSettingsScala3,
     libraryDependencies ++= Seq(
       // Jenetics 5.2.0 is the last to support Java 8.
       // Jenetics 6.0.0 requires Java 11 and benchmark update.
@@ -321,7 +321,7 @@ lazy val jdkConcurrentBenchmarks = (project in file("benchmarks/jdk-concurrent")
 lazy val jdkStreamsBenchmarks = (project in file("benchmarks/jdk-streams"))
   .settings(
     name := "jdk-streams",
-    commonSettingsScala213
+    commonSettingsScala3
   )
   .dependsOn(renaissanceCore % "provided")
 
@@ -360,7 +360,7 @@ lazy val neo4jBenchmarks = (project in file("benchmarks/neo4j"))
 lazy val rxBenchmarks = (project in file("benchmarks/rx"))
   .settings(
     name := "rx",
-    commonSettingsScala213,
+    commonSettingsScala3,
     libraryDependencies ++= Seq(
       "io.reactivex" % "rxjava" % "1.3.8"
     )

--- a/renaissance-core/src/main/java/org/renaissance/core/Launcher.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/Launcher.java
@@ -22,7 +22,7 @@ public final class Launcher {
 
   private static final String MARKDOWN_GENERATOR = "org.renaissance.harness.MarkdownGenerator";
   private static final String HARNESS_MAIN_CLASS = "org.renaissance.harness.RenaissanceSuite";
-  private static final String HARNESS_MODULE_NAME = "renaissance-harness_2.13";
+  private static final String HARNESS_MODULE_NAME = "renaissance-harness_3";
 
   private static final URI moduleMetadataUri = URI.create("resource:/modules.properties");
 


### PR DESCRIPTION
Because we need the harness to build with Scala 3 anyway, this makes Scala 3 the default for the harness and for the Scala wrappers of Java-only benchmarks. Unlike the wrappers, the harness needs to be maintained to cross-build with older Scala versions (2.13 and 2.12) so that an appropriate harness version can be used with the standalone benchmarks.