### PR TITLE
Use Spark to load CSV files and avoid extra IO

### DIFF
--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ResourceUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ResourceUtil.scala
@@ -6,33 +6,12 @@ import java.net.URL
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.{StandardCopyOption => CopyOption}
 import java.nio.file.{StandardOpenOption => OpenOption}
 import java.util.zip.ZipInputStream
 import scala.io.BufferedSource
 import scala.io.Source
 
 private object ResourceUtil {
-
-  /**
-   * Writes the resource associated with the [[ResourceUtil]] class
-   * to a file, replacing an existing file.
-   *
-   * @param resourceName path to the resource
-   * @param file path the output file
-   * @return [[Path]] to the output file
-   */
-  def writeResourceToFile(resourceName: String, file: Path) = {
-    val resourceStream = getResourceStream(resourceName)
-    try {
-      Files.copy(resourceStream, file, CopyOption.REPLACE_EXISTING)
-    } finally {
-      // This may mask a try-block exception, but at least it will fail anyway.
-      resourceStream.close()
-    }
-
-    file
-  }
 
   /**
    * Writes the resource associated with the [[ResourceUtil]] class

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ResourceUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/ResourceUtil.scala
@@ -73,7 +73,7 @@ private object ResourceUtil {
   def duplicateLinesFromUrl(url: URL, copyCount: Int, outputFile: Path): Path = {
     import scala.jdk.CollectionConverters._
 
-    val lines = linesFromUrl(url).asJava
+    val lines = linesFromSource(Source.fromURL(url)).asJava
 
     for (_ <- 0 until copyCount) {
       Files.write(outputFile, lines, OpenOption.CREATE, OpenOption.APPEND)
@@ -83,18 +83,28 @@ private object ResourceUtil {
   }
 
   /**
-   * Loads a file from the given [[URL]] as a sequence of lines.
+   * Loads the contents of a [[Source]] as a sequence of lines and closes the source.
    *
-   * @param url input file [[URL]]
+   * @param source input [[Source]]
    * @return a sequence of lines
    */
-  def linesFromUrl(url: URL): Seq[String] = {
-    val source = Source.fromURL(url)
+  def linesFromSource(source: Source): Seq[String] = {
     try {
       source.getLines().toSeq
     } finally {
       source.close()
     }
+  }
+
+  /**
+   * Creates a [[Source]] from a resource associated with the [[ResourceUtil]] class.
+   *
+   * @param resourceName path to the resource
+   * @return a [[Source]] for the given resource
+   */
+  def sourceFromResource(resourceName: String): BufferedSource = {
+    // Use an explicit codec to avoid influence of the environment.
+    Source.fromURL(getClass.getResource(resourceName))(scala.io.Codec.UTF8)
   }
 
   /**

--- a/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
+++ b/benchmarks/apache-spark/src/main/scala/org/renaissance/apache/spark/SparkUtil.scala
@@ -90,21 +90,6 @@ trait SparkUtil {
     )
   }
 
-  def createRddFromCsv[T: ClassTag](
-    lines: RDD[String],
-    hasHeader: Boolean,
-    delimiter: String,
-    mapper: Array[String] => T
-  ) = {
-    val linesWithoutHeader = if (hasHeader) dropFirstLine(lines) else lines
-    linesWithoutHeader.map(_.split(delimiter)).map(mapper).filter(_ != null)
-  }
-
-  private def dropFirstLine(lines: RDD[String]): RDD[String] = {
-    val first = lines.first()
-    lines.filter { line => line != first }
-  }
-
   def tearDownSparkContext(): Unit = {
     sparkSession.close()
   }


### PR DESCRIPTION
Use the Spark DataFrameReader to load the CSV files with movies and ratings to correctly load CSV files with quoted values. Specifically, `movies.csv` was loaded "by hand"  with splitting on coma, resulting in some movie titles being cut off and part of the movie title ending up in the "genres" field, but no harm was done, because the genres are not being used by the benchmark. Anyway, it also avoids the extra IO of copying the resource files to the scratch directory.

Given the above changes, the data initialization was made more localized to avoid keeping data that are not needed for benchmark execution after the initial setup.

Because the data are loaded using the `DataFrameReader` from Spark Session instead of the `textfile()` function from Spark Context (which uses `hadoopFile()` underneath), they are partitioned differently (there are more partitions), which seems to affect performance. To mimic the original behavior, we initially repartition the data using the same defaults as in `textfile()`.