### PR TITLE
Patch Hadoop Client API jar to avoid deprecated Java Security API

### DIFF
--- a/.github/workflows/ea-jdk.yml
+++ b/.github/workflows/ea-jdk.yml
@@ -5,7 +5,7 @@ env:
 jobs:
   linux-ea:
     runs-on: ubuntu-latest
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v11-openjdk23-ea"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk24-ea"
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v11-openjdk22"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk23"
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v11-openjdk22"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk23"
     continue-on-error: true
     steps:
       - name: Git checkout
@@ -98,10 +98,10 @@ jobs:
         shell: bash
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      - name: Setup JDK 22
+      - name: Setup JDK 23
         uses: actions/setup-java@v4
         with:
-          java-version: 22
+          java-version: 23
           distribution: temurin
 
       - name: Environment configuration
@@ -151,10 +151,10 @@ jobs:
         shell: bash
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      - name: Setup Java JDK 22
+      - name: Setup Java JDK 23
         uses: actions/setup-java@v4
         with:
-          java-version: 22
+          java-version: 23
           distribution: temurin
 
       - name: Environment configuration
@@ -194,7 +194,7 @@ jobs:
   plugins:
     runs-on: ubuntu-latest
     needs: linux
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v11-openjdk11-with-ant-gcc"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk11-with-ant-gcc"
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -240,7 +240,7 @@ jobs:
           - openj9-openjdk21
     runs-on: ubuntu-latest
     continue-on-error: true
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v11-${{ matrix.image }}"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-${{ matrix.image }}"
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/build.sbt
+++ b/build.sbt
@@ -767,7 +767,7 @@ lazy val generatePatchedHadoopClientApiJar = taskKey[Seq[File]](
     "allows running with GraalVM Native Image."
 )
 
-renaissance / generatePatchedHadoopClientApiJar :=
+def generatePatchedHadoopClientApiJarTask = {
   Def.task {
     val log = sLog.value
     val targetDir = (Compile / target).value / "patched"
@@ -793,7 +793,8 @@ renaissance / generatePatchedHadoopClientApiJar :=
           patchedJar
         }
     }
-  }.value
+  }
+}
 
 //
 // Tasks related to generating metadata-only jars for benchmarks.
@@ -909,6 +910,7 @@ lazy val renaissance = (project in file("."))
     name := "renaissance",
     // Reflect the distribution license in the package name.
     moduleName := name.value + "-" + (if (nonGplOnly.value) "mit" else "gpl"),
+    generatePatchedHadoopClientApiJar := generatePatchedHadoopClientApiJarTask.value,
     inConfig(Compile)(
       Seq(
         // The main class for the JAR is the Launcher from the core package.
@@ -1078,6 +1080,7 @@ lazy val renaissanceJmh = (project in file("renaissance-jmh"))
       "org.openjdk.jmh" % "jmh-generator-bytecode" % jmhVersion,
       "org.openjdk.jmh" % "jmh-generator-reflection" % jmhVersion
     ),
+    generatePatchedHadoopClientApiJar := generatePatchedHadoopClientApiJarTask.value,
     inConfig(Compile)(
       Seq(
         // Split result from the JMH generator task between sources and resources.
@@ -1104,7 +1107,7 @@ lazy val renaissanceJmh = (project in file("renaissance-jmh"))
         // Include benchmark dependency JAR files in the output JAR.
         packageBin / mappings ++= mapModuleDependencyJarsToAssemblyTask(
           renaissanceModules
-        ).value
+        ).dependsOn(generatePatchedHadoopClientApiJar).value
       )
     )
   )

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -3,3 +3,11 @@
 // root project can use them in utility code.
 //
 dependsOn(RootProject(uri("../renaissance-core")))
+
+//
+// The following classes are needed for the Hadoop Client API patcher.
+//
+libraryDependencies ++= Seq(
+  "org.ow2.asm" % "asm" % "9.7",
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0"
+)

