### PR TITLE
Add gauss-mix validation

### DIFF
--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/GaussMix.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/GaussMix.scala
@@ -8,11 +8,9 @@ import org.renaissance.Benchmark
 import org.renaissance.Benchmark._
 import org.renaissance.BenchmarkContext
 import org.renaissance.BenchmarkResult
-import org.renaissance.BenchmarkResult.Validators
+import org.renaissance.BenchmarkResult.ValidationException
 import org.renaissance.License
 
-import java.nio.file.Files
-import java.nio.file.Path
 import scala.util.Random
 
 @Name("gauss-mix")
@@ -27,119 +25,292 @@ import scala.util.Random
 )
 @Parameter(
   name = "point_count",
-  defaultValue = "15000",
+  defaultValue = "9000",
   summary = "Number of data points to generate."
 )
 @Parameter(
-  name = "component_count",
-  defaultValue = "10",
-  summary = "Number of components in each data point."
+  name = "dimension_count",
+  defaultValue = "8",
+  summary = "Number of dimensions in each data point."
 )
 @Parameter(
-  name = "distribution_count",
+  name = "cluster_count",
   defaultValue = "6",
-  summary = "Number of gaussian distributions in the mix."
+  summary = "Number of point clusters to generate."
 )
 @Parameter(
-  name = "max_iterations",
-  defaultValue = "15",
-  summary = "Maximum number of iterations of the clustering algorithm."
+  name = "cluster_distance",
+  defaultValue = "5",
+  summary = "Distance (in a single dimension) between generated gaussian clusters."
 )
