### PR TITLE
Submit the k-means computation as a task to the fork-join pool

### DIFF
--- a/benchmarks/jdk-concurrent/src/main/java/org/renaissance/jdk/concurrent/JavaKMeans.java
+++ b/benchmarks/jdk-concurrent/src/main/java/org/renaissance/jdk/concurrent/JavaKMeans.java
@@ -327,7 +327,7 @@ public final class JavaKMeans {
 
     private double[] average(final List<Double[]> elements) {
       final VectorSumTask sumTask = new VectorSumTask(elements);
-      final double[] vectorSums = getPool().invoke(sumTask);
+      final double[] vectorSums = sumTask.invoke();
       return div(vectorSums, elements.size());
     }
 


### PR DESCRIPTION
This ensures that all forked tasks get executed by the threads from the fork-join pool. Not doing so allows `invoke()` to start executing in the current thread, i.e., not on the (explicitly) given pool, which in turns allows subsequent `fork()` calls to schedule the forked tasks on the common pool, because the calling thread is not on the fork-join pool.

Fixes #374