### PR TITLE
add cpu usage plugin resolves #238

### DIFF
--- a/plugins/jmx-cpu/README.md
+++ b/plugins/jmx-cpu/README.md
@@ -1,0 +1,59 @@
+# jmx-cpu plugin for Renaissance suite
+
+This plugin collects information about processor usage 
+via [OperatingSystemMXBean](https://docs.oracle.com/javase/8/docs/api/java/lang/management/OperatingSystemMXBean.html).
+
+## Building
+
+To build the plugin run the following command:
+
+```shell
+../../tools/sbt/bin/sbt assembly
+```
+
+The plugin shall be available as `target/plugin-jmxcpu-assembly-VER.jar`.
+
+## Using the plugin
+
+To use the plugin, simply add it with the `--plugin` option when starting the suite.
+Note that we specify an output file as the counters are not visible on the standard output.
+
+```shell
+java renaissance-gpl-0.15.0.jar \
+  --plugin plugin-jmxcpu-assembly-0.0.1.jar\
+  --json results.json \
+  ...
+```
+
+The results in the JSON file will have the following form.
+Note that the totals might be increasing even when the delta
+values stay at `0` because some collections may happen between
+loops (i.e., outside of the measured operation). 
+
+The `OperatingSystemMXBean` may produce `NaN` values that are interpreted as `0` in the results.
+A delta measurement results in `0` if any of the delta values are `NaN`.
+
+```json
+{
+    ...
+    "data": {
+        "BENCHMARK": {
+            "results": [
+            {
+                "duration_ns": 589592667,
+                ...
+                "jmx_cpu_available_processors": 8,
+                "jmx_cpu_cpu_load_delta": 7,
+                "jmx_cpu_process_cpu_time_delta_ns": 1636691000,
+                "jmx_cpu_cpu_load": 93,
+                "jmx_cpu_process_load": 88,
+                "jmx_cpu_load_average": 3,
+                "jmx_cpu_process_load_delta": 7,
+                "jmx_cpu_available_processors_delta": 0,
+                "jmx_cpu_load_average_delta": 0,
+                "jmx_cpu_process_cpu_time_ns": 19644011000
+            },
+            ...
+    ...
+}
+```

--- a/plugins/jmx-cpu/build.sbt
+++ b/plugins/jmx-cpu/build.sbt
@@ -1,0 +1,21 @@
+lazy val renaissanceCore = RootProject(uri("../../renaissance-core"))
+
+lazy val pluginJMXMemory = (project in file("."))
+  .settings(
+    name := "plugin-jmxcpu",
+    version := "0.0.1",
+    crossPaths := false,
+    autoScalaLibrary := false,
+    organization := "org.renaissance",
+    assembly / assemblyMergeStrategy := {
+      case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
+      case PathList("org", "renaissance", "plugins", _*) => MergeStrategy.first
+      case PathList("org", "renaissance", _*) => MergeStrategy.discard
+      case _ => MergeStrategy.singleOrError
+    },
+    javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+    packageOptions += sbt.Package.ManifestAttributes(
+      ("Renaissance-Plugin", "org.renaissance.plugins.jmxcpu.Main")
+    ),
+  )
+  .dependsOn(renaissanceCore % "provided")

--- a/plugins/jmx-cpu/project/build.properties
+++ b/plugins/jmx-cpu/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.6

--- a/plugins/jmx-cpu/project/plugins.sbt
+++ b/plugins/jmx-cpu/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")

--- a/plugins/jmx-cpu/src/main/java/org/renaissance/plugins/jmxcpu/Main.java
+++ b/plugins/jmx-cpu/src/main/java/org/renaissance/plugins/jmxcpu/Main.java
@@ -1,0 +1,80 @@
+package org.renaissance.plugins.jmxcpu;
+
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.ManagementFactory;
+
+import org.renaissance.Plugin;
+
+public class Main implements Plugin,
+        Plugin.AfterOperationSetUpListener,
+        Plugin.BeforeOperationTearDownListener,
+        Plugin.MeasurementResultPublisher {
+
+    OperatingSystemMXBean __operatingSystemMXBean;
+
+    boolean __isPlatformSpecific;
+    double __systemLoadAverageBefore;
+    double __systemLoadAverageAfter;
+    int __availableProcessorsBefore;
+    int __availableProcessorsAfter;
+    long __processCpuTimeBefore;
+    long __processCpuTimeAfter;
+    double __systemCpuLoadBefore;
+    double __systemCpuLoadAfter;
+    double __processCpuLoadAfter;
+    double __processCpuLoadBefore;
+
+
+    public Main() {
+        __operatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean();
+        __isPlatformSpecific = __operatingSystemMXBean instanceof com.sun.management.OperatingSystemMXBean;
+    }
+
+    @Override
+    public void afterOperationSetUp(String benchmark, int opIndex, boolean isLastOp) {
+        if (__isPlatformSpecific) {
+            __processCpuTimeBefore = ((com.sun.management.OperatingSystemMXBean)__operatingSystemMXBean).getProcessCpuTime();
+            __systemCpuLoadBefore = ((com.sun.management.OperatingSystemMXBean)__operatingSystemMXBean).getSystemCpuLoad();
+            __processCpuLoadBefore = ((com.sun.management.OperatingSystemMXBean)__operatingSystemMXBean).getProcessCpuLoad();
+        }
+        __systemLoadAverageBefore = __operatingSystemMXBean.getSystemLoadAverage();
+        __availableProcessorsBefore = __operatingSystemMXBean.getAvailableProcessors();
+    }
+
+    @Override
+    public void beforeOperationTearDown(String benchmark, int opIndex, long harnessDuration) {
+        if (__isPlatformSpecific) {
+            __processCpuTimeAfter = ((com.sun.management.OperatingSystemMXBean)__operatingSystemMXBean).getProcessCpuTime();
+            __systemCpuLoadAfter = ((com.sun.management.OperatingSystemMXBean)__operatingSystemMXBean).getSystemCpuLoad();
+            __processCpuLoadAfter = ((com.sun.management.OperatingSystemMXBean)__operatingSystemMXBean).getProcessCpuLoad();
+        }
+        __systemLoadAverageAfter = __operatingSystemMXBean.getSystemLoadAverage();
+        __availableProcessorsAfter = __operatingSystemMXBean.getAvailableProcessors();
+    }
+
+    @Override
+    public void onMeasurementResultsRequested(String benchmark, int opIndex, Plugin.MeasurementResultListener dispatcher){
+        dispatcher.onMeasurementResult(benchmark, "jmx_cpu_load_average", (long)__systemLoadAverageAfter);
+        dispatcher.onMeasurementResult(benchmark, "jmx_cpu_load_average_delta", (long)(__systemLoadAverageAfter - __systemLoadAverageBefore));
+        dispatcher.onMeasurementResult(benchmark, "jmx_cpu_available_processors", __availableProcessorsAfter);
+        dispatcher.onMeasurementResult(benchmark, "jmx_cpu_available_processors_delta", __availableProcessorsAfter - __availableProcessorsBefore);
+        if (__isPlatformSpecific) {
+            dispatcher.onMeasurementResult(benchmark, "jmx_cpu_process_cpu_time_ns", __processCpuTimeAfter);
+            dispatcher.onMeasurementResult(benchmark, "jmx_cpu_process_cpu_time_delta_ns", __processCpuTimeAfter - __processCpuTimeBefore);
+            dispatcher.onMeasurementResult(benchmark, "jmx_cpu_cpu_load", (long) (__systemCpuLoadAfter * 100));
+            if (Double.isNaN(__systemCpuLoadAfter) || Double.isNaN(__systemCpuLoadBefore)) {
+                dispatcher.onMeasurementResult(benchmark, "jmx_cpu_cpu_load_delta", 0);
+            }
+            else {
+                dispatcher.onMeasurementResult(benchmark, "jmx_cpu_cpu_load_delta", (long)((__systemCpuLoadAfter - __systemCpuLoadBefore) * 100));
+            }
+            dispatcher.onMeasurementResult(benchmark, "jmx_cpu_process_load", (long) (__processCpuLoadAfter * 100));
+            if (Double.isNaN(__processCpuLoadAfter) || Double.isNaN(__processCpuLoadBefore)) {
+                dispatcher.onMeasurementResult(benchmark, "jmx_cpu_process_load_delta", 0);
+            }
+            else {
+                dispatcher.onMeasurementResult(benchmark, "jmx_cpu_process_load_delta", (long)((__processCpuLoadAfter - __processCpuLoadBefore) * 100));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Based on the request in post #238, I added a plugin that exports CPU metrics. Unfortunately, I ran into a problem with inconsistent measurements. The `OperatingSystemMXBean` module,  which is used to gather the metrics, can return `NaN` values if the CPU load cannot be read at that moment.  This produces a `0` values  in the measurement results. 

Also, not all devices provide the `OperatingSystemMXBean` subinterface of the `com.sun.management` package, so some metrics are not available in some OSes.