--- a/project/hadoop.scala
+++ b/project/hadoop.scala
@@ -1,0 +1,190 @@
+import sbt.File
+import sbt.Logger
+import sbt.io.IO
+
+import scala.util.Try
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Using
+import scala.collection.compat.immutable.LazyList
+
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.security.MessageDigest
+import java.security.NoSuchAlgorithmException
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+import java.util.jar.JarInputStream
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.Properties
+
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
+object Hadoop {
+
+  def patchClientApiJar(inputJarFile: File, outputJarFile: File, log: Logger): Boolean = {
+    Using.Manager { use =>
+      val jis = use(new JarInputStream(new FileInputStream(inputJarFile)))
+      val jos = use(new JarOutputStream(new FileOutputStream(outputJarFile)))
+
+      // Enable the multi-release attribute in the output jar.
+      val manifest = createOrUpdateManifest(Option(jis.getManifest()));
+      jos.putNextEntry(new JarEntry(JarFile.MANIFEST_NAME));
+      manifest.write(jos);
+      jos.closeEntry()
+
+      // Copy JAR entries, adding a patched UserGroupInformation class.
+      lazyJarEntries(jis).foreach { entry =>
+        val inputBytes = jis.readAllBytes
+        jis.closeEntry
+
+        storeJarEntry(jos, entry.getName, inputBytes)
+
+        // Include patched UserGroupInformation class for Java 23+, which will
+        // pick it up from the version-specific location in multi-release jar.
+        if ("org/apache/hadoop/security/UserGroupInformation.class".equals(entry.getName)) {
+          log.debug(s"processing byte code in $entry")
+          ensureMatchingDigest(inputBytes, "md5:a6be5d7798cda1e3e854feb0edbdaacf", "input")
+
+          val outputBytes = patchUserGroupInformationClass(inputBytes)
+          ensureMatchingDigest(outputBytes, "md5:16a321b5a4ffa65946da39bccfc6883f", "output")
+
+          storeJarEntry(jos, s"META-INF/versions/23/${entry.getName}", outputBytes)
+        }
+      }
+    } match {
+      case Failure(exception) =>
+        log.error(s"Hadoop Client API patcher: ${exception.getMessage}")
+        false
+      case Success(value) => true
+    }
+  }
+
+  private def createOrUpdateManifest(manifest: Option[Manifest]) = {
+    val result = manifest.getOrElse(new Manifest)
+    result.getMainAttributes().putValue("Multi-Release", "true")
+    result
+  }
+
+  private def lazyJarEntries(initialJis: JarInputStream): LazyList[JarEntry] = {
+    //
+    // Provide the entries lazily!
+    //
+    // The consumer will want to access the bytes of the current entry, so the state
+    // of the input stream must not change until the next entry is requested.
+    //
+    LazyList.unfold(initialJis) { jis =>
+      Option(jis.getNextJarEntry()).map(entry => Some(entry, jis)).getOrElse(None)
+    }
+  }
+
+  private def ensureMatchingDigest(bytes: Array[Byte], expected: String, kind: String): Unit = {
+    val actual = md5(bytes)
+    if (!expected.equals(actual)) {
+      throw new IllegalStateException(
+        s"mismatching $kind class digest: expected=$expected, actual=$actual"
+      )
+    }
+  }
+
+  private def md5(bytes: Array[Byte]) =
+    try {
+      val digest = MessageDigest.getInstance("md5")
+      val hexString = digest.digest(bytes).map("%02x".format(_)).mkString
+      val algorithm = digest.getAlgorithm.toLowerCase
+      s"$algorithm:$hexString"
+    } catch {
+      case e: NoSuchAlgorithmException => ""
+    }
+
+  private def patchUserGroupInformationClass(bytes: Array[Byte]) = {
+    val classReader = new ClassReader(bytes)
+    val classWriter = new ClassWriter(
+      classReader,
+      ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS
+    )
+    val classPatcher = new UserGroupInformationPatcher(Opcodes.ASM9, classWriter)
+    classReader.accept(classPatcher, ClassReader.EXPAND_FRAMES)
+    classWriter.toByteArray
+  }
+
+  private def storeJarEntry(jos: JarOutputStream, name: String, bytes: Array[Byte]): Unit = {
+    jos.putNextEntry(new JarEntry(name))
+    jos.write(bytes)
+    jos.closeEntry
+  }
+
+  // ASM transformer classes.
+
+  private class UserGroupInformationPatcher(api: Int, cv: ClassVisitor)
+    extends ClassVisitor(api: Int, cv: ClassVisitor) {
+
+    override def visitMethod(
+      access: Int,
+      name: String,
+      descriptor: String,
+      signature: String,
+      exceptions: Array[String]
+    ) = {
+      val mv = super.visitMethod(access, name, descriptor, signature, exceptions)
+
+      // Modify only the getCurrentUser method.
+      if (isGetCurrentUserMethod(name, descriptor)) {
+        new GetCurrentUserMethodPatcher(Opcodes.ASM9, mv);
+      } else {
+        mv
+      }
+    }
+
+    private def isGetCurrentUserMethod(name: String, descriptor: String) = {
+      "getCurrentUser".equals(name) &&
+      "()Lorg/apache/hadoop/security/UserGroupInformation;".equals(descriptor)
+    }
+  }
+
+  private class GetCurrentUserMethodPatcher(api: Int, mv: MethodVisitor)
+    extends MethodVisitor(api: Int, mv: MethodVisitor) {
+
+    override def visitMethodInsn(
+      opcode: Int,
+      owner: String,
+      name: String,
+      descriptor: String,
+      isInterface: Boolean
+    ) = {
+      // Check if the method being called is Subject.getSubject
+      if (isGetSubjectMethod(owner, name, descriptor)) {
+        if (opcode != Opcodes.INVOKESTATIC) {
+          throw new AssertionError(s"${owner}.${name} invocation is not static")
+        }
+
+        // Remove the argument from the stack.
+        super.visitInsn(Opcodes.POP)
+        super.visitMethodInsn(
+          opcode,
+          owner,
+          "current",
+          "()Ljavax/security/auth/Subject;",
+          false
+        )
+      } else {
+        super.visitMethodInsn(opcode, owner, name, descriptor, isInterface)
+      }
+    }
+
+    private def isGetSubjectMethod(owner: String, name: String, descriptor: String) = {
+      "javax/security/auth/Subject".equals(owner) &&
+      "getSubject".equals(name) &&
+      "(Ljava/security/AccessControlContext;)Ljavax/security/auth/Subject;".equals(descriptor)
+    }
+  }
+
+}

--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -52,7 +52,7 @@ cp_reflink() {
 
 get_jvm_workaround_args() {
     case "$RENAISSANCE_JVM_MAJOR_VERSION" in
-        16|17|18|19|20|21|22|23-ea)
+        16|17|18|19|20|21|22|23|24-ea|24)
             echo "--add-opens=java.base/java.lang=ALL-UNNAMED"
             echo "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
             echo "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"


### PR DESCRIPTION
Uses ASM to patch the `UserGroupInformation` class at build time and stores it in a version-specific directory of a newly created multi-release jar, where it will be picked up by Java 23+.

This is a temporary solution, but it may be a long-term temporary solution.

Fixes #439.