### PR TITLE
Migrate scala-stm benchmarks from Scala 2.12 to Scala 3

### DIFF
--- a/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/Philosophers.scala
+++ b/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/Philosophers.scala
@@ -8,8 +8,8 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("philosophers")
-@Group("scala")
 @Group("scala-stm")
+@Group("scala") // With Scala 3, the primary group goes last.
 @Summary("Solves a variant of the dining philosophers problem using ScalaSTM.")
 @Licenses(Array(License.BSD3))
 @Repetitions(30)

--- a/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/ScalaStmBench7.scala
+++ b/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/ScalaStmBench7.scala
@@ -8,8 +8,8 @@ import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
 @Name("scala-stm-bench7")
-@Group("scala")
 @Group("scala-stm")
+@Group("scala") // With Scala 3, the primary group goes last.
 @Summary("Runs the stmbench7 benchmark using ScalaSTM.")
 @Licenses(Array(License.BSD3, License.GPL2))
 @Repetitions(60)

--- a/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/ImmutableSeqImpl.scala
+++ b/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/ImmutableSeqImpl.scala
@@ -2,7 +2,7 @@
 
 package stmbench7.scalastm
 
-import scala.collection.JavaConversions
+import scala.jdk.CollectionConverters.IteratorHasAsJava
 
 import stmbench7.backend.ImmutableCollection
 
@@ -10,7 +10,5 @@ class ImmutableSeqImpl[A](contents: Seq[A]) extends ImmutableCollection[A] {
   override def clone: ImmutableCollection[A] = this
   override def contains(element: A): Boolean = contents.contains(element)
   override def size: Int = contents.size
-
-  override def iterator: java.util.Iterator[A] =
-    JavaConversions.asJavaIterator(contents.iterator)
+  override def iterator: java.util.Iterator[A] = contents.iterator.asJava
 }

--- a/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/ImmutableSetImpl.scala
+++ b/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/ImmutableSetImpl.scala
@@ -2,7 +2,7 @@
 
 package stmbench7.scalastm
 
-import scala.collection.JavaConversions
+import scala.jdk.CollectionConverters.IteratorHasAsJava
 
 import scala.concurrent.stm.TSet
 
@@ -17,7 +17,5 @@ class ImmutableSetImpl[A](contents: TSet.View[A], shared: Boolean = true)
 
   override def contains(element: A): Boolean = contents.contains(element)
   override def size: Int = contents.size
-
-  override def iterator: java.util.Iterator[A] =
-    JavaConversions.asJavaIterator(contents.iterator)
+  override def iterator: java.util.Iterator[A] = contents.iterator.asJava
 }

--- a/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/IndexImpl.scala
+++ b/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/IndexImpl.scala
@@ -2,8 +2,9 @@
 
 package stmbench7.scalastm
 
-import scala.collection.JavaConversions
 import scala.collection.immutable.TreeMap
+import scala.jdk.CollectionConverters.SetHasAsJava
+import scala.jdk.CollectionConverters.IteratorHasAsJava
 
 import scala.concurrent.stm.Ref
 
@@ -34,8 +35,7 @@ object IndexImpl {
 
     override def iterator: java.util.Iterator[V] = makeValuesIterator(underlying())
 
-    override def getKeys: java.lang.Iterable[K] =
-      JavaConversions.setAsJavaSet(underlying().keySet)
+    override def getKeys: java.lang.Iterable[K] = underlying().keySet.asJava
 
     override def getRange(minKey: K, maxKey: K): java.lang.Iterable[V] =
       new java.lang.Iterable[V] {
@@ -44,7 +44,7 @@ object IndexImpl {
       }
 
     private def makeValuesIterator(m: TreeMap[K, V]) = {
-      JavaConversions.asJavaIterator(m.values.iterator)
+      m.values.iterator.asJava
     }
   }
 }

--- a/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/LargeSetImpl.scala
+++ b/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/LargeSetImpl.scala
@@ -2,7 +2,7 @@
 
 package stmbench7.scalastm
 
-import scala.collection.JavaConversions
+import scala.jdk.CollectionConverters.IteratorHasAsJava
 
 import scala.concurrent.stm.TMap
 
