### PR TITLE
Make the number of "camera scans" constant in the philosophers benchmark

### DIFF
--- a/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/RealityShowPhilosophers.scala
+++ b/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/RealityShowPhilosophers.scala
@@ -160,9 +160,13 @@ object RealityShowPhilosophers {
     }
   }
 
-  def run(mealCount: Int, philosopherCount: Int): (Seq[Option[String]], Seq[Int]) = {
+  def run(
+    mealCount: Int,
+    philosopherCount: Int,
+    blockMealCount: Int
+  ): (Seq[Option[String]], Seq[Int], Int) = {
     val forks = Array.tabulate(philosopherCount) { i => new Fork(s"fork-$i") }
-    val controller = new CameraController(philosopherCount, 1 << 12)
+    val controller = new CameraController(philosopherCount, blockMealCount)
     val philosophers = Array.tabulate(philosopherCount) { i =>
       new PhilosopherThread(
         s"philosopher-$i",
@@ -184,6 +188,7 @@ object RealityShowPhilosophers {
     camera.join()
 
     // Collect fork owners and meals eaten for validation.
-    camera.stateSnapshot
+    val (forkOwners, mealsEaten) = camera.stateSnapshot
+    (forkOwners, mealsEaten, camera.images.length)
   }
 }

--- a/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/RealityShowPhilosophers.scala
+++ b/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/RealityShowPhilosophers.scala
@@ -2,26 +2,27 @@ package org.renaissance.scala.stm
 
 import scala.annotation.tailrec
 import scala.collection.mutable
-import scala.concurrent.stm._
+import scala.concurrent.stm.atomic
+import scala.concurrent.stm.retry
+import scala.concurrent.stm.Ref
 
 /**
  * This extends a solution to the dining philosopher's problem to include an
- * outside perspective that occasionally examines everything that is
- * happening.
+ * outside perspective that periodically examines what is happening.
  */
 object RealityShowPhilosophers {
 
-  class Fork {
-    val owner = Ref(None: Option[String])
+  private class Fork(val name: String) {
+    private[stm] val owner = Ref(None: Option[String])
   }
 
-  class PhilosopherThread(
+  private class PhilosopherThread(
     val name: String,
     val meals: Int,
     left: Fork,
     right: Fork
   ) extends Thread {
-    val mealsEaten = Ref(0)
+    private[stm] val mealsEaten = Ref(0)
 
     override def run(): Unit = {
       for (_ <- 0 until meals) {
@@ -29,12 +30,15 @@ object RealityShowPhilosophers {
         atomic { implicit txn =>
           if (!(left.owner().isEmpty && right.owner().isEmpty))
             retry
+
           left.owner() = Some(name)
           right.owner() = Some(name)
         }
+
         // Eating.
         atomic { implicit txn =>
           mealsEaten += 1
+
           left.owner() = None
           right.owner() = None
         }
@@ -42,66 +46,70 @@ object RealityShowPhilosophers {
     }
 
     def done: Boolean = mealsEaten.single() == meals
-
-    override def toString: String =
-      "%s is %5.2f%% done".format(name, mealsEaten.single() * 100.0 / meals)
   }
 
-  class CameraThread(
+  private class CameraThread(
     intervalMilli: Int,
     forks: Seq[Fork],
     philosophers: Seq[PhilosopherThread]
   ) extends Thread {
-    val outputs = mutable.Buffer[String]()
+    private[stm] val images = mutable.Buffer[String]()
 
     @tailrec final override def run(): Unit = {
       Thread.sleep(intervalMilli)
-      val (str, done) = image
-      outputs += str
+      val (image, done) = captureImage
+      images += image
       if (!done) {
         run()
       } else {
         // TODO Consistent way of handling stdout.
         //  See https://github.com/D-iii-S/renaissance-benchmarks/issues/20
-        println(s"Camera thread performed ${outputs.length} scans.")
+        println(s"Camera thread performed ${images.length} scans.")
       }
     }
 
-    /**
-     * We want to print exactly one image of the final state, so we check
-     * completion at the same time as building the image.
-     */
-    def image: (String, Boolean) =
+    private def captureImage: (String, Boolean) =
+      //
+      // We want to capture exactly one image of the final state, so we
+      // check completion at the same time as building the image.
+      //
       atomic { implicit txn =>
-        val buf = new StringBuilder
-        for (i <- forks.indices)
-          buf ++= "fork %d is owned by %s\n".format(i, forks(i).owner.single())
+        val image = new StringBuilder
+        for (f <- forks)
+          image ++= "%s is owned by %s\n".format(f.name, f.owner.single())
+
         var done = true
         for (p <- philosophers) {
-          buf ++= p.toString += '\n'
+          val progress = p.mealsEaten.single() * 100.0 / p.meals
+          image ++= "%s is %5.2f%% done\n".format(p.name, progress)
           done &&= p.done
         }
-        (buf.toString, done)
+
+        (image.toString, done)
       }
   }
 
   def run(mealCount: Int, philosopherCount: Int): (Seq[Option[String]], Seq[Int]) = {
-    val names = for (i <- 0 until philosopherCount) yield {
-      s"philosopher-$i"
+    val forks = Array.tabulate(philosopherCount) { i => new Fork(s"fork-$i") }
+    val philosophers = Array.tabulate(philosopherCount) { i =>
+      new PhilosopherThread(
+        s"philosopher-$i",
+        mealCount,
+        forks(i),
+        forks((i + 1) % forks.length)
+      )
     }
-    val forks = Array.tabulate(names.size) { _ =>
-      new Fork
-    }
-    val pthreads = Array.tabulate(names.size) { i =>
-      new PhilosopherThread(names(i), mealCount, forks(i), forks((i + 1) % forks.length))
-    }
-    val camera = new CameraThread(1000 / 60, forks, pthreads)
+
+    val camera = new CameraThread(1000 / 60, forks, philosophers)
+
     camera.start()
-    for (t <- pthreads) t.start()
-    for (t <- pthreads) t.join()
+    philosophers.foreach(_.start())
+    philosophers.foreach(_.join())
     camera.join()
+
+    // Collect fork owners and meals eaten for validation.
     atomic { implicit txn =>
-      (forks.map(_.owner.get), pthreads.map(_.mealsEaten.get))
+      (forks.map(_.owner.get), philosophers.map(_.mealsEaten.get))
     }
   }
 }


### PR DESCRIPTION
This includes two related changes and one extra bit.

The first reduces the duration of the transaction building the "image of the scene". Previously the image was being built inside the transaction, making the transaction last unnecessarily longer. Now we only take a snapshot of the state within the transaction and build the image outside the transaction to avoid blocking philosopher threads.

The second change makes the number of scans constant for a given workload. Previously, camera scans were triggered in reference to wall clock time, resulting in variable number of scans during each repetition. Now the camera scans are requested based on thread progress. To keep the number of camera scans constant, the requests are counted to avoid potential loss of wake-ups when the rate of progress increases (due to reduced contention towards the end of the workload).

These two changes should alleviate the banding in the operation durations (#202), but probably not entirely, because there simply is a thread that periodically blocks all threads for a while.

The extra bit is inclusion of the number of camera scans in the validation.

Below are plots from simple measurements I collected from 15 runs (150 repetitions each) using JDK 11 (default settings) on 8 cores of Xeon E5-2697A v4:
- the `split_scan` variant corresponds to commit d3a614a
- the `const_scan_lbq` variant corresponds to commit 18b4936 (scan requests queued using `LinkedBlockingQueue`)
- the `const_scan_stm` variant corresponds to commit 05ad765 (scan requests "queued" using STM transactions) 

![plot-runs-samples](https://github.com/renaissance-benchmarks/renaissance/assets/6641099/ed33ce13-e9a2-4f0f-ba25-8b7813331ea8)
![plot-runs-histograms](https://github.com/renaissance-benchmarks/renaissance/assets/6641099/cf367b39-a1cd-4c69-a361-7777c65028c7)
![plot-runs-violins](https://github.com/renaissance-benchmarks/renaissance/assets/6641099/825c70a2-57ef-4be2-b555-9fe4f87352bf)