### PR TITLE
Refactor parameter and variable names for clarity in the future-genetic benchmark

### DIFF
--- a/benchmarks/jdk-concurrent/src/main/java/org/renaissance/jdk/concurrent/JavaJenetics.java
+++ b/benchmarks/jdk-concurrent/src/main/java/org/renaissance/jdk/concurrent/JavaJenetics.java
@@ -29,7 +29,7 @@ public final class JavaJenetics {
 
   private final int geneCount;
 
-  private final int chromosomeCount;
+  private final int populationSize;
 
   private final int generationCount;
 
@@ -45,13 +45,13 @@ public final class JavaJenetics {
   //
 
   public JavaJenetics(
-    int geneMinValue, int geneMaxValue, int geneCount, int chromosomeCount,
+    int geneMinValue, int geneMaxValue, int geneCount, int populationSize,
     int generationCount, int threadCount, int randomSeed
   ) {
     this.geneMinValue = geneMinValue;
     this.geneMaxValue = geneMaxValue;
     this.geneCount = geneCount;
-    this.chromosomeCount = chromosomeCount;
+    this.populationSize = populationSize;
     this.generationCount = generationCount;
     this.randomSeed = randomSeed;
     this.threadCount = threadCount;
@@ -82,9 +82,9 @@ public final class JavaJenetics {
     //
     final long seed = initialSeed.getAndIncrement();
 
-    final Random chromosomeRandom = new Random(seed);
+    final Random genotypeRandom = new Random(seed);
     Genotype<DoubleGene> genotype = Genotype.of(DoubleChromosome.of(geneMinValue, geneMaxValue, geneCount));
-    Factory<Genotype<DoubleGene>> factory = () -> RandomRegistry.with(chromosomeRandom, r -> genotype.newInstance());
+    Factory<Genotype<DoubleGene>> factory = () -> RandomRegistry.with(genotypeRandom, r -> genotype.newInstance());
 
     final Random altererRandom = new Random(seed + 15);
     Alterer<DoubleGene, Double> singlePointCrossover = new SinglePointCrossover<DoubleGene, Double>(0.2);
@@ -110,7 +110,7 @@ public final class JavaJenetics {
       .alterers(alterer)
       .offspringSelector(offSpringSelector)
       .survivorsSelector(survivorsSelector)
-      .populationSize(chromosomeCount)
+      .populationSize(populationSize)
       .build();
 
     final Genotype<DoubleGene> result = engine.stream()

--- a/benchmarks/jdk-concurrent/src/main/scala/org/renaissance/jdk/concurrent/FutureGenetic.scala
+++ b/benchmarks/jdk-concurrent/src/main/scala/org/renaissance/jdk/concurrent/FutureGenetic.scala
@@ -19,14 +19,14 @@ import java.util.concurrent.TimeUnit
 @Summary("Runs a genetic algorithm using the Jenetics library and futures.")
 @Licenses(Array(License.APACHE2))
 @Repetitions(50)
-@Parameter(name = "chromosome_count", defaultValue = "50")
+@Parameter(name = "population_size", defaultValue = "50")
 @Parameter(name = "generation_count", defaultValue = "5000")
 @Parameter(name = "expected_sum", defaultValue = "-10975.2462578835")
 @Parameter(name = "expected_sum_squares", defaultValue = "130336964.45529507")
 @Configuration(
   name = "test",
   settings = Array(
-    "chromosome_count = 10",
+    "population_size = 10",
     "generation_count = 200",
     "expected_sum = -1857.224767254019",
     "expected_sum_squares = 135348190.4555571"
@@ -38,7 +38,7 @@ final class FutureGenetic extends Benchmark {
   // TODO: Consolidate benchmark parameters across the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/27
 
-  private var chromosomeCountParam: Int = _
+  private var populationSizeParam: Int = _
 
   private var generationCountParam: Int = _
 
@@ -64,7 +64,7 @@ final class FutureGenetic extends Benchmark {
   private var benchmark: JavaJenetics = _
 
   override def setUpBeforeAll(c: BenchmarkContext): Unit = {
-    chromosomeCountParam = c.parameter("chromosome_count").toPositiveInteger
+    populationSizeParam = c.parameter("population_size").toPositiveInteger
     generationCountParam = c.parameter("generation_count").toPositiveInteger
     expectedSum = c.parameter("expected_sum").toDouble
     expectedSumSquares = c.parameter("expected_sum_squares").toDouble
@@ -75,7 +75,7 @@ final class FutureGenetic extends Benchmark {
       GENE_MIN_VALUE,
       GENE_MAX_VALUE,
       GENE_COUNT,
-      chromosomeCountParam,
+      populationSizeParam,
       generationCountParam,
       THREAD_COUNT,
       RANDOM_SEED


### PR DESCRIPTION
Renamed chromosome_count to population_size to better reflect its role. The benchmark generates a population of 50 genotypes, each containing a single chromosome with 200 double Genes. Evolution is computed for the population, and at the end, the best genotype is selected, and its chromosome is returned. Since the term chromosome_count=50 was misleading, this change improves clarity.

Renamed chromosomeRandom to genotypeRandom, as this random generator is responsible for creating new random genotypes, not chromosomes.