### PR TITLE
Close URLClassLoader instances to enable proper cleanup on NFS

### DIFF
--- a/renaissance-core/src/main/java/org/renaissance/core/BenchmarkSuite.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/BenchmarkSuite.java
@@ -283,6 +283,10 @@ public final class BenchmarkSuite {
       throw new ExtensionException("malformed URL(s) in classpath specification");
     }
 
+    //
+    // No need to explicitly close this URLClassLoader on exit, because it does not
+    // operate on files created by the harness that need to be deleted on exit.
+    //
     ClassLoader parent = ModuleLoader.class.getClassLoader();
     return new URLClassLoader(classPathUrls, parent);
   }

--- a/renaissance-core/src/main/java/org/renaissance/core/Cleaner.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/Cleaner.java
@@ -1,0 +1,76 @@
+package org.renaissance.core;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+final class Cleaner {
+  private static Set<Closeable> registeredCloseables = new LinkedHashSet<>();
+  private static Set<Path> registeredPaths = new LinkedHashSet<>();
+
+  private Cleaner() {}
+
+  static Path deleteOnExit(Path path) {
+    return register(registeredPaths, path);
+  }
+
+  static <T extends Closeable> T closeOnExit(T closeable) {
+    return register(registeredCloseables, closeable);
+  }
+
+  private synchronized static <T> T register(Set<? super T> registry, T item) {
+    if (registry == null) {
+      throw new IllegalStateException("Shutdown in progress");
+    } else {
+      registry.add(Objects.requireNonNull(item));
+    }
+
+    return item;
+  }
+
+  private static void run() {
+    Set<Closeable> closeables;
+    Set<Path> paths;
+
+    synchronized (Cleaner.class) {
+      closeables = registeredCloseables;
+      registeredCloseables = null;
+
+      paths = registeredPaths;
+      registeredPaths = null;
+    }
+
+    // Close closeables BEFORE deleting files/directories.
+    // In particular URLClassLoader instances which keep files open.
+    // Delete files/directories AFTER closing closeables.
+
+    cleanupEach(closeables, "close", Closeable::close).clear();
+    cleanupEach(paths, "delete", DirUtils::deleteRecursively).clear();
+  }
+
+  @FunctionalInterface
+  private interface Action<T> {
+    void accept(T object) throws IOException;
+  }
+
+  private static <T, C extends Iterable<T>> C cleanupEach(C items, String name, Action<T> action) {
+    for (T item : items) {
+      try {
+        action.accept(item);
+      } catch (IOException e) {
+        // Just a notification. This should be rare and is not critical.
+        System.err.format("warning: failed to %s %s on shutdown: %s\n", name, item, e);
+      }
+    }
+
+    return items;
+  }
+
+  static {
+    Runtime.getRuntime().addShutdownHook(new Thread(Cleaner::run));
+  }
+
+}

--- a/renaissance-core/src/main/java/org/renaissance/core/DirUtils.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/DirUtils.java
@@ -39,7 +39,7 @@ public final class DirUtils {
         if (deleteRoot || !rootDir.equals(dir)) {
           if (exc != null) {
             // There was an earlier failure with one of the children, which means
-            // that we will not be able do delete this directory anyway.
+            // that we will not be able to delete this directory anyway.
             throw exc;
           }
 

--- a/renaissance-core/src/main/java/org/renaissance/core/DirUtils.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/DirUtils.java
@@ -37,6 +37,12 @@ public final class DirUtils {
       @Override
       public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
         if (deleteRoot || !rootDir.equals(dir)) {
+          if (exc != null) {
+            // There was an earlier failure with one of the children, which means
+            // that we will not be able do delete this directory anyway.
+            throw exc;
+          }
+
           Files.delete(dir);
         }
 
@@ -52,24 +58,10 @@ public final class DirUtils {
 
     Path scratchDir = createTempDirectory(base, tsPrefix).normalize();
     if (!keepOnExit) {
-      Runtime.getRuntime().addShutdownHook(new Thread (() -> {
-        logger.fine(() -> "Deleting scratch directory: " + printable(scratchDir));
-        try {
-          deleteRecursively(scratchDir);
-        } catch (IOException e) {
-          // Just a notification. This should be rare and is not critical.
-          logger.warning(String.format(
-            "Error deleting scratch directory %s: %s", printable(scratchDir), e.getMessage()
-          ));
-        }
-      }));
+      Cleaner.deleteOnExit(scratchDir);
     }
 
     return scratchDir;
-  }
-
-  private static Path printable(Path path) {
-    return path.toAbsolutePath().normalize();
   }
 
 }

--- a/renaissance-core/src/main/java/org/renaissance/core/Logging.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/Logging.java
@@ -1,8 +1,8 @@
 package org.renaissance.core;
 
+import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.logging.SimpleFormatter;
 import java.util.logging.StreamHandler;
 
 public final class Logging {
@@ -30,8 +30,8 @@ public final class Logging {
       System.setProperty(FORMAT_PROPERTY, DEFAULT_FORMAT);
     }
 
-    // Create SimpleFormatter AFTER setting the system property.
-    return new StreamHandler(System.err, new SimpleFormatter());
+    // Creates SimpleFormatter AFTER setting the system property.
+    return new ConsoleHandler();
   }
 
   private Logging() {}

--- a/renaissance-core/src/main/java/org/renaissance/core/ModuleLoader.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/ModuleLoader.java
@@ -158,6 +158,14 @@ public final class ModuleLoader {
           name, filePaths.size(), makeClassPath(filePaths)
         ));
 
+        //
+        // Make sure to explicitly close this URLClassLoader on exit, because it operates
+        // on files created by the harness in the scratch directory hierarchy that need to
+        // be deleted on exit. Leaving the class loader open keeps the library JAR files
+        // open, preventing removal of the scratch directories. This is because on NFS,
+        // deleting an open file produces a NFS temporary file in the same directory, and
+        // on Windows, an open file cannot be deleted at all.
+        //
         return Cleaner.closeOnExit(new URLClassLoader(urls, thisClass.getClassLoader()));
 
       } catch (IOException e) {

--- a/renaissance-core/src/main/java/org/renaissance/core/ModuleLoader.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/ModuleLoader.java
@@ -158,7 +158,7 @@ public final class ModuleLoader {
           name, filePaths.size(), makeClassPath(filePaths)
         ));
 
-        return new URLClassLoader(urls, thisClass.getClassLoader());
+        return Cleaner.closeOnExit(new URLClassLoader(urls, thisClass.getClassLoader()));
 
       } catch (IOException e) {
         // Just wrap the underlying IOException.


### PR DESCRIPTION
This ensures that library JAR files stored in the launcher and harness scratch directories are closed before removing the scratch
directory roots. This was a problem on NFS, where the open files could not be unlinked from the directory (NFS kept around `.nfs*` temporaries), preventing the removal of the directories.

Also fixes the logging setup which used `StreamHandler` instead of `ConsoleHandler` for `stderr`, which resulted in closing of the `stderr` as a result of running the `java.util.logging` shutdown hook, effectively gagging `stderr`.

Closes #464 