### PR TITLE
CI: Build on Java 21 and drop Java 8

### DIFF
--- a/.github/workflows/ea-jdk.yml
+++ b/.github/workflows/ea-jdk.yml
@@ -1,33 +1,31 @@
 name: EA JDK
 on: workflow_dispatch
-
+env:
+  COURSIER_CACHE: ${{ github.workspace }}/.cache/coursier
 jobs:
   linux-ea:
     runs-on: ubuntu-latest
-    container: "fedora:34"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v7-openjdk22-ea"
     steps:
-      - name: Install base requirements
-        shell: bash
-        run: dnf install -y ca-certificates git unzip
-
       - name: Git checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Fetch latest EA JDK
-        run: tools/ci/get-latest-ea-jdk.sh $RUNNER_TEMP/jdk-ea-linux.tar.gz
-
-      - name: Setup EA JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: 99-ea
-          distribution: jdkfile
-          jdkFile: ${{ runner.temp }}/jdk-ea-linux.tar.gz
+      - name: Fix Git safe directory
+        shell: bash
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - name: Environment configuration
         shell: bash
         run: tools/ci/pre-show-env.sh
+
+      - name: Coursier downloads cache
+        uses: actions/cache@v3
+        with:
+          enableCrossOsArchive: true
+          key: coursier_cache-${{ hashFiles('build.sbt') }}
+          path: ${{ env.COURSIER_CACHE }}
 
       - name: Build both base & JMH bundles
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,12 @@ on:
   push:
     branches: [master]
   pull_request:
+env:
+  COURSIER_CACHE: ${{ github.workspace }}/.cache/coursier
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: "renaissancebench/buildenv:v5-openjdk8"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v7-openjdk21"
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -17,14 +19,11 @@ jobs:
         shell: bash
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      - name: Cache SBT
+      - name: Coursier downloads cache
         uses: actions/cache@v3
         with:
-          path: |
-            ~/.ivy2/cache
-            ~/.sbt
-            ~/.cache/coursier
-          key: ${{ runner.os }}-sbt-${{ hashFiles('build.sbt') }}
+          key: coursier_cache-${{ runner.os }}-${{ hashFiles('build.sbt') }}
+          path: ${{ env.COURSIER_CACHE }}
 
       - name: Check file encoding
         shell: bash
@@ -44,7 +43,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    container: "renaissancebench/buildenv:v5-openjdk17"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v7-openjdk21"
     continue-on-error: true
     steps:
       - name: Git checkout
@@ -56,18 +55,15 @@ jobs:
         shell: bash
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      - name: Cache SBT
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.sbt
-            ~/.cache/coursier
-          key: ${{ runner.os }}-sbt-${{ hashFiles('build.sbt') }}
-
       - name: Environment configuration
         shell: bash
         run: tools/ci/pre-show-env.sh
+
+      - name: Coursier downloads cache
+        uses: actions/cache@v3
+        with:
+          key: coursier_cache-${{ runner.os }}-${{ hashFiles('build.sbt') }}
+          path: ${{ env.COURSIER_CACHE }}
 
       - name: Build both base & JMH bundles
         shell: bash
@@ -102,20 +98,26 @@ jobs:
         shell: bash
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      - name: Fetch JDK 17
+      - name: Fetch JDK 21
         run: |
-          aria2c -d ${{ runner.temp }} -o openjdk-17_macos-x64_bin.tar.gz https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_macos-x64_bin.tar.gz
+          aria2c -d ${{ runner.temp }} -o openjdk-21_macos-x64_bin.tar.gz https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_macos-x64_bin.tar.gz
 
-      - name: Setup JDK 17
+      - name: Setup JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: jdkfile
-          jdkFile: ${{ runner.temp }}/openjdk-17_macos-x64_bin.tar.gz
+          jdkFile: ${{ runner.temp }}/openjdk-21_macos-x64_bin.tar.gz
 
       - name: Environment configuration
         shell: bash
         run: tools/ci/pre-show-env.sh
+
+      - name: Coursier downloads cache
+        uses: actions/cache@v3
+        with:
+          key: coursier_cache-${{ runner.os }}-${{ hashFiles('build.sbt') }}
+          path: ${{ env.COURSIER_CACHE }}
 
       - name: Build both base & JMH bundles
         shell: bash
@@ -154,24 +156,30 @@ jobs:
         shell: bash
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      - name: Fetch JDK 17
+      - name: Fetch JDK 21
         run: |
-          aria2c -d ${{ runner.temp }} -o openjdk-17_windows-x64_bin.zip https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_windows-x64_bin.zip
+          aria2c -d ${{ runner.temp }} -o openjdk-21_windows-x64_bin.zip https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_windows-x64_bin.zip
 
-      - name: Setup JDK 17
+      - name: Setup JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: jdkfile
-          jdkFile: ${{ runner.temp }}/openjdk-17_windows-x64_bin.zip
+          jdkFile: ${{ runner.temp }}/openjdk-21_windows-x64_bin.zip
 
       - name: Environment configuration
         shell: bash
         run: tools/ci/pre-show-env.sh
 
