### PR TITLE
CI: update images to v14

### DIFF
--- a/.github/workflows/ea-jdk.yml
+++ b/.github/workflows/ea-jdk.yml
@@ -5,7 +5,7 @@ env:
 jobs:
   linux-ea:
     runs-on: ubuntu-latest
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk24-ea"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v14-openjdk24-ea"
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
 
   style:
     runs-on: ubuntu-latest
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk23"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v14-openjdk23"
     # We rarely build for more than 3 minutes
     timeout-minutes: 10
     steps:
@@ -44,7 +44,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk11-with-ant-gcc"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v14-openjdk11-with-ant-gcc"
     # We rarely build for more than 3 minutes
     timeout-minutes: 10
     steps:
@@ -93,7 +93,7 @@ jobs:
   readme:
     needs: build
     runs-on: ubuntu-latest
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk23"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v14-openjdk23"
     # We rarely build for more than 3 minutes
     timeout-minutes: 10
     steps:
@@ -162,7 +162,7 @@ jobs:
     #  - We need to set container to null on Windows and Mac as containers are
     #    supported on Linux only
     runs-on: ${{ (matrix.os == 'linux') && 'ubuntu' || matrix.os }}-latest
-    container: ${{ (matrix.os == 'linux') && format('ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-{0}', matrix.image) || null }}
+    container: ${{ (matrix.os == 'linux') && format('ghcr.io/renaissance-benchmarks/renaissance-buildenv:v14-{0}', matrix.image) || null }}
 
     # We rarely run over 17 minutes but a runaway JMH can loop forever.
     timeout-minutes: 30
@@ -216,7 +216,7 @@ jobs:
   plugins:
     runs-on: ubuntu-latest
     needs: build
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v12-openjdk11-with-ant-gcc"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v14-openjdk11-with-ant-gcc"
     # We rarely run over 10 minutes anyway.
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Image update to Fedora 41 done in renaissance-benchmarks/docker-buildenv#29.