@@ -15,7 +15,5 @@ class LargeSetImpl[A <: Comparable[A]] extends LargeSet[A] {
   override def remove(e: A): Boolean = underlying.remove(e).isDefined
   override def contains(e: A): Boolean = underlying.contains(e)
   override def size: Int = underlying.size
-
-  override def iterator: java.util.Iterator[A] =
-    JavaConversions.asJavaIterator(underlying.keysIterator)
+  override def iterator: java.util.Iterator[A] = underlying.keysIterator.asJava
 }

--- a/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/ScalaSTMInitializer.scala
+++ b/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/ScalaSTMInitializer.scala
@@ -2,6 +2,8 @@
 
 package stmbench7.scalastm
 
+import scala.annotation.unused
+
 import scala.concurrent.stm.atomic
 import scala.concurrent.stm.Ref
 
@@ -23,6 +25,7 @@ import stmbench7.core.Module
 import stmbench7.core.Operation
 import stmbench7.impl.core.ConnectionImpl
 
+@unused("Referenced via string name")
 class ScalaSTMInitializer extends SynchMethodInitializer {
 
   def createOperationExecutorFactory(): OperationExecutorFactory =

--- a/benchmarks/scala-stm/stmbench7/src/main/java/stmbench7/Benchmark.java
+++ b/benchmarks/scala-stm/stmbench7/src/main/java/stmbench7/Benchmark.java
@@ -130,7 +130,7 @@ public class Benchmark {
     				else if(currentArg.equals("-w")) workload = optionValue;
     				else if(currentArg.equals("-g")) synchType = optionValue;
     				else if(currentArg.equals("-s")) stmInitializerClassName = optionValue;
-					else if(currentArg.equals("-c")) countOfOperations = Integer.parseInt(optionValue);
+    				else if(currentArg.equals("-c")) countOfOperations = Integer.parseInt(optionValue);
     				else throw new BenchmarkParametersException("Invalid option: " + currentArg);
     			}
     		}
@@ -201,8 +201,8 @@ public class Benchmark {
     		break;
     	}
 		try {
-			synchMethodInitializer = 
-				synchMethodInitializerClass.newInstance();
+			synchMethodInitializer =
+				synchMethodInitializerClass.getDeclaredConstructor().newInstance();
 		}
 		catch(Exception e) {
 			throw new BenchmarkParametersException("Error instantiating STM initializer class", e);

--- a/build.sbt
+++ b/build.sbt
@@ -450,9 +450,13 @@ lazy val scalaStdlibBenchmarks = (project in file("benchmarks/scala-stdlib"))
 lazy val scalaStmBenchmarks = (project in file("benchmarks/scala-stm"))
   .settings(
     name := "scala-stm",
-    commonSettingsScala212,
+    commonSettingsScala3,
     libraryDependencies := Seq(
       "org.scala-stm" %% "scala-stm" % "0.11.1"
+    ),
+    dependencyOverrides ++= Seq(
+      // Force common version of Scala 3 library.
+      "org.scala-lang" %% "scala3-library" % scalaVersion3
     )
   )
   .dependsOn(


### PR DESCRIPTION
Migrates the `scala-stm` benchmarks to Scala 3 (skipping Scala 2.13), leaving only the `reactors` benchmark to be migrated to at least Scala 2.13 (#324).

Below are plots from simple measurements I collected from 15 runs (150 repetitions each) using JDK 11 (default settings) on 8 cores of Xeon E5-2697A v4:
- the `scala212` variant corresponds to commit 87358d9 (Renaissance 0.15.0, scala-stm 0.8 with Scala 2.12.18)
- the `scala3_stm` variant corresponds to commit 6d1cb1f (scala-stm 0.11.1 with Scala 3.3.1)

![plot-runs-samples](https://github.com/renaissance-benchmarks/renaissance/assets/6641099/c447c9ea-1fd8-4789-89e9-4beaa651a12a)
![plot-runs-histograms](https://github.com/renaissance-benchmarks/renaissance/assets/6641099/0da29751-e593-47e6-b826-582f03dca93b)
![plot-runs-violins](https://github.com/renaissance-benchmarks/renaissance/assets/6641099/faf41625-3f7f-4e31-b4fa-18001e7e0de8)