-@Configuration(name = "test", settings = Array("point_count = 7", "max_iterations = 3"))
+@Parameter(
+  name = "gm_configs",
+  defaultValue =
+    "model_count,gaussians_per_cluster,iteration_count;" +
+      "4,2.0,25;" +
+      "4,1.5,30;"
+)
+@Parameter(
+  name = "prediction_tolerance",
+  defaultValue = "0.25",
+  summary = "Tolerance between assigned and expected gaussian mu value of points."
+)
+@Parameter(
+  name = "expected_model_accuracy",
+  defaultValue = "0.99",
+  summary = "Expected percentage of points correctly assigned to centroids."
+)
+@Configuration(
+  name = "test",
+  settings = Array(
+    "point_count = 2500",
+    "cluster_count = 2",
+    "gm_configs = " +
+      "model_count,gaussians_per_cluster,iteration_count;" +
+      "2,2.0,25;"
+  )
+)
 @Configuration(name = "jmh")
 final class GaussMix extends Benchmark with SparkUtil {
 
   // TODO: Consolidate benchmark parameters across the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/27
 
-  private var maxIterationsParam: Int = _
+  private var predictionTolerance: Double = _
 
-  private var distributionCountParam: Int = _
+  private var expectedModelAccuracy: Double = _
 
-  private var inputVectors: RDD[org.apache.spark.mllib.linalg.Vector] = _
+  private type Point = org.apache.spark.mllib.linalg.Vector
 
-  private var outputGaussianMixture: GaussianMixtureModel = _
+  private var trainingPoints: RDD[Point] = _
 
-  private def prepareInput(pointCount: Int, componentCount: Int, outputFile: Path): Path = {
-    import scala.jdk.CollectionConverters._
+  private var validationPoints: RDD[Point] = _
 
+  private var validationCentroids: RDD[Point] = _
+
+  private var testingPoints: RDD[Point] = _
+
+  private var testingCentroids: RDD[Point] = _
+
+  private case class GmConfig(
+    /** The number of models (with different random seed) to train. */
+    modelCount: Int,
+    /** The number of gaussians to use in the model. */
+    gaussianCount: Int,
+    /** The maximum number of iterations for training the model. */
+    iterationCount: Int
+  )
+
+  /**
+   * Gaussian Mixture configurations for individual model-fitting rounds.
+   */
+  private var gmConfigurations: Iterable[GmConfig] = _
+
+  /**
+   * Random seed for a model-fitting round. Generally remains unchanged, unless
+   * [[randomizeGmSeed]] is set to `true`.
+   */
+  private var gmSeedBase: Int = 159147643
+
+  /**
+   * Enables generating a new random seed for each model-fitting round.
+   * Primarily for debugging purposes when finding a new seed for model-fitting.
+   */
+  private val randomizeGmSeed: Boolean = false
+
+  /**
+   * Random generator for the seed used in model-fitting rounds.
+   * Only used when [[randomizeGmSeed]] is `true`.
+   */
+  private val gmSeedRandom: Random = new Random()
+
+  private def prepareInput(
+    pointCount: Int,
+    dimensionCount: Int,
+    clusterCount: Int,
+    clusterDistance: Int
+  ): Seq[(Point, Point)] = {
     // TODO: Use a Renaissance-provided random generator.
-    val rand = new Random(0L)
+    val rand = new Random(524764901)
 
-    def randDouble(): Double = {
-      (rand.nextDouble() * 10).toInt / 10.0
+    def randGauss(scale: Double): Double = {
+      rand.nextGaussian() * scale
     }
 
-    val lines = (0 until pointCount).map { _ =>
-      (0 until componentCount).map(_ => randDouble()).mkString(" ")
+    def makeCentroids(clusterCount: Int, dimensionCount: Int): Seq[Array[Double]] = {
+      // Generate cluster centers with increasing offset from vertices of a hypercube.
+      (0 until clusterCount).map { clusterIndex =>
+        (0 until dimensionCount).map { dimensionIndex =>
+          ((clusterIndex >> dimensionIndex) % 2) * (clusterDistance + clusterIndex * 0.8)
+        }.toArray
+      }
     }
 
-    // Write output using UTF-8 encoding.
-    Files.write(outputFile, lines.asJava)
+    assert(
+      clusterCount <= (1 << dimensionCount),
+      "The cluster count should be less than or equal to 2 raised to the power of the dimension count."
+    )
+
+    val centroids = makeCentroids(clusterCount, dimensionCount)
+
+    // Scale an N(0,1) gaussian so that most points (expressed as a multiple of standard
+    // deviation) of the last centroid fall within half the centroid "distance". The limit
+    // is proportionally lower for centroids with lower indices.
+    val sigmaCount = 3
+    val scaleMax = (clusterDistance / 2.0) / sigmaCount
+    val scaleFraction = scaleMax / centroids.length
+
+    (0 until pointCount).map { pointIndex =>
+      val centroidIndex = pointIndex % centroids.length
+      val centroid = centroids(centroidIndex)
+      val point = centroid.indices.map { dimension =>
+        centroid(dimension) + randGauss((centroidIndex + 1) * scaleFraction)
+      }.toArray
+
+      (Vectors.dense(point), Vectors.dense(centroid))
+    }
   }
 
-  private def loadData(inputFile: Path) = {
-    sparkContext
-      .textFile(inputFile.toString)
-      .map { line =>
-        val raw = line.split(" ").map(_.toDouble)
-        Vectors.dense(raw)
+  private def splitAt[T](xs: Seq[T], splitPoints: Double*) = {
+    assert(
+      !splitPoints.exists(p => p <= 0.0 || p >= 1.0),
+      "Split points must be between 0 and 1 (exclusive)."
+    )
+
+    val length = xs.length
+    val indices = (0 +: splitPoints.map(p => (p * length).toInt) :+ length).distinct.sorted
+
+    indices
+      .sliding(2)
+      .map {
+        case Seq(start, end) =>
+          xs.slice(start, end)
       }
+      .toSeq
+  }
+
+  private def parallelizePoints(pointsWithCentroids: Seq[(Point, Point)]) = {
+    val points = pointsWithCentroids.map { case (point, _) => point }
+    sparkContext.parallelize(points)
+  }
+
+  private def parallelizeCentroids(pointsWithCentroids: Seq[(Point, Point)]) = {
+    val centroids = pointsWithCentroids.map { case (_, centroid) => centroid }
+    sparkContext.parallelize(centroids)
   }
 
   override def setUpBeforeAll(bc: BenchmarkContext): Unit = {
     setUpSparkContext(bc)
 
-    maxIterationsParam = bc.parameter("max_iterations").toPositiveInteger
-    distributionCountParam = bc.parameter("distribution_count").toPositiveInteger
+    // Validation parameters.
+    predictionTolerance = bc.parameter("prediction_tolerance").toDouble
+    expectedModelAccuracy = bc.parameter("expected_model_accuracy").toDouble
 
-    val inputFile = prepareInput(
+    // Generate input points.
+    val clusterCount = bc.parameter("cluster_count").toPositiveInteger
+    val inputPointsWithCentroids = prepareInput(
       bc.parameter("point_count").toPositiveInteger,
-      bc.parameter("component_count").toPositiveInteger,
-      bc.scratchDirectory().resolve("input.txt")
+      bc.parameter("dimension_count").toPositiveInteger,
+      clusterCount,
+      bc.parameter("cluster_distance").toPositiveInteger
     )
 
-    inputVectors = ensureCached(loadData(inputFile))
+    // Split input points into training (80%), validation (10%), and testing (10%) sets.
+    val Seq(training, validation, testing) = splitAt(inputPointsWithCentroids, 0.8, 0.9)
+    trainingPoints = ensureCached(parallelizePoints(training))
+    validationPoints = ensureCached(parallelizePoints(validation))
+    validationCentroids = ensureCached(parallelizeCentroids(validation))
+    testingPoints = ensureCached(parallelizePoints(testing))
+    testingCentroids = ensureCached(parallelizeCentroids(validation))
+
+    // GM algorithm parameters.
+    import scala.jdk.CollectionConverters._
+
+    gmConfigurations = bc
+      .parameter("gm_configs")
+      .toCsvRows(row =>
+        GmConfig(
+          row.get("model_count").toInt,
+          // Use more gaussians than clusters to improve fitting.
+          (row.get("gaussians_per_cluster").toDouble * clusterCount).toInt,
+          row.get("iteration_count").toInt
+        )
+      )
+      .asScala
+  }
+
+  override def setUpBeforeEach(context: BenchmarkContext): Unit = {
+    if (randomizeGmSeed) {
+      gmSeedBase = gmSeedRandom.nextInt()
+    }
+  }
+
+  private def computeModelAccuracy(
+    model: GaussianMixtureModel,
+    points: RDD[Point],
+    expectedCentroids: RDD[Point]
+  ): Double = {
+    def isAccurate(predictedCentroid: Point, expectedCentroid: Point, tolerance: Double) = {
+      Vectors.sqdist(predictedCentroid, expectedCentroid) <= tolerance
+    }
+
+    // Turn the tolerance parameter into a local constant so that it can be captured.
+    val tolerance = predictionTolerance
+
+    val predictedCentroids = model.predict(points).map(index => model.gaussians(index).mu)
+    val accuratePredictionCount = predictedCentroids
+      .zip(expectedCentroids)
+      .filter(centroids => isAccurate(centroids._1, centroids._2, tolerance))
+      .count()
+
+    accuratePredictionCount.toDouble / points.count()
+  }
+
+  private def trainModels(): GaussianMixtureModel = {
+    var bestModel: GaussianMixtureModel = null
+    var bestAccuracy: Double = 0.0
+
+    for (config <- gmConfigurations) {
+      for (i <- 0 until config.modelCount) {
+        val seed = gmSeedBase + i
+        val gaussMix = new GaussianMixture()
+          .setK(config.gaussianCount)
+          .setMaxIterations(config.iterationCount)
+          .setSeed(seed)
+          .setConvergenceTol(0)
+
+        val model = gaussMix.run(trainingPoints)
+        val accuracy = computeModelAccuracy(model, validationPoints, validationCentroids)
+
+        println(
+          f"Accuracy (validation) = ${accuracy}%.5f for the model trained with " +
+            s"K = ${config.gaussianCount}, maxIterations = ${config.iterationCount}, and seed = ${seed}."
+        )
+
+        if (accuracy >= bestAccuracy) {
+          bestModel = model
+          bestAccuracy = accuracy
+        }
+      }
+    }
+
+    bestModel
   }
 
   override def run(bc: BenchmarkContext): BenchmarkResult = {
-    outputGaussianMixture = new GaussianMixture()
-      .setK(distributionCountParam)
-      .setMaxIterations(maxIterationsParam)
-      .setSeed(159147643)
-      .run(inputVectors)
+    val bestModel = trainModels()
+    val bestModelAccuracy = computeModelAccuracy(bestModel, testingPoints, testingCentroids)
 
-    // TODO: add more in-depth validation
-    Validators.simple("number of gaussians", distributionCountParam, outputGaussianMixture.k)
+    () => {
+      if (bestModelAccuracy < expectedModelAccuracy) {
+        throw new ValidationException(
+          s"Expected model accuracy of at least ${expectedModelAccuracy} but got ${bestModelAccuracy}"
+        )
+      }
+    }
   }
 
-  override def tearDownAfterAll(bc: BenchmarkContext) = {
-    if (dumpResultsBeforeTearDown && outputGaussianMixture != null) {
-      val outputFile = bc.scratchDirectory().resolve("output.txt")
-      dumpResult(outputGaussianMixture, outputFile)
-    }
-
+  override def tearDownAfterAll(bc: BenchmarkContext): Unit = {
     tearDownSparkContext()
   }
-
-  private def dumpResult(gmm: GaussianMixtureModel, outputFile: Path) = {
-    val output = new StringBuilder
-    gmm.gaussians
-      .zip(gmm.weights)
-      .zipWithIndex
-      .foreach({
-        case ((g, w), i) =>
-          output.append(s"gaussian $i:\n")
-          output.append(s"  weight: $w\n")
-          output.append("  mu: ").append(g.mu).append("\n")
-          output
-            .append("  sigma: ")
-            .append(g.sigma.rowIter.mkString("[", ", ", "]"))
-            .append("\n\n")
-      })
-
-    // Files.writeString() is only available from Java 11.
-    Files.write(outputFile, output.toString.getBytes)
-  }
-
 }


### PR DESCRIPTION
The benchmark computation was originally unstable due to the method of generating training data points. The benchmark generated random points such that each dimension of each point was a random double between zero and one, rounded to one decimal place. This approach resulted in points representing random noise within a cuboid defined by [0, 0, ..., 0] and [1, 1, ..., 1], rather than Gaussian distributions. Additionally, the Spark GMM model fitting returns inconsistent results when different thread counts are used, making it impossible to achieve benchmark stability even with a fixed seed for the random generator.

Currently, the benchmark generates input data points grouped into clusters. These clusters are positioned with increasing offset from the vertices of a hypercube. To enhance model fit quality, the clusters have varying deviations. After generation, the points are split into three sets: training, validation, and test. The training data points are used to train multiple models, each with different training parameters: iteration count, seed, and K.

Each model is trained with a different seed to explore variations in model initialization, which can lead to better fits. To ensure consistency, the benchmark uses an initial seed and increments it by one for each subsequent trained model.

The K parameter represents the number of Gaussian clusters the model should fit. In the benchmark, K is set to either 1.5 or 2.0 times the actual number of generated centroids. Using a higher K improves the model fit quality.

After training models with all defined configurations, the best model is selected. For each model, cluster inclusion for all points in the validation set is predicted, and the prediction accuracy is computed. The distance between the expected and correctly predicted Gaussian distribution mean (mu) should be 0.25 or less. The best model is then used to predict the points in the test set, and its prediction accuracy is computed. The benchmark validation requires the prediction accuracy of the best model on the test set to exceed 99%.

I believe the duration of the gauss-mix benchmark will vary due to modifications in its computation. Specifically, I reduced the point count and dimension count while increasing the number of trained models from 1 to 8 to enhance validation stability. To document the change in benchmark duration, I measured 15 runs (each with 150 repetitions) using JDK21 on a 6-cores (12-threads) system, both before and after the modifications. During these measurements, I included JVM warmup and did not filter outliers. The collected measurements are visualized in the graphs bellow:

![Samples graph of the gauss-mix benchmark duration before and after validation.](https://github.com/user-attachments/assets/4e06e19f-9a89-465a-9559-d7288faa4038)
![Histograms graph of the gauss-mix benchmark duration before and after validation.](https://github.com/user-attachments/assets/6c5c7635-1f23-4293-bbac-d8822afe5900)
![Violins graph of the gauss-mix benchmark duration before and after validation.](https://github.com/user-attachments/assets/cd7b0027-0f5d-48cc-b179-7ee1930f07b0)

The average benchmark duration before validation was: 532.923ms
The average benchmark duration after validation is: 4608.173ms