### PR TITLE
Set 'java.class.path' temporarily during Chronicle intialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The following is the complete list of benchmarks, separated into groups.
 
 - `db-shootout` - Executes a shootout test using several in-memory databases.
   \
-  Default repetitions: 16; APACHE2 license, MIT distribution; Supported JVM: 11 - 22
+  Default repetitions: 16; APACHE2 license, MIT distribution; Supported JVM: 11 and later
 
 - `neo4j-analytics` - Executes Neo4j graph queries against a movie database.
   \

--- a/benchmarks/database/src/main/scala/org/renaissance/database/DbShootout.scala
+++ b/benchmarks/database/src/main/scala/org/renaissance/database/DbShootout.scala
@@ -21,7 +21,6 @@ import scala.collection.Seq
 @Group("database")
 @Summary("Executes a shootout test using several in-memory databases.")
 @Licenses(Array(License.APACHE2))
-@SupportsJvm("22") // Works on Java 24 in standalone mode.
 @Repetitions(16)
 @Parameter(name = "rw_entry_count", defaultValue = "500000")
 @Configuration(name = "test", settings = Array("rw_entry_count = 10000"))

--- a/benchmarks/database/src/main/scala/org/renaissance/database/DbShootout.scala
+++ b/benchmarks/database/src/main/scala/org/renaissance/database/DbShootout.scala
@@ -10,6 +10,13 @@ import org.renaissance.BenchmarkResult
 import org.renaissance.BenchmarkResult.Validators
 import org.renaissance.License
 
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import scala.collection.Seq
+
 @Name("db-shootout")
 @Group("database")
 @Summary("Executes a shootout test using several in-memory databases.")
@@ -49,6 +56,21 @@ final class DbShootout extends Benchmark {
 
   var mvStoreWriter: MvStore.Writer = _
 
+  private def buildChronicleClassPath(classPath: String): Seq[Path] = {
+    val elements = classPath.split(File.pathSeparatorChar).map(Paths.get(_)).toSeq
+    Thread.currentThread.getContextClassLoader match {
+      case ucl: URLClassLoader =>
+        ucl.getURLs.map(url => Paths.get(url.toURI)).filter { path =>
+          val fn = path.getFileName.toString
+          fn.startsWith("chronicle-core") || fn.startsWith("chronicle-bytes")
+        }
+      case _ =>
+        // Fall back to current class path.
+        // This should be the case in standalone mode.
+        elements
+    }
+  }
+
   override def setUpBeforeAll(c: BenchmarkContext): Unit = {
     val tempDirPath = c.scratchDirectory()
     val readWriteEntryCountParam = c.parameter("rw_entry_count").toPositiveInteger
@@ -59,11 +81,23 @@ final class DbShootout extends Benchmark {
     mapDbReader.setup(tempDirPath.toFile, readWriteEntryCountParam)
     mapDbWriter.setup(tempDirPath.toFile, readWriteEntryCountParam)
 
+    //
+    // Chronicle needs the 'java.class.path' property to contain certain jars because
+    // it is using the Java compiler to compile generated source code and expects the
+    // compiler to find libraries through the normal class path. It is enough to set
+    // the property during initialization.
+    //
+    val oldClassPath = System.getProperty("java.class.path")
+    val newClassPath = buildChronicleClassPath(oldClassPath).mkString(File.pathSeparator)
+    System.setProperty("java.class.path", newClassPath)
+
     chronicle = new Chronicle
     chronicleReader = new Chronicle.Reader
     chronicleWriter = new Chronicle.Writer
     chronicleReader.setup(tempDirPath.toFile, readWriteEntryCountParam)
     chronicleWriter.setup(tempDirPath.toFile, readWriteEntryCountParam)
+
+    System.setProperty("java.class.path", oldClassPath)
 
     mvStore = new MvStore
     mvStoreReader = new MvStore.Reader


### PR DESCRIPTION
Chronicle needs the `java.class.path` property to contain certain jars because it is using the Java compiler to compile generated source code and expects the compiler to find libraries through the normal class path lookup. It is enough to set the property during initialization.

On Java 22 and lower, some code actually sets the `java.class.path` property to the contents of the URL class loader, but it does not happen on Java 23 and later. So we do it explicitly.

This makes `db-shootout` compatible with Java 23 and 24-ea both in standalone and harness mode.

Closes #458.