### PR TITLE
Add validation to future-genetic benchmark

### DIFF
--- a/benchmarks/jdk-concurrent/src/main/scala/org/renaissance/jdk/concurrent/FutureGenetic.scala
+++ b/benchmarks/jdk-concurrent/src/main/scala/org/renaissance/jdk/concurrent/FutureGenetic.scala
@@ -1,11 +1,17 @@
 package org.renaissance.jdk.concurrent
 
+import io.jenetics.Chromosome
+import io.jenetics.DoubleGene
 import org.renaissance.Benchmark
 import org.renaissance.Benchmark._
 import org.renaissance.BenchmarkContext
 import org.renaissance.BenchmarkResult
-import org.renaissance.BenchmarkResult.Validators
+import org.renaissance.BenchmarkResult.Assert
 import org.renaissance.License
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 @Name("future-genetic")
 @Group("jdk-concurrent")
@@ -15,9 +21,16 @@ import org.renaissance.License
 @Repetitions(50)
 @Parameter(name = "chromosome_count", defaultValue = "50")
 @Parameter(name = "generation_count", defaultValue = "5000")
+@Parameter(name = "expected_sum", defaultValue = "-10975.2462578835")
+@Parameter(name = "expected_sum_squares", defaultValue = "130336964.45529507")
 @Configuration(
   name = "test",
-  settings = Array("chromosome_count = 10", "generation_count = 200")
+  settings = Array(
+    "chromosome_count = 10",
+    "generation_count = 200",
+    "expected_sum = -1857.224767254019",
+    "expected_sum_squares = 135348190.4555571"
+  )
 )
 @Configuration(name = "jmh")
 final class FutureGenetic extends Benchmark {
@@ -29,6 +42,10 @@ final class FutureGenetic extends Benchmark {
 
   private var generationCountParam: Int = _
 
+  private var expectedSum: Double = _
+
+  private var expectedSumSquares: Double = _
+
   private val THREAD_COUNT = 2
 
   private val RANDOM_SEED = 7
@@ -39,11 +56,20 @@ final class FutureGenetic extends Benchmark {
 
   private val GENE_COUNT = 200
 
+  //
+
+  /** Executor to use for the GA tasks in each repetition. */
+  private var executor: ExecutorService = _
+
   private var benchmark: JavaJenetics = _
 
   override def setUpBeforeAll(c: BenchmarkContext): Unit = {
     chromosomeCountParam = c.parameter("chromosome_count").toPositiveInteger
     generationCountParam = c.parameter("generation_count").toPositiveInteger
+    expectedSum = c.parameter("expected_sum").toDouble
+    expectedSumSquares = c.parameter("expected_sum_squares").toDouble
+
+    executor = Executors.newWorkStealingPool();
 
     benchmark = new JavaJenetics(
       GENE_MIN_VALUE,
@@ -54,18 +80,45 @@ final class FutureGenetic extends Benchmark {
       THREAD_COUNT,
       RANDOM_SEED
     )
-
-    benchmark.setupBeforeAll()
   }
 
-  override def tearDownAfterAll(c: BenchmarkContext): Unit = {
-    benchmark.tearDownAfterAll()
+  override def setUpBeforeEach(context: BenchmarkContext): Unit = {
+    benchmark.setupBeforeEach()
+  }
+
+  private def validate(result: Chromosome[DoubleGene]): Unit = {
+    def chromosomeGeneValues(result: Chromosome[DoubleGene]) = {
+      result.stream().mapToDouble(_.allele().toDouble)
+    }
+
+    val EPSILON = 0.00001
+    val actualSum = chromosomeGeneValues(result).sum()
+    val actualSumSquares = chromosomeGeneValues(result).map(d => d * d).sum()
+
+    Assert.assertEquals(expectedSum, actualSum, EPSILON, "sum of gene values")
+
+    Assert.assertEquals(
+      expectedSumSquares,
+      actualSumSquares,
+      EPSILON,
+      "sum of squares of gene values"
+    )
   }
 
   override def run(c: BenchmarkContext): BenchmarkResult = {
-    val result = benchmark.runRepetition()
-
-    // TODO: add proper validation
-    Validators.dummy(result)
+    val result = benchmark.runRepetition(executor)
+    () => validate(result)
   }
+
+  override def tearDownAfterAll(c: BenchmarkContext): Unit = {
+    executor.shutdown()
+
+    try {
+      executor.awaitTermination(1, TimeUnit.SECONDS)
+    } catch {
+      case e: InterruptedException =>
+        throw new RuntimeException(e)
+    }
+  }
+
 }


### PR DESCRIPTION
There were race conditions in the computation of future-genetic, because all threads in algorithm parallelization were using same random generator. Therefore results were not stable. Solved by creating and adding to the computation engine new instances of Alterer, Survivor Selector, Offspring selector, Genotype factory and initialized those instances with their own random generator. (Created new instances of original objects, but with unique random generator connected to it.)

Validation is done by sorting genes of result genotype by their value and comparing genes values with expected values of genes in the genotype.