### PR TITLE
Update benchmark dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The following is the complete list of benchmarks, separated into groups.
 
 - `db-shootout` - Executes a shootout test using several in-memory databases.
   \
-  Default repetitions: 16; APACHE2 license, MIT distribution; Supported JVM: 11 - 18
+  Default repetitions: 16; APACHE2 license, MIT distribution; Supported JVM: 11 - 22
 
 - `neo4j-analytics` - Executes Neo4j graph queries against a movie database.
   \

--- a/benchmarks/database/src/main/resources/simplelogger.properties
+++ b/benchmarks/database/src/main/resources/simplelogger.properties
@@ -1,1 +1,3 @@
 org.slf4j.simpleLogger.defaultLogLevel=warn
+# Silence warnings related to CPU cores with different number of hardware threads.
+org.slf4j.simpleLogger.log.net.openhft.affinity.impl.VanillaCpuLayout=error

--- a/benchmarks/database/src/main/scala/org/renaissance/database/DbShootout.scala
+++ b/benchmarks/database/src/main/scala/org/renaissance/database/DbShootout.scala
@@ -14,7 +14,7 @@ import org.renaissance.License
 @Group("database")
 @Summary("Executes a shootout test using several in-memory databases.")
 @Licenses(Array(License.APACHE2))
-@SupportsJvm("18")
+@SupportsJvm("22") // Works on Java 24 in standalone mode.
 @Repetitions(16)
 @Parameter(name = "rw_entry_count", defaultValue = "500000")
 @Configuration(name = "test", settings = Array("rw_entry_count = 10000"))

--- a/benchmarks/scala-dotty/src/main/scala/org/renaissance/scala/dotty/Dotty.scala
+++ b/benchmarks/scala-dotty/src/main/scala/org/renaissance/scala/dotty/Dotty.scala
@@ -51,7 +51,7 @@ final class Dotty extends Benchmark {
    *
    * find . -type f -name '*.tasty'|egrep -v '(Classfile|ByteCode)\.tasty' | LC_ALL=C sort|xargs cat|md5sum
    */
-  private val expectedTastyHash: String = "cda4bf9f729d30c97ec7b793c54039d1"
+  private val expectedTastyHash: String = "5c33664eacffb74f853dec92efd9d503"
 
   private val excludedTastyFiles = Seq("Classfile.tasty", "ByteCode.tasty")
 

--- a/build.sbt
+++ b/build.sbt
@@ -243,6 +243,10 @@ lazy val actorsAkkaBenchmarks = (project in file("benchmarks/actors-akka"))
       // akka-actor 2.6.17+ supports Scala 2.12, 2.13, and 3 under Apache 2.0 license
       // akka-actor 2.7.0+ supports Scala 2.12, 2.13, and 3 under Business Source 1.1 license
       "com.typesafe.akka" %% "akka-actor" % "2.6.21"
+    ),
+    excludeDependencies ++= Seq(
+      // Drop dependencies that are not needed for running on Java 11+.
+      ExclusionRule("org.scala-lang.modules", "scala-java8-compat_3")
     )
   )
   .dependsOn(renaissanceCore % "provided")

--- a/build.sbt
+++ b/build.sbt
@@ -258,7 +258,7 @@ lazy val actorsReactorsBenchmarks = (project in file("benchmarks/actors-reactors
     ProjectRef(uri("benchmarks/actors-reactors/reactors"), "reactorsCoreJVM")
   )
 
-val sparkVersion = "3.5.0"
+val sparkVersion = "3.5.3"
 
 lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -339,10 +339,10 @@ lazy val jdkConcurrentBenchmarks = (project in file("benchmarks/jdk-concurrent")
     name := "jdk-concurrent",
     commonSettingsScala3,
     libraryDependencies ++= Seq(
-      // Jenetics 5.2.0 is the last to support Java 8.
-      // Jenetics 6.0.0 requires Java 11 and benchmark update.
+      // Jenetics 6.3.0 is the last to support Java 11.
       // Jenetics 7.0.0 requires Java 17 and benchmark update.
-      "io.jenetics" % "jenetics" % "5.2.0"
+      // Jenetics 8.0.0 requires Java 21 and benchmark update.
+      "io.jenetics" % "jenetics" % "6.3.0"
     )
   )
   .dependsOn(renaissanceCore % "provided")

--- a/build.sbt
+++ b/build.sbt
@@ -465,7 +465,7 @@ lazy val scalaStmBenchmarks = (project in file("benchmarks/scala-stm"))
     RootProject(uri("benchmarks/scala-stm/stmbench7"))
   )
 
