### PR TITLE
Add simple validation to the philosophers benchmark

### DIFF
--- a/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/Philosophers.scala
+++ b/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/Philosophers.scala
@@ -1,5 +1,6 @@
 package org.renaissance.scala.stm
 
+import scala.collection.JavaConverters._
 import org.renaissance.Benchmark
 import org.renaissance.Benchmark._
 import org.renaissance.BenchmarkContext
@@ -33,17 +34,21 @@ final class Philosophers extends Benchmark {
    */
   private var mealCountParam: Int = _
 
+  private var expectedHash: String = _
+
   override def setUpBeforeAll(c: BenchmarkContext) = {
     threadCountParam = c.parameter("thread_count").toPositiveInteger
     mealCountParam = c.parameter("meal_count").toPositiveInteger
+    val expectedOutput = Array.fill(threadCountParam)(mealCountParam).toSeq.asJava;
+    expectedHash = Validators.computeHash(expectedOutput);
   }
 
   override def run(c: BenchmarkContext): BenchmarkResult = {
-    // TODO: Return something useful, not elapsed time
-    RealityShowPhilosophers.run(mealCountParam, threadCountParam)
+    val mealsEaten = RealityShowPhilosophers.run(mealCountParam, threadCountParam)
 
-    // TODO: add proper validation
-    Validators.dummy()
+    () => {
+      Validators.hashing(expectedHash, mealsEaten.toSeq.asJava).validate()
+    }
   }
 
 }

--- a/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/Philosophers.scala
+++ b/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/Philosophers.scala
@@ -1,11 +1,10 @@
 package org.renaissance.scala.stm
 
-import scala.collection.JavaConverters._
 import org.renaissance.Benchmark
 import org.renaissance.Benchmark._
 import org.renaissance.BenchmarkContext
 import org.renaissance.BenchmarkResult
-import org.renaissance.BenchmarkResult.Validators
+import org.renaissance.BenchmarkResult.Assert
 import org.renaissance.License
 
 @Name("philosophers")
@@ -34,20 +33,28 @@ final class Philosophers extends Benchmark {
    */
   private var mealCountParam: Int = _
 
-  private var expectedHash: String = _
-
-  override def setUpBeforeAll(c: BenchmarkContext) = {
+  override def setUpBeforeAll(c: BenchmarkContext): Unit = {
     threadCountParam = c.parameter("thread_count").toPositiveInteger
     mealCountParam = c.parameter("meal_count").toPositiveInteger
-    val expectedOutput = Array.fill(threadCountParam)(mealCountParam).toSeq.asJava;
-    expectedHash = Validators.computeHash(expectedOutput);
+  }
+
+  private def validate(forkOwners: Seq[Option[String]], mealsEaten: Seq[Int]): Unit = {
+    // All forks should be available, i.e., not owned by anyone.
+    for (i <- 0 until threadCountParam) {
+      Assert.assertEquals(None, forkOwners(i), s"owner of fork %i")
+    }
+
+    // All philosophers should have eaten the expected number of meals.
+    for (i <- 0 until threadCountParam) {
+      Assert.assertEquals(mealCountParam, mealsEaten(i), s"meals eaten by philosopher $i")
+    }
   }
 
   override def run(c: BenchmarkContext): BenchmarkResult = {
-    val mealsEaten = RealityShowPhilosophers.run(mealCountParam, threadCountParam)
+    val (forkOwners, mealsEaten) = RealityShowPhilosophers.run(mealCountParam, threadCountParam)
 
     () => {
-      Validators.hashing(expectedHash, mealsEaten.toSeq.asJava).validate()
+      validate(forkOwners, mealsEaten)
     }
   }
 

--- a/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/RealityShowPhilosophers.scala
+++ b/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/RealityShowPhilosophers.scala
@@ -85,7 +85,7 @@ object RealityShowPhilosophers {
       }
   }
 
-  def time(philosopherCount: Int, meals: Int): Long = {
+  def eatenMeals(philosopherCount: Int, meals: Int): Array[Int] = {
     val names = for (i <- 0 until philosopherCount) yield {
       s"philosopher-$i"
     }
@@ -96,16 +96,18 @@ object RealityShowPhilosophers {
       new PhilosopherThread(names(i), meals, forks(i), forks((i + 1) % forks.length))
     }
     val camera = new CameraThread(1000 / 60, forks, pthreads)
-    val start = System.currentTimeMillis
     camera.start()
     for (t <- pthreads) t.start()
     for (t <- pthreads) t.join()
-    val elapsed = System.currentTimeMillis - start
     camera.join()
-    elapsed
+    atomic { implicit txn =>
+      pthreads.map { p =>
+        p.mealsEaten.get(txn)
+      }
+    }
   }
 
   def run(meals: Int, philosopherCount: Int) = {
-    time(philosopherCount, meals)
+    eatenMeals(philosopherCount, meals)
   }
 }


### PR DESCRIPTION
This started as a simple hash-based validation @BohdanQQ's [fork](https://github.com/BohdanQQ/renaissance/tree/benchmark/philosophers/validation) from which I cherry-picked bits. Because there is no reason to validate hash of the output when we have the actual values, I modified the validation to validate the number of meals eaten directly and added an extra check that the forks have no owner at the end.