### PR TITLE
Set/restore context class loader around benchmark methods in JMH

### DIFF
--- a/renaissance-jmh/wrappers/src/main/java/org/renaissance/jmh/JmhRenaissanceBenchmark.java
+++ b/renaissance-jmh/wrappers/src/main/java/org/renaissance/jmh/JmhRenaissanceBenchmark.java
@@ -115,7 +115,7 @@ public abstract class JmhRenaissanceBenchmark {
     benchmark.setUpBeforeAll(context);
   }
 
-  @Setup(Level.Iteration)
+  @Setup(Level.Invocation)
   public final void setUpBeforeEach() {
     benchmark.setUpBeforeEach(context);
   }
@@ -128,7 +128,7 @@ public abstract class JmhRenaissanceBenchmark {
     result = benchmark.run(context);
   }
 
-  @TearDown(Level.Iteration)
+  @TearDown(Level.Invocation)
   public final void tearDownAfterEach() throws ValidationException {
     benchmark.tearDownAfterEach(context);
 

--- a/renaissance-jmh/wrappers/src/main/java/org/renaissance/jmh/JmhRenaissanceBenchmark.java
+++ b/renaissance-jmh/wrappers/src/main/java/org/renaissance/jmh/JmhRenaissanceBenchmark.java
@@ -111,12 +111,12 @@ public abstract class JmhRenaissanceBenchmark {
   //
 
   @Setup(Level.Trial)
-  public final void setUpBenchmark() {
+  public final void setUpBeforeAll() {
     benchmark.setUpBeforeAll(context);
   }
 
   @Setup(Level.Iteration)
-  public final void setUpOperation() {
+  public final void setUpBeforeEach() {
     benchmark.setUpBeforeEach(context);
   }
 
@@ -124,12 +124,12 @@ public abstract class JmhRenaissanceBenchmark {
   @BenchmarkMode(Mode.SingleShotTime)
   @OutputTimeUnit(MILLISECONDS)
   @Measurement(timeUnit = MILLISECONDS)
-  public final void runOperation() {
+  public final void run() {
     result = benchmark.run(context);
   }
 
   @TearDown(Level.Iteration)
-  public final void tearDownOperation() throws ValidationException {
+  public final void tearDownAfterEach() throws ValidationException {
     benchmark.tearDownAfterEach(context);
 
     result.validate();
@@ -137,7 +137,7 @@ public abstract class JmhRenaissanceBenchmark {
   }
 
   @TearDown(Level.Trial)
-  public final void defaultTearBenchmark() {
+  public final void tearDownAfterAll() {
     benchmark.tearDownAfterAll(context);
   }
 

--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -53,6 +53,7 @@ cp_reflink() {
 get_jvm_workaround_args() {
     case "$RENAISSANCE_JVM_MAJOR_VERSION" in
         16|17|18|18-ea|19|19-ea|20|21-ea)
+            echo "--add-opens=java.base/java.lang=ALL-UNNAMED"
             echo "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
             echo "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
             echo "--add-opens=java.base/java.util=ALL-UNNAMED"


### PR DESCRIPTION
Wraps `Benchmark` interface methods with code that set and restores the context class loader for the current thread when running with JMH. This is because JMH option `-t` causes it to create more benchmark runners that invoke the `Benchmark.run()` method concurrently on a single benchmark instance, but do not replicate the context class loader of the (initial) main thread.

Even though this is not really supported (or intended) use of the `Benchmark` interface, the benchmarks should not crash because they fail to load their classes.

One other change is that the JMH wrappers now call `setupBeforeEach()` and `tearDownAfterEach()` after each measured method invocation as they should. This probably only affects runs with timed JMH iterations, during which JMH would invoke the measured method multiple times without calling the setup/tear-down methods.

Fixes #373 