-val finagleVersion = "22.12.0"
+val finagleVersion = "24.2.0"
 
 lazy val twitterFinagleBenchmarks = (project in file("benchmarks/twitter-finagle"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -160,8 +160,11 @@ val generateManifestAttributesTask = Def.task {
 // Subprojects
 //
 
+val arrowVersion = "18.0.0"
 // ASM 9.7+ requires Java 11.
 val asmVersion = "9.7.1"
+// Caffeine 3.0+ requires Java 11.
+val caffeineVersion = "3.1.8"
 val commonsCompressVersion = "1.27.1"
 val commonsIoVersion = "2.17.0"
 val commonsLang3Version = "3.17.0"
@@ -170,11 +173,15 @@ val commonsTextVersion = "1.12.0"
 val eclipseCollectionsVersion = "11.1.0"
 val guavaVersion = "33.3.1-jre"
 val jacksonVersion = "2.18.1"
+val jakartaXmlBindVersion = "2.3.3"
 val jerseyVersion = "2.45"
 val jnaVersion = "5.15.0"
+val nettyTomcatNativeVersion = "2.0.69.Final"
 val nettyVersion = "4.1.114.Final"
+val parquetVersion = "1.14.3"
 val scalaCollectionCompatVersion = "2.12.0"
 val scalaParallelCollectionsVersion = "1.0.4"
+val scalaParserCombinatorsVersion = "2.4.0"
 val slf4jVersion = "2.0.16"
 val zstdJniVersion = "1.5.6-7"
 
@@ -293,6 +300,11 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
       // Force common (newer) version of Jackson packages.
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
+      // Force common (newer) version of Arrow packages.
+      "org.apache.arrow" % "arrow-vector" % arrowVersion,
+      "org.apache.arrow" % "arrow-memory-netty" % arrowVersion,
+      // Force common (newer) version of Parquet packages.
+      "org.apache.parquet" % "parquet-hadoop" % parquetVersion,
       // Force common (newer) version of Jersey packages.
       "org.glassfish.jersey.containers" % "jersey-container-servlet" % jerseyVersion,
       "org.glassfish.jersey.core" % "jersey-server" % jerseyVersion,
@@ -301,12 +313,14 @@ lazy val apacheSparkBenchmarks = (project in file("benchmarks/apache-spark"))
       "com.github.luben" % "zstd-jni" % zstdJniVersion,
       "com.google.guava" % "guava" % guavaVersion,
       "commons-io" % "commons-io" % commonsIoVersion,
+      "jakarta.xml.bind" % "jakarta.xml.bind-api" % jakartaXmlBindVersion,
       "org.apache.commons" % "commons-compress" % commonsCompressVersion,
       "org.apache.commons" % "commons-lang3" % commonsLang3Version,
       "org.apache.commons" % "commons-math3" % commonsMath3Version,
       "org.apache.commons" % "commons-text" % commonsTextVersion,
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.scala-lang.modules" %% "scala-parallel-collections" % scalaParallelCollectionsVersion,
+      "org.scala-lang.modules" %% "scala-parser-combinators" % scalaParserCombinatorsVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "jcl-over-slf4j" % slf4jVersion,
       "org.slf4j" % "jul-to-slf4j" % slf4jVersion
@@ -410,6 +424,10 @@ lazy val neo4jBenchmarks = (project in file("benchmarks/neo4j"))
       "io.netty" % "netty-tcnative-classes" % nettyTomcatNativeVersion,
       // Force common (newer) version of Eclipse collection packages.
       "org.eclipse.collections" % "eclipse-collections" % eclipseCollectionsVersion,
+      // Force common (newer) version of Arrow packages.
+      "org.apache.arrow" % "flight-core" % arrowVersion,
+      // Force common (newer) version of Parquet packages.
+      "org.apache.parquet" % "parquet-hadoop" % parquetVersion,
       // Force common (newer) version of Jersey packages.
       "org.glassfish.jersey.containers" % "jersey-container-servlet" % jerseyVersion,
       "org.glassfish.jersey.core" % "jersey-server" % jerseyVersion,
@@ -417,8 +435,10 @@ lazy val neo4jBenchmarks = (project in file("benchmarks/neo4j"))
       // Force common (newer) version of ASM packages.
       "org.ow2.asm" % "asm-util" % asmVersion,
       // Force common versions of other dependencies.
+      "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion,
       "com.github.luben" % "zstd-jni" % zstdJniVersion,
       "commons-io" % "commons-io" % commonsIoVersion,
+      "jakarta.xml.bind" % "jakarta.xml.bind-api" % jakartaXmlBindVersion,
       "org.apache.commons" % "commons-lang3" % commonsLang3Version,
       "org.apache.commons" % "commons-compress" % commonsCompressVersion,
       "org.apache.commons" % "commons-text" % commonsTextVersion,
@@ -523,8 +543,10 @@ lazy val twitterFinagleBenchmarks = (project in file("benchmarks/twitter-finagle
       // Force common (newer) version of Jackson packages.
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
       // Force common versions of other dependencies.
+      "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion,
       "com.github.luben" % "zstd-jni" % zstdJniVersion,
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion
+      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+      "org.scala-lang.modules" %% "scala-parser-combinators" % scalaParserCombinatorsVersion
     )
   )
   .dependsOn(renaissanceCore % "provided")

--- a/build.sbt
+++ b/build.sbt
@@ -160,22 +160,23 @@ val generateManifestAttributesTask = Def.task {
 // Subprojects
 //
 
-val asmVersion = "9.6"
-val commonsCompressVersion = "1.24.0"
-val commonsIoVersion = "2.14.0"
-val commonsLang3Version = "3.13.0"
+// ASM 9.7+ requires Java 11.
+val asmVersion = "9.7.1"
+val commonsCompressVersion = "1.27.1"
+val commonsIoVersion = "2.17.0"
+val commonsLang3Version = "3.17.0"
 val commonsMath3Version = "3.6.1"
-val commonsTextVersion = "1.10.0"
+val commonsTextVersion = "1.12.0"
 val eclipseCollectionsVersion = "11.1.0"
-val guavaVersion = "32.1.2-jre"
-val jacksonVersion = "2.15.2"
-val jerseyVersion = "2.40"
-val jnaVersion = "5.13.0"
-val nettyVersion = "4.1.99.Final"
-val scalaCollectionCompatVersion = "2.11.0"
+val guavaVersion = "33.3.1-jre"
+val jacksonVersion = "2.18.1"
+val jerseyVersion = "2.45"
+val jnaVersion = "5.15.0"
+val nettyVersion = "4.1.114.Final"
+val scalaCollectionCompatVersion = "2.12.0"
 val scalaParallelCollectionsVersion = "1.0.4"
-val slf4jVersion = "2.0.9"
-val zstdJniVersion = "1.5.5-6"
+val slf4jVersion = "2.0.16"
+val zstdJniVersion = "1.5.6-7"
 
 lazy val renaissanceCore = (project in file("renaissance-core"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -354,6 +354,8 @@ lazy val jdkStreamsBenchmarks = (project in file("benchmarks/jdk-streams"))
   )
   .dependsOn(renaissanceCore % "provided")
 
+val grpcVersion = "1.68.1"
+
 lazy val neo4jBenchmarks = (project in file("benchmarks/neo4j"))
   .settings(
     name := "neo4j",
@@ -361,9 +363,9 @@ lazy val neo4jBenchmarks = (project in file("benchmarks/neo4j"))
     libraryDependencies ++= Seq(
       // neo4j 4.4 supports Scala 2.12 and requires JDK11.
       // neo4j 5.x supports Scala 2.13 and requires JDK17.
-      "org.neo4j" % "neo4j" % "5.12.0",
+      "org.neo4j" % "neo4j" % "5.25.1",
       // play-json 2.10.x requires SBT running on JDK11 to compile.
-      "com.typesafe.play" %% "play-json" % "2.10.1"
+      "com.typesafe.play" %% "play-json" % "2.10.6"
     ),
     excludeDependencies ++= Seq(
       // Drop dependencies that are not really used by the benchmark.
@@ -372,12 +374,19 @@ lazy val neo4jBenchmarks = (project in file("benchmarks/neo4j"))
     dependencyOverrides ++= Seq(
       // Force common (newer) version of Jackson packages.
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
+      "com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-json-provider" % jacksonVersion,
       // Force newer JNA to support more platforms/architectures.
       "net.java.dev.jna" % "jna" % jnaVersion,
+      // Force newer version of gRPC packages.
+      "io.grpc" % "grpc-netty" % grpcVersion,
+      "io.grpc" % "grpc-protobuf" % grpcVersion,
+      "io.grpc" % "grpc-stub" % grpcVersion,
       // Force common (newer) version of Netty packages.
-      "io.netty" % "netty-codec-http" % nettyVersion,
+      "io.netty" % "netty-codec-http2" % nettyVersion,
+      "io.netty" % "netty-handler-proxy" % nettyVersion,
       "io.netty" % "netty-transport-native-epoll" % nettyVersion,
       "io.netty" % "netty-transport-native-kqueue" % nettyVersion,
+      "io.netty" % "netty-tcnative-classes" % nettyTomcatNativeVersion,
       // Force common (newer) version of Eclipse collection packages.
       "org.eclipse.collections" % "eclipse-collections" % eclipseCollectionsVersion,
       // Force common (newer) version of Jersey packages.
@@ -488,6 +497,7 @@ lazy val twitterFinagleBenchmarks = (project in file("benchmarks/twitter-finagle
       "io.netty" % "netty-handler-proxy" % nettyVersion,
       "io.netty" % "netty-resolver-dns" % nettyVersion,
       "io.netty" % "netty-transport-native-epoll" % nettyVersion,
+      "io.netty" % "netty-tcnative-boringssl-static" % nettyTomcatNativeVersion,
       // Force common (newer) version of Jackson packages.
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
       // Force common versions of other dependencies.

--- a/build.sbt
+++ b/build.sbt
@@ -411,7 +411,7 @@ lazy val rxBenchmarks = (project in file("benchmarks/rx"))
     name := "rx",
     commonSettingsScala3,
     libraryDependencies ++= Seq(
-      "io.reactivex.rxjava3" % "rxjava" % "3.1.8"
+      "io.reactivex.rxjava3" % "rxjava" % "3.1.9"
     )
   )
   .dependsOn(renaissanceCore % "provided")

--- a/build.sbt
+++ b/build.sbt
@@ -428,12 +428,13 @@ lazy val scalaDottyBenchmarks = (project in file("benchmarks/scala-dotty"))
       // Version 3.1.2 was the last to compile with Scala 2.13.11. Version 3.1.3-RC2
       // broke compilation due to "Unsupported Scala 3 union in parameter value".
       // Compiling with Scala 3.1.0+ avoids compatibility issues.
-      "org.scala-lang" % "scala3-compiler_3" % "3.3.1",
+      "org.scala-lang" % "scala3-compiler_3" % "3.3.4",
       // The following is required to compile the workload sources. Keep it last!
       "org.scala-lang" % "scala-compiler" % scalaVersion213 % Runtime
     ),
     excludeDependencies ++= Seq(
       // Drop dependencies that are not really used by the benchmark.
+      ExclusionRule("net.java.dev.jna", "jna"),
       ExclusionRule("org.jline", "jline"),
       ExclusionRule("org.jline", "jline-reader"),
       ExclusionRule("org.jline", "jline-terminal"),

--- a/build.sbt
+++ b/build.sbt
@@ -57,9 +57,9 @@ ThisBuild / git.useGitDescribe := true
 // Compilation settings
 //
 val javaRelease = "11"
-val scalaVersion212 = "2.12.18"
-val scalaVersion213 = "2.13.12"
-val scalaVersion3 = "3.3.1"
+val scalaVersion212 = "2.12.20"
+val scalaVersion213 = "2.13.15"
+val scalaVersion3 = "3.3.4"
 
 // Explicitly target a specific JDK release.
 ThisBuild / javacOptions ++= Seq("--release", javaRelease)

--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,10 @@ val generateManifestAttributesTask = Def.task {
     "java.base/sun.nio.ch",
     "java.management/sun.management",
     "java.management/sun.management.counter",
-    "java.management/sun.management.counter.perf"
+    "java.management/sun.management.counter.perf",
+    // Required by Chronicle Map.
+    "java.base/jdk.internal.ref",
+    "jdk.compiler/com.sun.tools.javac.file"
   )
 
   Package.ManifestAttributes(
@@ -147,7 +150,9 @@ val generateManifestAttributesTask = Def.task {
     ("Git-Head-Commit", git.gitHeadCommit.value.getOrElse("unknown")),
     ("Git-Head-Commit-Date", git.gitHeadCommitDate.value.getOrElse("unknown")),
     ("Git-Uncommitted-Changes", git.gitUncommittedChanges.value.toString),
-    ("Add-Opens", addOpensPackages.mkString(" "))
+    ("Add-Opens", addOpensPackages.mkString(" ")),
+    // Required by "org.lz4" % "lz4-java".
+    ("Enable-Native-Access", "ALL-UNNAMED")
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -313,17 +313,24 @@ lazy val databaseBenchmarks = (project in file("benchmarks/database"))
     name := "database",
     commonSettingsScala3,
     libraryDependencies ++= Seq(
-      "com.github.jnr" % "jnr-posix" % "3.1.18",
+      "com.github.jnr" % "jnr-posix" % "3.1.20",
       "org.apache.commons" % "commons-math3" % commonsMath3Version,
-      "org.agrona" % "agrona" % "1.19.2",
+      // Agrona 1.23+ requires Java 17.
+      "org.agrona" % "agrona" % "1.22.0",
       // Database libraries.
-      "org.mapdb" % "mapdb" % "3.0.10",
-      "com.h2database" % "h2-mvstore" % "2.2.224",
-      "net.openhft" % "chronicle-map" % "3.22.9",
+      "org.mapdb" % "mapdb" % "3.1.0",
+      "com.h2database" % "h2-mvstore" % "2.3.232",
+      // Chronicle Map 3.25+ supports Java 21.
+      "net.openhft" % "chronicle-map" % "3.26ea4",
       // Add simple binding to silence SLF4J warnings.
-      "org.slf4j" % "slf4j-simple" % slf4jVersion
+      "org.slf4j" % "slf4j-simple" % slf4jVersion,
+      // Replacement for excluded "net.jpountz.lz4" % "lz4".
+      "org.lz4" % "lz4-java" % "1.8.0"
     ),
     dependencyOverrides ++= Seq(
+      // Force newer version of Chronicle modules.
+      "net.openhft" % "chronicle-wire" % "2.26ea10",
+      "net.openhft" % "posix" % "2.26ea3",
       // Force newer JNA to support more platforms/architectures.
       "net.java.dev.jna" % "jna-platform" % jnaVersion,
       // Force common (newer) version of ASM packages.
@@ -334,6 +341,10 @@ lazy val databaseBenchmarks = (project in file("benchmarks/database"))
       // Force common versions of other dependencies.
       "com.google.guava" % "guava" % guavaVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion
+    ),
+    excludeDependencies ++= Seq(
+      // Replaced by the "org.lz4" % "lz4-java".
+      ExclusionRule("net.jpountz.lz4", "lz4")
     )
   )
   .dependsOn(renaissanceCore % "provided")

--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -58,7 +58,9 @@ get_jvm_workaround_args() {
             echo "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
             echo "--add-opens=java.base/java.util=ALL-UNNAMED"
             echo "--add-opens=java.base/java.nio=ALL-UNNAMED"
+            echo "--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED"
             echo "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+            echo "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED"
             ;;
         *)
             ;;


### PR DESCRIPTION
Updates Scala, primary benchmark dependencies and a number of secondary dependencies. Partially builds on top of #443 (which it supersedes) and goes a bit further where possible. The `db-shootout` benchmark is now compatible with JDK upto 22 (interestingly, in standalone mode, it can actually run even on Java 24). This should bring us close to release.

Scala updates
- Scala 2.12 updated to `2.12.20`
- Scala 2.13 updated to `2.13.15`
- Scala 3 updated to `3.3.4`

Updates in `apache-spark`
- Spark updated from `3.5.0` to `3.5.3`
- Secondary dependencies
    - Arrow updated to `18.0.0`
    - Parquet updated to `1.14.3`
    - Netty updated to `4.1.114.Final`
    - Guava updated to `33.3.1-jre`

Updates in `db-shootout`
- `agrona` updated from `1.19.2` to `1.22.0` (later versions require Java 17)
- `mapdb` updated from `3.0.10` to `3.1.0`
- `h2-mvstore` updated from `2.2.224` to `2.3.232`
- `chronicle-map` updated from `3.22.9` to `3.26ea4` (supports Java 21+)
- Secondary dependencies
    - ASM updated to `9.7.1` (requires Java 11+)
    - `lz4` version `1.3.0` replaced with `lz4-java` version `1.8.0`
    - Guava updated to `33.3.1-jre`
    - JNA updated to `5.15.0`

Updates in `future-genetic`
- Jenetics updated from `5.2.0` to `6.3.0` (requires Java 11+)

Updates in `neo4j-analytics`
- `neo4j` updated from `5.12.0` to `5.25.1`
- Secondary dependencies
    - Arrow updated to `18.0.0`
    - ASM updated to `9.7.1` (requires Java 11+)
    - Caffeine updated to `3.1.8` (requires Java 11+)
    - gRPC updated to `1.68.1` (secondary)
    - JNA updated to `5.15.0`
    - Netty updated to `4.1.114.Final`
    - Netty Tomcat Native updated to `2.0.69.Final`
    - Parquet updated to `1.14.3`

Updates in `rx`
- `rxjava` updated from `3.1.8` to `3.1.9`

Updates in `scala-dotty`
- `scala3-compiler` updated from `3.3.1` to `3.3.4`

Updates in `twitter-finagle`
- Finagle updated from `22.12.0` to `24.2.0`
- Secondary dependencies
    - Caffeine updated to `3.1.8` (requires Java 11+)
    - Netty updated to `4.1.114.Final`