### PR TITLE
CI: build once, run on multiple JDKs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,6 +145,10 @@ jobs:
             image: null
             java: 23
 
+    # The following two lines are a bit of a hack:
+    #  - We use only short OS name in the matrix to have short build names.
+    #  - We need to set container to null on Windows and Mac as containers are
+    #    supported on Linux only
     runs-on: ${{ (matrix.os == 'linux') && 'ubuntu' || matrix.os }}-latest
     container: ${{ (matrix.os == 'linux') && format('ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-{0}', matrix.image) || null }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ on:
 env:
   COURSIER_CACHE: ${{ github.workspace }}/.cache/coursier
 
+  # Retention period of the generated artifacts (main and JMH Renaissance JARs)
+  # (Using the pseudo-ternary operator here, the retention can be 1 to 90 days)
+  ARTIFACT_RETENTION_DAYS: ${{ ((github.event_name == 'push') && (github.ref == 'refs/heads/master')) && 30 || 4 }}
+
 jobs:
 
   checks:
@@ -80,14 +84,14 @@ jobs:
         with:
           name: main-jar
           path: target/renaissance-*.jar
-          retention-days: 1
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
       - name: Upload JMH JAR
         uses: actions/upload-artifact@v4
         with:
           name: jmh-jar
           path: renaissance-jmh/target/renaissance-*.jar
-          retention-days: 1
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
 
   run-linux:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
 
-  checks:
+  style:
     runs-on: ubuntu-latest
     container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk23"
     # We rarely build for more than 3 minutes
@@ -40,14 +40,6 @@ jobs:
       - name: Check source code formatting
         shell: bash
         run: tools/ci/check-formatting.sh
-
-      - name: Build the base bundle
-        shell: bash
-        run: tools/ci/build-base.sh
-
-      - name: Check generated files are up-to-date
-        shell: bash
-        run: tools/ci/check-markdown.sh
 
 
   build:
@@ -96,6 +88,34 @@ jobs:
           name: jmh-jar
           path: renaissance-jmh/target/renaissance-*.jar
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+
+
+  readme:
+    needs: build
+    runs-on: ubuntu-latest
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk23"
+    # We rarely build for more than 3 minutes
+    timeout-minutes: 10
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fix Git safe directory
+        shell: bash
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: Fetch pre-built main JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: main-jar
+          path: target
+
+      - name: Check generated files are up-to-date
+        shell: bash
+        run: tools/ci/check-markdown.sh
+
 
   run:
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,9 +213,11 @@ jobs:
           key: coursier_cache-${{ runner.os }}-${{ hashFiles('build.sbt') }}
           path: ${{ env.COURSIER_CACHE }}
 
-      - name: Build base
-        shell: bash
-        run: tools/ci/build-base.sh
+      - name: Fetch pre-built main JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: main-jar
+          path: target
 
       - name: Build plugins
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,9 @@ on:
   pull_request:
 env:
   COURSIER_CACHE: ${{ github.workspace }}/.cache/coursier
+
 jobs:
+
   checks:
     runs-on: ubuntu-latest
     container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk23"
@@ -41,10 +43,10 @@ jobs:
         shell: bash
         run: tools/ci/check-markdown.sh
 
-  linux:
+
+  build:
     runs-on: ubuntu-latest
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk23"
-    continue-on-error: true
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk11-with-ant-gcc"
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -73,6 +75,62 @@ jobs:
         shell: bash
         run: tools/ci/check-jmh.sh
 
+      - name: Upload the main JAR
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-jar
+          path: target/renaissance-*.jar
+          retention-days: 1
+
+      - name: Upload JMH JAR
+        uses: actions/upload-artifact@v4
+        with:
+          name: jmh-jar
+          path: renaissance-jmh/target/renaissance-*.jar
+          retention-days: 1
+
+
+  run-linux:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - openjdk11
+          - openjdk17
+          - openjdk21
+          - openjdk23
+          - openj9-openjdk11
+          - openj9-openjdk17
+          - openj9-openjdk21
+    runs-on: ubuntu-latest
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-${{ matrix.image }}"
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fix Git safe directory
+        shell: bash
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: Environment configuration
+        shell: bash
+        run: tools/ci/pre-show-env.sh
+
+      - name: Fetch pre-built main JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: main-jar
+          path: target
+
+      - name: Fetch pre-built JMH JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: jmh-jar
+          path: renaissance-jmh/target
+
       - name: Run the suite
         shell: bash
         run: tools/ci/bench-base.sh
@@ -85,9 +143,14 @@ jobs:
         shell: bash
         run: tools/ci/bench-jmh.sh
 
-  macos:
+
+  run-macos:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '11', '17', '21', '23' ]
     runs-on: macos-latest
