### PR TITLE
Add VM start in terms of nanoTime() to the CSV and JSON outputs

### DIFF
--- a/renaissance-core/src/main/java/org/renaissance/BenchmarkParameter.java
+++ b/renaissance-core/src/main/java/org/renaissance/BenchmarkParameter.java
@@ -84,15 +84,15 @@ public interface BenchmarkParameter {
   List<Map<String, String>> toCsvRows();
 
   /**
-   * Interprets the value as a CSV-like table with rows separated by
-   * semicolons, columns separated by commas, and a header row with
-   * column names.
+   * Interprets the value as a CSV-like table and produces a {@link List}
+   * of objects obtained by applying a user-defined mapping function on
+   * each row. Each row is represented as a {@link Map} of column values
+   * (strings) keyed by column names. The CSV-like input has a header row
+   * with column names, the rows are separated by semicolons, and columns are
+   * separated by commas.
    *
-   * @param parser Function to parse a row from a {@link Map} containing
-   * column values keyed by column names.
-   *
-   * @return A {@link List} of rows represented by a {@link Map} of column
-   * names to string values, with rows and columns preserving iteration order.
+   * @param mapper Function that converts a CSV row to the result type.
+   * @return A {@link List} of objects obtained from CSV rows.
    */
   <R> List<R> toCsvRows(Function<Map<String, String>, R> parser);
 

--- a/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
+++ b/renaissance-harness/src/main/scala/org/renaissance/harness/ResultWriter.scala
@@ -1,6 +1,5 @@
 package org.renaissance.harness
 
-import com.sun.management.UnixOperatingSystemMXBean
 import org.renaissance.Benchmark
 import org.renaissance.Plugin.BeforeHarnessShutdownListener
 import org.renaissance.Plugin.BenchmarkFailureListener
@@ -209,14 +208,23 @@ private final class JsonWriter(val jsonFile: Path) extends ResultWriter {
     )
 
     os match {
-      case unixOs: UnixOperatingSystemMXBean =>
+      case extOs: com.sun.management.OperatingSystemMXBean =>
         // Gag possible exceptions.
         result ++= Seq(
-          "phys_mem_total" -> Try(unixOs.getTotalPhysicalMemorySize).toOption.toJson,
-          "phys_mem_free" -> Try(unixOs.getFreePhysicalMemorySize).toOption.toJson,
-          "virt_mem_committed" -> Try(unixOs.getCommittedVirtualMemorySize).toOption.toJson,
-          "swap_space_total" -> Try(unixOs.getTotalSwapSpaceSize).toOption.toJson,
-          "swap_space_free" -> Try(unixOs.getFreeSwapSpaceSize).toOption.toJson,
+          "phys_mem_total" -> Try(extOs.getTotalPhysicalMemorySize).toOption.toJson,
+          "phys_mem_free" -> Try(extOs.getFreePhysicalMemorySize).toOption.toJson,
+          "virt_mem_committed" -> Try(extOs.getCommittedVirtualMemorySize).toOption.toJson,
+          "swap_space_total" -> Try(extOs.getTotalSwapSpaceSize).toOption.toJson,
+          "swap_space_free" -> Try(extOs.getFreeSwapSpaceSize).toOption.toJson
+        )
+
+      case _ =>
+    }
+
+    os match {
+      case unixOs: com.sun.management.UnixOperatingSystemMXBean =>
+        // Gag possible exceptions.
+        result ++= Seq(
           "max_fd_count" -> Try(unixOs.getMaxFileDescriptorCount).toOption.toJson,
           "open_fd_count" -> Try(unixOs.getOpenFileDescriptorCount).toOption.toJson
         )


### PR DESCRIPTION
The value is stored as `vm_start_ns` in the CSV output and `vm.start_ns` in the JSON output. It has no official semantics (unlike `vm_start_unix_ms`), but allows recovering the `nanoTime()` value associated with the `vm_start_unix_ms` value. It also bumps the JSON format version to 6.

BTW, only the last commit is the important one, the others are things that I had lying around for quite some time and thought to sneak them in.

Closes #468 