### PR TITLE
Add validation to als benchmark

### DIFF
--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/Als.scala
@@ -31,9 +31,9 @@ import scala.util.Random
   summary = "Number of users giving ratings."
 )
 @Parameter(
-  name = "product_count",
+  name = "item_count",
   defaultValue = "100",
-  summary = "Number of products rated by each user."
+  summary = "Number of items rated by each user."
 )
 @Parameter(name = "als_rank", defaultValue = "10")
 @Parameter(name = "als_lambda", defaultValue = "0.01")
@@ -88,7 +88,7 @@ final class Als extends Benchmark with SparkUtil {
 
   private var alsUserCount: Int = _
 
-  private var alsProductCount: Int = _
+  private var alsItemCount: Int = _
 
   private var expectedUserFactorsSummary: FactorsSummary = _
 
@@ -98,11 +98,11 @@ final class Als extends Benchmark with SparkUtil {
 
   private type Rating = ALS.Rating[Int]
 
-  private def generateRatings(userCount: Int, productCount: Int): Seq[Rating] = {
+  private def generateRatings(userCount: Int, itemCount: Int): Seq[Rating] = {
     // TODO: Use a Renaissance-provided random generator.
     val rand = new Random(randomSeed)
 
-    for (userId <- 0 until userCount; itemId <- 0 until productCount) yield {
+    for (userId <- 0 until userCount; itemId <- 0 until itemCount) yield {
       val rating = 1 + rand.nextInt(3) + rand.nextInt(3)
       Rating[Int](userId, itemId, rating.toFloat)
     }
@@ -131,7 +131,7 @@ final class Als extends Benchmark with SparkUtil {
     alsLambdaParam = bc.parameter("als_lambda").toDouble
     alsIterationsParam = bc.parameter("als_iterations").toPositiveInteger
     alsUserCount = bc.parameter("user_count").toPositiveInteger
-    alsProductCount = bc.parameter("product_count").toPositiveInteger
+    alsItemCount = bc.parameter("item_count").toPositiveInteger
 
     // Validation parameters.
     expectedUserFactorsSummary = FactorsSummary(
@@ -145,12 +145,12 @@ final class Als extends Benchmark with SparkUtil {
       bc.parameter("expected_item_factors_sum").toDouble,
       bc.parameter("expected_item_factors_sum_squares").toDouble,
       ClosedInterval(alsRankParam),
-      alsProductCount
+      alsItemCount
     )
 
     // Store generated ratings as a single file.
     val ratingsCsv = storeRatings(
-      generateRatings(alsUserCount, alsProductCount),
+      generateRatings(alsUserCount, alsItemCount),
       bc.scratchDirectory().resolve("ratings.csv")
     )
 


### PR DESCRIPTION
The trained ALS model can be represented as a 2-dimensional matrix of features and the validation checks the shape and the content of the matrix. Regarding the content, it compares the sum and sum of squares of all matrix values with expected values.

The validation does not change the code that is being measured and should not really impact benchmark performance. As a quick check, I calculated an average duration from the last 5 repetitions of a single run of the benchmark before and after validation:

- without validation: 2235,345ms
([als.no-validation.result.txt](https://github.com/renaissance-benchmarks/renaissance/files/14229213/als.no-validation.result.txt))
- with validation: 2323,872ms
([als.with-validation.result.txt](https://github.com/renaissance-benchmarks/renaissance/files/14229214/als.with-validation.result.txt))

The variant with validation appears approx. 4% slower, but this is just from a single run. Given that the benchmark code did not change, I don't think this indicates an actual change, but if necessary, I can do the comparison for multiple runs.