-    continue-on-error: true
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -98,33 +161,27 @@ jobs:
         shell: bash
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      - name: Setup JDK 23
+      - name: Setup correct Java version
         uses: actions/setup-java@v4
         with:
-          java-version: 23
           distribution: temurin
+          java-version: ${{ matrix.java }}
 
       - name: Environment configuration
         shell: bash
         run: tools/ci/pre-show-env.sh
 
-      - name: Coursier downloads cache
-        uses: actions/cache@v4
+      - name: Fetch pre-built main JAR
+        uses: actions/download-artifact@v4
         with:
-          key: coursier_cache-${{ runner.os }}-${{ hashFiles('build.sbt') }}
-          path: ${{ env.COURSIER_CACHE }}
+          name: main-jar
+          path: target
 
-      - name: Build both base & JMH bundles
-        shell: bash
-        run: tools/ci/build-both.sh
-
-      - name: Check JMH bundle
-        shell: bash
-        run: tools/ci/check-jmh.sh
-
-      - name: Dummy run and environment configuration
-        shell: bash
-        run: tools/ci/bench-show-env.sh
+      - name: Fetch pre-built JMH JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: jmh-jar
+          path: renaissance-jmh/target
 
       - name: Run the suite
         shell: bash
@@ -138,9 +195,13 @@ jobs:
         shell: bash
         run: tools/ci/bench-jmh.sh
 
-  windows:
+  run-windows:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '11', '17', '21', '23' ]
     runs-on: windows-latest
-    continue-on-error: true
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -151,33 +212,27 @@ jobs:
         shell: bash
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      - name: Setup Java JDK 23
+      - name: Setup correct Java version
         uses: actions/setup-java@v4
         with:
-          java-version: 23
           distribution: temurin
+          java-version: ${{ matrix.java }}
 
       - name: Environment configuration
         shell: bash
         run: tools/ci/pre-show-env.sh
 
-      - name: Coursier downloads cache
-        uses: actions/cache@v4
+      - name: Fetch pre-built main JAR
+        uses: actions/download-artifact@v4
         with:
-          key: coursier_cache-${{ runner.os }}-${{ hashFiles('build.sbt') }}
-          path: ${{ env.COURSIER_CACHE }}
+          name: main-jar
+          path: target
 
-      - name: Build both base & JMH bundles
-        shell: bash
-        run: tools/ci/build-both.sh
-
-      - name: Check JMH bundle
-        shell: bash
-        run: tools/ci/check-jmh.sh
-
-      - name: Dummy run and environment configuration
-        shell: bash
-        run: tools/ci/bench-show-env.sh
+      - name: Fetch pre-built JMH JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: jmh-jar
+          path: renaissance-jmh/target
 
       - name: Run the suite
         shell: bash
@@ -193,7 +248,7 @@ jobs:
 
   plugins:
     runs-on: ubuntu-latest
-    needs: linux
+    needs: build
     container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk11-with-ant-gcc"
     steps:
       - name: Git checkout
@@ -226,172 +281,3 @@ jobs:
       - name: Run the suite with all plugins
         shell: bash
         run: tools/ci/bench-plugins.sh
