### PR TITLE
Target Java 11 as the default minimal JVM for benchmarks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,15 +14,14 @@ the community.
 
 ### Setting up your environment
 
-Renaissance Benchmark Suite is built via SBT and is written in both
-Java and Scala.
+Renaissance Benchmark Suite is built via SBT and is written in both Java and Scala.
 Several tips on how to setup your IDE are in `documentation/ide.md`.
 
 
 ### Building the suite
 
-To build the suite and create the so-called fat JAR (or super JAR), you only
-need to run `sbt` build tool as follows:
+To build the suite and create the so-called fat JAR (or super JAR), you need to have
+a JDK (at least version 11) installed and run the `sbt` build tool as follows:
 
 ```
 $ tools/sbt/bin/sbt renaissancePackage
@@ -30,7 +29,6 @@ $ tools/sbt/bin/sbt renaissancePackage
 
 This will retrieve all the dependencies, compile all the benchmark projects and the harness,
 bundle the JARs and create the final JAR under the `target` directory.
-
 
 ### Making a contribution
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ from <https://renaissance.dev/download>.
 If you wish to build it yourself, please, consult [CONTRIBUTING.md](CONTRIBUTING.md)
 for instructions on building.
 
-To run a Renaissance benchmark, you need to have a JRE installed.
-This allows you to execute the following `java` command:
-
+To run a Renaissance benchmark, you need to have a JRE version 11 (or later)
+installed and execute the following `java` command:
 
 ```
 $ java -jar 'renaissance-gpl-0.14.2.jar' <benchmarks>
 ```
 
-Above, `<benchmarks>` is the list of benchmarks that you wish to run.
-For example, you can specify `scala-kmeans` as the benchmark.
+In the above command, `<benchmarks>` is the list of benchmarks that you want to run.
+You can refer to individual benchmarks, e.g., `scala-kmeans`, or a group of benchmarks,
+e.g., `apache-spark`.
 
 The suite generally executes the benchmark's measured operation multiple times. By default,
 the suite executes each benchmark operation for a specific number of times. The benchmark-specific
@@ -67,55 +67,55 @@ The following is the complete list of benchmarks, separated into groups.
 
 - `als` - Runs the ALS algorithm from the Spark ML library.
   \
-  Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 11 and later
 
 - `chi-square` - Runs the chi-square test from Spark MLlib.
   \
-  Default repetitions: 60; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 60; APACHE2 license, MIT distribution; Supported JVM: 11 and later
 
 - `dec-tree` - Runs the Random Forest algorithm from the Spark ML library.
   \
-  Default repetitions: 40; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 40; APACHE2 license, MIT distribution; Supported JVM: 11 and later
 
 - `gauss-mix` - Computes a Gaussian mixture model using expectation-maximization.
   \
-  Default repetitions: 40; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 40; APACHE2 license, MIT distribution; Supported JVM: 11 and later
 
 - `log-regression` - Runs the Logistic Regression algorithm from the Spark ML library.
   \
-  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 11 and later
 
 - `movie-lens` - Recommends movies using the ALS algorithm.
   \
-  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 11 and later
 
 - `naive-bayes` - Runs the multinomial Naive Bayes algorithm from the Spark ML library.
   \
-  Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 11 and later
 
 - `page-rank` - Runs a number of PageRank iterations, using RDDs.
   \
-  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 11 and later
 
 #### concurrency
 
 - `akka-uct` - Runs the Unbalanced Cobwebbed Tree actor workload in Akka.
   \
-  Default repetitions: 24; MIT license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 24; MIT license, MIT distribution; Supported JVM: 11 and later
 
 - `fj-kmeans` - Runs the K-Means algorithm using the fork/join framework.
   \
-  Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 30; APACHE2 license, MIT distribution; Supported JVM: 11 and later
 
 - `reactors` - Runs benchmarks inspired by the Savina microbenchmark workloads in a sequence on Reactors.IO.
   \
-  Default repetitions: 10; MIT license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 10; MIT license, MIT distribution; Supported JVM: 11 and later
 
 #### database
 
 - `db-shootout` - Executes a shootout test using several in-memory databases.
   \
-  Default repetitions: 16; APACHE2 license, MIT distribution; Supported JVM: 1.8 - 18
+  Default repetitions: 16; APACHE2 license, MIT distribution; Supported JVM: 11 - 18
 
 - `neo4j-analytics` - Executes Neo4j graph queries against a movie database.
   \
@@ -125,55 +125,55 @@ The following is the complete list of benchmarks, separated into groups.
 
 - `future-genetic` - Runs a genetic algorithm using the Jenetics library and futures.
   \
-  Default repetitions: 50; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 50; APACHE2 license, MIT distribution; Supported JVM: 11 and later
 
 - `mnemonics` - Solves the phone mnemonics problem using JDK streams.
   \
-  Default repetitions: 16; MIT license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 16; MIT license, MIT distribution; Supported JVM: 11 and later
 
 - `par-mnemonics` - Solves the phone mnemonics problem using parallel JDK streams.
   \
-  Default repetitions: 16; MIT license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 16; MIT license, MIT distribution; Supported JVM: 11 and later
 
 - `rx-scrabble` - Solves the Scrabble puzzle using the Rx streams.
   \
-  Default repetitions: 80; GPL2 license, GPL3 distribution; Supported JVM: 1.8 and later
+  Default repetitions: 80; GPL2 license, GPL3 distribution; Supported JVM: 11 and later
 
 - `scrabble` - Solves the Scrabble puzzle using JDK Streams.
   \
-  Default repetitions: 50; GPL2 license, GPL3 distribution; Supported JVM: 1.8 and later
+  Default repetitions: 50; GPL2 license, GPL3 distribution; Supported JVM: 11 and later
 
 #### scala
 
 - `dotty` - Runs the Dotty compiler on a set of source code files.
   \
-  Default repetitions: 50; BSD3 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 50; BSD3 license, MIT distribution; Supported JVM: 11 and later
 
 - `philosophers` - Solves a variant of the dining philosophers problem using ScalaSTM.
   \
-  Default repetitions: 30; BSD3 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 30; BSD3 license, MIT distribution; Supported JVM: 11 and later
 
 - `scala-doku` - Solves Sudoku Puzzles using Scala collections.
   \
-  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 11 and later
 
 - `scala-kmeans` - Runs the K-Means algorithm using Scala collections.
   \
-  Default repetitions: 50; MIT license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 50; MIT license, MIT distribution; Supported JVM: 11 and later
 
 - `scala-stm-bench7` - Runs the stmbench7 benchmark using ScalaSTM.
   \
-  Default repetitions: 60; BSD3, GPL2 license, GPL3 distribution; Supported JVM: 1.8 and later
+  Default repetitions: 60; BSD3, GPL2 license, GPL3 distribution; Supported JVM: 11 and later
 
 #### web
 
 - `finagle-chirper` - Simulates a microblogging service using Twitter Finagle.
   \
-  Default repetitions: 90; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 90; APACHE2 license, MIT distribution; Supported JVM: 11 and later
 
 - `finagle-http` - Sends many small Finagle HTTP requests to a Finagle HTTP server and awaits response.
   \
-  Default repetitions: 12; APACHE2 license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 12; APACHE2 license, MIT distribution; Supported JVM: 11 and later
 
 
 
@@ -184,27 +184,27 @@ purposes:
 
 - `dummy-empty` - A dummy benchmark which only serves to test the harness.
   \
-  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 11 and later
 
 - `dummy-failing` - A dummy benchmark for testing the harness (fails during iteration).
   \
-  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 11 and later
 
 - `dummy-param` - A dummy benchmark for testing the harness (test configurable parameters).
   \
-  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 11 and later
 
 - `dummy-setup-failing` - A dummy benchmark for testing the harness (fails during setup).
   \
-  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 11 and later
 
 - `dummy-teardown-failing` - A dummy benchmark for testing the harness (fails during teardown).
   \
-  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 11 and later
 
 - `dummy-validation-failing` - A dummy benchmark for testing the harness (fails during validation).
   \
-  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 1.8 and later
+  Default repetitions: 20; MIT license, MIT distribution; Supported JVM: 11 and later
 
 
 

--- a/benchmarks/actors-reactors/reactors/build.sbt
+++ b/benchmarks/actors-reactors/reactors/build.sbt
@@ -14,6 +14,7 @@ def projectSettings(suffix: String) = {
     scalacOptions := (parentProject / scalacOptions).value ++ Seq(
       "-feature", "-no-specialization"
     ),
+    javacOptions := (parentProject / javacOptions).value,
     Compile / unmanagedSourceDirectories := Seq(
       baseDirectory.value / "jvm" / "src" / "main" / "java",
       baseDirectory.value / "jvm" / "src" / "main" / "scala",

--- a/build.sbt
+++ b/build.sbt
@@ -362,7 +362,7 @@ lazy val neo4jBenchmarks = (project in file("benchmarks/neo4j"))
       // neo4j 5.x supports Scala 2.13 and requires JDK17.
       "org.neo4j" % "neo4j" % "5.12.0",
       // play-json 2.10.x requires SBT running on JDK11 to compile.
-      "com.typesafe.play" %% "play-json" % "2.9.4"
+      "com.typesafe.play" %% "play-json" % "2.10.1"
     ),
     excludeDependencies ++= Seq(
       // Drop dependencies that are not really used by the benchmark.

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,6 @@ Global / onLoad := {
   previousOnLoad.andThen(state => "setupPrePush" :: state)
 }
 
-//
 // Support for distributions with different licenses.
 //
 val nonGplOnly = SettingKey[Boolean](
@@ -56,14 +55,13 @@ ThisBuild / git.useGitDescribe := true
 //
 // Compilation settings
 //
-val javaRelease = "8"
+val javaRelease = "11"
 val scalaVersion212 = "2.12.18"
 val scalaVersion213 = "2.13.12"
 val scalaVersion3 = "3.3.1"
 
 // Explicitly target a specific JDK release.
-ThisBuild / javacOptions ++= Seq("-source", javaRelease, "-target", javaRelease)
-ThisBuild / scalacOptions ++= Seq("-release", javaRelease)
+ThisBuild / javacOptions ++= Seq("--release", javaRelease)
 
 // Use common organization name.
 ThisBuild / organization := "org.renaissance"
@@ -78,15 +76,19 @@ lazy val commonSettingsNoScala = Seq(
 )
 
 lazy val commonSettingsScala212 = Seq(
-  scalaVersion := scalaVersion212
+  scalaVersion := scalaVersion212,
+  // Scala 2.12 can only emit valid Java 8 classes.
+  scalacOptions ++= Seq(s"-release:$javaRelease")
 )
 
 lazy val commonSettingsScala213 = Seq(
-  scalaVersion := scalaVersion213
+  scalaVersion := scalaVersion213,
+  scalacOptions ++= Seq(s"-release:$javaRelease")
 )
 
 lazy val commonSettingsScala3 = Seq(
   scalaVersion := scalaVersion3,
+  scalacOptions ++= Seq("-java-output-version", javaRelease),
   dependencyOverrides ++= Seq(
     // Force common version of Scala 2.13 library.
     "org.scala-lang" % "scala-library" % scalaVersion213
@@ -173,7 +175,8 @@ lazy val renaissanceCore = (project in file("renaissance-core"))
   .settings(
     name := "renaissance-core",
     commonSettingsNoScala,
-    Compile / mainClass := Some(launcherMainClass)
+    Compile / mainClass := Some(launcherMainClass),
+    Compile / javacOptions := Seq("--release", "8")
   )
 
 val renaissanceHarnessCommonSettings = Seq(
@@ -184,6 +187,7 @@ val renaissanceHarnessCommonSettings = Seq(
     "io.spray" %% "spray-json" % "1.3.6"
   ),
   Compile / mainClass := Some(harnessMainClass),
+  Compile / javacOptions := Seq("--release", "8"),
   Compile / packageBin / packageOptions += generateManifestAttributesTask.value
 )
 
@@ -191,7 +195,8 @@ lazy val renaissanceHarness3 = (project in file("renaissance-harness"))
   .settings(
     name := "renaissance-harness_3",
     commonSettingsScala3,
-    renaissanceHarnessCommonSettings
+    renaissanceHarnessCommonSettings,
+    scalacOptions := Seq("-java-output-version", "8")
   )
   .dependsOn(renaissanceCore % "provided")
 
@@ -199,7 +204,8 @@ lazy val renaissanceHarness213 = (project in file("renaissance-harness"))
   .settings(
     name := "renaissance-harness_2.13",
     commonSettingsScala213,
-    renaissanceHarnessCommonSettings
+    renaissanceHarnessCommonSettings,
+    scalacOptions := Seq("-release:8")
   )
   .dependsOn(renaissanceCore % "provided")
 
@@ -208,6 +214,7 @@ lazy val renaissanceHarness212 = (project in file("renaissance-harness"))
     name := "renaissance-harness_2.12",
     commonSettingsScala212,
     renaissanceHarnessCommonSettings,
+    scalacOptions := Seq("-release:8"),
     libraryDependencies ++= Seq(
       // Needed to compile Scala 2.13 collections with Scala 2.12.
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion

--- a/project/build.scala
+++ b/project/build.scala
@@ -16,6 +16,11 @@ class BenchmarkInfo(
   val scalaVersion: String
 ) {
 
+  /**
+   * Default minimal JVM version for benchmarks that do not specify it explicitly.
+   */
+  private val JVM_VERSION_MIN_DEFAULT = "11"
+
   private def kebabCase(s: String): String = {
     val camelCaseName = if (s.last == '$') s.init else s
     val pattern = Pattern.compile("([A-Za-z])([A-Z])")
@@ -133,8 +138,8 @@ class BenchmarkInfo(
   }
 
   def jvmVersionMin: String = {
-    // Require at least JVM 1.8 where unspecified.
-    getAnnotation(classOf[RequiresJvm]).map(_.value()).getOrElse("1.8")
+    // When unspecified, require the default minimum version.
+    getAnnotation(classOf[RequiresJvm]).map(_.value()).getOrElse(JVM_VERSION_MIN_DEFAULT)
   }
 
   def jvmVersionMax: String = {

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/MarkdownGenerator.scala
@@ -236,16 +236,16 @@ from <https://renaissance.dev/download>.
 If you wish to build it yourself, please, consult [CONTRIBUTING.md](CONTRIBUTING.md)
 for instructions on building.
 
-To run a Renaissance benchmark, you need to have a JRE installed.
-This allows you to execute the following `java` command:
-
+To run a Renaissance benchmark, you need to have a JRE version 11 (or later)
+installed and execute the following `java` command:
 
 ```
 $$ java -jar 'renaissance-gpl-${tags("renaissanceVersion")}.jar' <benchmarks>
 ```
 
-Above, `<benchmarks>` is the list of benchmarks that you wish to run.
-For example, you can specify `scala-kmeans` as the benchmark.
+In the above command, `<benchmarks>` is the list of benchmarks that you want to run.
+You can refer to individual benchmarks, e.g., `scala-kmeans`, or a group of benchmarks,
+e.g., `apache-spark`.
 
 The suite generally executes the benchmark's measured operation multiple times. By default,
 the suite executes each benchmark operation for a specific number of times. The benchmark-specific


### PR DESCRIPTION
The core classes and the harness still targets Java 8 (for now) so that the big bundle can politely say that a benchmark is not supported when run on Java 8. This will probably go away with the next "major" update or when we start using Java 11 features (or API) in the harness.