### PR TITLE
Update Hadoop to version 3.3.6

### DIFF
--- a/benchmarks/apache-spark/src/main/resources/log4j2.xml
+++ b/benchmarks/apache-spark/src/main/resources/log4j2.xml
@@ -61,11 +61,17 @@
     -->
     <Logger name="org.apache.hadoop.util.NativeCodeLoader" level="error"/>
 
-    <!-- 
+    <!--
       Note that spark.local.dir will be overridden by the value set by the cluster manager
       (via SPARK_LOCAL_DIRS in mesos/standalone/kubernetes and LOCAL_DIRS in YARN).
     -->
     <Logger name="org.apache.spark.SparkConf" level="error"/>
+
+    <!--
+      To enable non-built-in garbage collector(s) List(...), users should configure it(them) to
+      spark.eventLog.gcMetrics.youngGenerationGarbageCollectors or spark.eventLog.gcMetrics.oldGenerationGarbageCollectors
+    -->
+    <Logger name="org.apache.spark.metrics.GarbageCollectionMetrics" level="error"/>
 
     <!--
       URL.setURLStreamHandlerFactory failed to set FsUrlStreamHandlerFactory

--- a/build.sbt
+++ b/build.sbt
@@ -268,6 +268,8 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
     ),
     // Override versions pulled in by dependencies.
     dependencyOverrides ++= Seq(
+      // Force newer version of Hadoop (compatibility with IBM Semeru JDK builds).
+      "org.apache.hadoop" % "hadoop-client-runtime" % "3.3.6",
       // Force common (newer) version of Netty packages.
       "io.netty" % "netty-all" % nettyVersion,
       // Force common (newer) version of Jackson packages.


### PR DESCRIPTION
This is to improve compatibility with (more recent) IBM Semeru builds of OpenJ9-based JVMs. There was some renaming going on that resulted in changes to the contents of `java.vendor`, resulting in Hadoop 3.3.4 failing to find some classes. This was fixed in Hadoop version 3.3.5, but 3.3.6 is the most recent.

Details at https://github.com/apache/hadoop/pull/4537