-
-  linux-jdks:
-    needs: linux
-    strategy:
-      matrix:
-        image:
-          - openjdk11
-          - openjdk17
-          - openjdk21
-          - openj9-openjdk11
-          - openj9-openjdk17
-          - openj9-openjdk21
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-${{ matrix.image }}"
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Fix Git safe directory
-        shell: bash
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
-
-      - name: Environment configuration
-        shell: bash
-        run: tools/ci/pre-show-env.sh
-
-      - name: Coursier downloads cache
-        uses: actions/cache@v4
-        with:
-          key: coursier_cache-${{ runner.os }}-${{ hashFiles('build.sbt') }}
-          path: ${{ env.COURSIER_CACHE }}
-
-      - name: Build base & JMH bundles
-        shell: bash
-        run: tools/ci/build-both.sh
-
-      - name: Check JMH bundle
-        shell: bash
-        run: tools/ci/check-jmh.sh
-
-      - name: Run the suite
-        shell: bash
-        run: tools/ci/bench-base.sh
-
-      - name: Run the suite in standalone mode
-        shell: bash
-        run: tools/ci/bench-standalone.sh
-
-      - name: Run the suite with JMH
-        shell: bash
-        run: tools/ci/bench-jmh.sh
-
-
-  windows-legacy:
-    needs: windows
-    strategy:
-      matrix:
-        java: [ '11', '17', '21' ]
-    runs-on: windows-latest
-    continue-on-error: true
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Fix Git safe directory
-        shell: bash
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
-
-      - name: Setup correct Java version
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java }}
-
-      - name: Environment configuration
-        shell: bash
-        run: tools/ci/pre-show-env.sh
-
-      - name: Coursier downloads cache
-        uses: actions/cache@v4
-        with:
-          key: coursier_cache-${{ runner.os }}-${{ hashFiles('build.sbt') }}
-          path: ${{ env.COURSIER_CACHE }}
-
-      - name: Build both base & JMH bundles
-        shell: bash
-        run: tools/ci/build-both.sh
-
-      - name: Check JMH bundle
-        shell: bash
-        run: tools/ci/check-jmh.sh
-
-      - name: Dummy run and environment configuration
-        shell: bash
-        run: tools/ci/bench-show-env.sh
-
-      - name: Run the suite
-        shell: bash
-        run: tools/ci/bench-base.sh
-
-      - name: Run the suite in standalone mode
-        shell: bash
-        run: tools/ci/bench-standalone.sh
-
-      - name: Run the suite with JMH
-        shell: bash
-        run: tools/ci/bench-jmh.sh
-
-  macos-legacy:
-    needs: macos
-    strategy:
-      matrix:
-        java: [ '11', '17', '21' ]
-    runs-on: macos-latest
-    continue-on-error: true
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Fix Git safe directory
-        shell: bash
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
-
-      - name: Setup correct Java version
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java }}
-
-      - name: Environment configuration
-        shell: bash
-        run: tools/ci/pre-show-env.sh
-
-      - name: Coursier downloads cache
-        uses: actions/cache@v4
-        with:
-          key: coursier_cache-${{ runner.os }}-${{ hashFiles('build.sbt') }}
-          path: ${{ env.COURSIER_CACHE }}
-
-      - name: Build both base & JMH bundles
-        shell: bash
-        run: tools/ci/build-both.sh
-
-      - name: Check JMH bundle
-        shell: bash
-        run: tools/ci/check-jmh.sh
-
-      - name: Dummy run and environment configuration
-        shell: bash
-        run: tools/ci/bench-show-env.sh
-
-      - name: Run the suite
-        shell: bash
-        run: tools/ci/bench-base.sh
-
-      - name: Run the suite in standalone mode
-        shell: bash
-        run: tools/ci/bench-standalone.sh
-
-      - name: Run the suite with JMH
-        shell: bash
-        run: tools/ci/bench-jmh.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,68 +93,56 @@ jobs:
           path: renaissance-jmh/target/renaissance-*.jar
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
-
-  run-linux:
+  run:
     needs: build
     strategy:
       fail-fast: false
+
       matrix:
-        image:
-          - openjdk11
-          - openjdk17
-          - openjdk21
-          - openjdk23
-          - openj9-openjdk11
-          - openj9-openjdk17
-          - openj9-openjdk21
-    runs-on: ubuntu-latest
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-${{ matrix.image }}"
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        include:
+          - os: linux
+            image: openjdk11
+          - os: linux
+            image: openjdk17
+          - os: linux
+            image: openjdk21
+          - os: linux
+            image: openjdk23
+          - os: linux
+            image: openj9-openjdk11
+          - os: linux
+            image: openj9-openjdk17
+          - os: linux
+            image: openj9-openjdk21
 
