### PR TITLE
CI: thread dump on benchmark timeout

### DIFF
--- a/tools/ci/bench-base.sh
+++ b/tools/ci/bench-base.sh
@@ -6,5 +6,5 @@ java -jar "$RENAISSANCE_JAR" --raw-list > list.txt
 
 for BENCH in $(cat list.txt); do
 	echo "====> $BENCH"
-	java -Xms2500M -Xmx2500M -jar "$RENAISSANCE_JAR" -c test -r 1 --csv output.csv --json output.json "$BENCH" || exit 1
+	timeout_with_thread_dump 5m java -Xms2500M -Xmx2500M -jar "$RENAISSANCE_JAR" -c test -r 1 --csv output.csv --json output.json "$BENCH" || exit 1
 done

--- a/tools/ci/bench-standalone.sh
+++ b/tools/ci/bench-standalone.sh
@@ -8,5 +8,5 @@ unzip "$RENAISSANCE_JAR" -d "extracted-renaissance"
 
 for BENCH in $(cat list.txt); do
 	echo "====> $BENCH"
-	java -Xms2500M -Xmx2500M -jar "./extracted-renaissance/single/$BENCH.jar" -c test -r 1 --csv output.csv --json output.json "$BENCH" || exit 1
+	timeout_with_thread_dump 5m java -Xms2500M -Xmx2500M -jar "./extracted-renaissance/single/$BENCH.jar" -c test -r 1 --csv output.csv --json output.json "$BENCH" || exit 1
 done

--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -67,6 +67,10 @@ get_jvm_workaround_args() {
     esac
 }
 
+timeout_with_thread_dump() {
+    timeout --signal=3 --kill-after=5s "$@"
+}
+
 
 # Make sure we are in the top-level directory so that we can use
 # relative paths when referring to files within the project.

--- a/tools/ci/common.sh
+++ b/tools/ci/common.sh
@@ -67,8 +67,21 @@ get_jvm_workaround_args() {
     esac
 }
 
-timeout_with_thread_dump() {
+if command -v timeout >/dev/null; then
+    TIMEOUT_IMPL=timeout_with_thread_dump_real
+else
+    TIMEOUT_IMPL=timeout_with_thread_dump_fake
+fi
+
+timeout_with_thread_dump_real() {
     timeout --signal=3 --kill-after=5s "$@"
+}
+timeout_with_thread_dump_fake() {
+    shift
+    "$@"
+}
+timeout_with_thread_dump() {
+    "$TIMEOUT_IMPL" "$@"
 }
 
 


### PR DESCRIPTION
To debug #457 we could run each Java process in `timeout` that first sends `SIGQUIT` (`3`) which tells the JVM to dump all threads (thanks @ceresek for the suggestion) and then kills the process anyway.

This also shortens the execution time for failing jobs as `gauss-mix` is killed after 5 minutes instead of eating the maximum job time (30m).

This works on both Linux and Windows (I am not sure if the signal is somehow emulated as I have not seen it fail there yet but it does not fail anything on good runs), on MacOS the command is not installed but majority of the failures were on Linux anyway.

Already we have one instance of failure here: https://github.com/renaissance-benchmarks/renaissance/actions/runs/11932162022/job/33256738789?pr=462#step:9:397