+      - name: Coursier downloads cache
+        uses: actions/cache@v3
+        with:
+          key: coursier_cache-${{ runner.os }}-${{ hashFiles('build.sbt') }}
+          path: ${{ env.COURSIER_CACHE }}
+
       - name: Build both base & JMH bundles
         shell: bash
-        run: tools/sbt/bin/sbt --batch 'renaissance/package;renaissanceJmh/package'
+        run: tools/ci/build-both.sh
 
       - name: Check JMH bundle
         shell: bash
@@ -196,7 +204,7 @@ jobs:
   plugins:
     runs-on: ubuntu-latest
     needs: linux
-    container: "renaissancebench/buildenv:v5-openjdk8-with-ant-gcc"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v7-openjdk11-with-ant-gcc"
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -207,18 +215,15 @@ jobs:
         shell: bash
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      - name: Cache SBT
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.sbt
-            ~/.cache/coursier
-          key: ${{ runner.os }}-sbt-${{ hashFiles('build.sbt') }}
-
       - name: Environment configuration
         shell: bash
         run: tools/ci/pre-show-env.sh
+
+      - name: Coursier downloads cache
+        uses: actions/cache@v3
+        with:
+          key: coursier_cache-${{ runner.os }}-${{ hashFiles('build.sbt') }}
+          path: ${{ env.COURSIER_CACHE }}
 
       - name: Build base
         shell: bash
@@ -237,15 +242,13 @@ jobs:
     strategy:
       matrix:
         image:
-          - openjdk8
           - openjdk11
-          - openjdk20
-          - openj9-openjdk8
+          - openjdk17
           - openj9-openjdk11
           - openj9-openjdk17
     runs-on: ubuntu-latest
     continue-on-error: true
-    container: "renaissancebench/buildenv:v5-${{ matrix.image }}"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v7-${{ matrix.image }}"
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -256,18 +259,15 @@ jobs:
         shell: bash
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      - name: Cache SBT
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.sbt
-            ~/.cache/coursier
-          key: ${{ runner.os }}-sbt-${{ hashFiles('build.sbt') }}
-
       - name: Environment configuration
         shell: bash
         run: tools/ci/pre-show-env.sh
+
+      - name: Coursier downloads cache
+        uses: actions/cache@v3
+        with:
+          key: coursier_cache-${{ runner.os }}-${{ hashFiles('build.sbt') }}
+          path: ${{ env.COURSIER_CACHE }}
 
       - name: Build base & JMH bundles
         shell: bash
@@ -294,7 +294,7 @@ jobs:
     needs: windows
     strategy:
       matrix:
-        java: [ '8', '11' ]
+        java: [ '11', '17' ]
     runs-on: windows-latest
     continue-on-error: true
     steps:
@@ -317,9 +317,15 @@ jobs:
         shell: bash
         run: tools/ci/pre-show-env.sh
 
+      - name: Coursier downloads cache
+        uses: actions/cache@v3
+        with:
+          key: coursier_cache-${{ runner.os }}-${{ hashFiles('build.sbt') }}
+          path: ${{ env.COURSIER_CACHE }}
+
       - name: Build both base & JMH bundles
         shell: bash
-        run: tools/sbt/bin/sbt --batch 'renaissance/package;renaissanceJmh/package'
+        run: tools/ci/build-both.sh
 
       - name: Check JMH bundle
         shell: bash
@@ -345,7 +351,7 @@ jobs:
     needs: macos
     strategy:
       matrix:
-        java: [ '8', '11' ]
+        java: [ '11', '17' ]
     runs-on: macos-latest
     continue-on-error: true
     steps:
@@ -367,6 +373,12 @@ jobs:
       - name: Environment configuration
         shell: bash
         run: tools/ci/pre-show-env.sh
+
+      - name: Coursier downloads cache
+        uses: actions/cache@v3
+        with:
+          key: coursier_cache-${{ runner.os }}-${{ hashFiles('build.sbt') }}
+          path: ${{ env.COURSIER_CACHE }}
 
       - name: Build both base & JMH bundles
         shell: bash

--- a/build.sbt
+++ b/build.sbt
@@ -861,7 +861,8 @@ lazy val renaissance = (project in file("."))
   .settings(
     aggregate := false,
     clean / aggregate := true,
-    scalafmt / aggregate := true
+    scalafmt / aggregate := true,
+    update / aggregate := true
   )
 
 //

--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -52,7 +52,7 @@ cp_reflink() {
 
 get_jvm_workaround_args() {
     case "$RENAISSANCE_JVM_MAJOR_VERSION" in
-        16|17|18|18-ea|19|19-ea|20|21-ea)
+        16|17|18|19|20|21|22-ea)
             echo "--add-opens=java.base/java.lang=ALL-UNNAMED"
             echo "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
             echo "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"


### PR DESCRIPTION
This updates the CI to build on Java 21, 17, and 11, dropping Java 8. Also fixes cache configuration and uses new build environment packages that introduce testing on IBM Semeru Open builds of the OpenJ9-based JVMs.