-      - name: Fix Git safe directory
-        shell: bash
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+          - os: windows
+            image: null
+            java: 11
+          - os: windows
+            image: null
+            java: 17
+          - os: windows
+            image: null
+            java: 21
+          - os: windows
+            image: null
+            java: 23
 
-      - name: Environment configuration
-        shell: bash
-        run: tools/ci/pre-show-env.sh
+          - os: macos
+            image: null
+            java: 11
+          - os: macos
+            image: null
+            java: 17
+          - os: macos
+            image: null
+            java: 21
+          - os: macos
+            image: null
+            java: 23
 
-      - name: Fetch pre-built main JAR
-        uses: actions/download-artifact@v4
-        with:
-          name: main-jar
-          path: target
-
-      - name: Fetch pre-built JMH JAR
-        uses: actions/download-artifact@v4
-        with:
-          name: jmh-jar
-          path: renaissance-jmh/target
-
-      - name: Run the suite
-        shell: bash
-        run: tools/ci/bench-base.sh
-
-      - name: Run the suite in standalone mode
-        shell: bash
-        run: tools/ci/bench-standalone.sh
-
-      - name: Run the suite with JMH
-        shell: bash
-        run: tools/ci/bench-jmh.sh
-
-
-  run-macos:
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [ '11', '17', '21', '23' ]
-    runs-on: macos-latest
+    runs-on: ${{ (matrix.os == 'linux') && 'ubuntu' || matrix.os }}-latest
+    container: ${{ (matrix.os == 'linux') && format('ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-{0}', matrix.image) || null }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -170,6 +158,7 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
+        if: ${{ matrix.os != 'linux' }}
 
       - name: Environment configuration
         shell: bash
@@ -199,56 +188,6 @@ jobs:
         shell: bash
         run: tools/ci/bench-jmh.sh
 
-  run-windows:
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [ '11', '17', '21', '23' ]
-    runs-on: windows-latest
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Fix Git safe directory
-        shell: bash
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
-
-      - name: Setup correct Java version
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java }}
-
-      - name: Environment configuration
-        shell: bash
-        run: tools/ci/pre-show-env.sh
-
-      - name: Fetch pre-built main JAR
-        uses: actions/download-artifact@v4
-        with:
-          name: main-jar
-          path: target
-
-      - name: Fetch pre-built JMH JAR
-        uses: actions/download-artifact@v4
-        with:
-          name: jmh-jar
-          path: renaissance-jmh/target
-
-      - name: Run the suite
-        shell: bash
-        run: tools/ci/bench-base.sh
-
-      - name: Run the suite in standalone mode
-        shell: bash
-        run: tools/ci/bench-standalone.sh
-
-      - name: Run the suite with JMH
-        shell: bash
-        run: tools/ci/bench-jmh.sh
 
   plugins:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk23"
+    # We rarely build for more than 3 minutes
+    timeout-minutes: 10
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -51,6 +53,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk11-with-ant-gcc"
+    # We rarely build for more than 3 minutes
+    timeout-minutes: 10
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -143,6 +147,10 @@ jobs:
 
     runs-on: ${{ (matrix.os == 'linux') && 'ubuntu' || matrix.os }}-latest
     container: ${{ (matrix.os == 'linux') && format('ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-{0}', matrix.image) || null }}
+
+    # We rarely run over 17 minutes but a runaway JMH can loop forever.
+    timeout-minutes: 30
+
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -193,6 +201,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk11-with-ant-gcc"
+    # We rarely run over 10 minutes anyway.
+    timeout-minutes: 30
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,29 +140,21 @@ jobs:
             image: openj9-openjdk21
 
           - os: windows
-            image: null
             java: 11
           - os: windows
-            image: null
             java: 17
           - os: windows
-            image: null
             java: 21
           - os: windows
-            image: null
             java: 23
 
           - os: macos
-            image: null
             java: 11
           - os: macos
-            image: null
             java: 17
           - os: macos
-            image: null
             java: 21
           - os: macos
-            image: null
             java: 23
 
     # The following two lines are a bit of a hack:


### PR DESCRIPTION
Trying how the build times would be changed if we would built Renaissance just once and then pass the pre-built JAR across multiple jobs running it.