### PR TITLE
Update Akka configuration to avoid registering JVM shutdown hooks and calling system exit on fatal error

### DIFF
--- a/benchmarks/actors-akka/src/main/resources/reference.conf
+++ b/benchmarks/actors-akka/src/main/resources/reference.conf
@@ -2,14 +2,23 @@
 
 akka {
 
-  # Log level used by the configured loggers (see "loggers") as soon
-  # as they have been started; before that, see "stdout-loglevel"
-  # Options: OFF, ERROR, WARNING, INFO, DEBUG
-  loglevel = "WARNING"
-
-  # Log level for the very basic logger activated during ActorSystem startup.
+  # Log level for the very basic logger activated during startup.
   # This logger prints the log messages to stdout (System.out).
   # Options: OFF, ERROR, WARNING, INFO, DEBUG
   stdout-loglevel = "WARNING"
+
+  # Log level used by the configured loggers (see "loggers") as soon
+  # as they have been started; before that, see "stdout-loglevel".
+  loglevel = "WARNING"
+
+  # Log complete configuration upon start. Enable for debugging.
+  log-config-on-start = off
+
+  # Do not exit directly from the framework, let the higher-ups do it.
+  jvm-exit-on-fatal-error = off
+
+  # Do not install JVM shutdown hooks to terminate the ActorSystem.
+  # The benchmark should do it in its tear down stage.
+  jvm-shutdown-hooks = off
 
 }


### PR DESCRIPTION
Configures default logging levels, disables framework exit on fatal error (harness should do it) and disables JVM shutdown hooks (benchmark should handle it). The idea is that benchmark should not register global hooks that run outside the harness control. The benchmark appears to terminate the actor system properly, so there should be no need for Akka to do this.