### PR TITLE
Update CI images to v 16 (bump to Fedora 42)

### DIFF
--- a/.github/workflows/ea-jdk.yml
+++ b/.github/workflows/ea-jdk.yml
@@ -5,7 +5,7 @@ env:
 jobs:
   linux-ea:
     runs-on: ubuntu-latest
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v15-openjdk25-ea"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v16-openjdk25-ea"
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,6 +217,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v16-openjdk11-with-ant-gcc"
+    env:
+      JAVA_HOME: "/opt/jdk-11.0.2/"
     # We rarely run over 10 minutes anyway.
     timeout-minutes: 30
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
 
   style:
     runs-on: ubuntu-latest
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v15-openjdk24"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v16-openjdk24"
     # We rarely build for more than 3 minutes
     timeout-minutes: 10
     steps:
@@ -44,7 +44,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v15-openjdk11-with-ant-gcc"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v16-openjdk11-with-ant-gcc"
     # We rarely build for more than 3 minutes
     timeout-minutes: 10
     steps:
@@ -93,7 +93,7 @@ jobs:
   readme:
     needs: build
     runs-on: ubuntu-latest
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v15-openjdk24"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v16-openjdk24"
     # We rarely build for more than 3 minutes
     timeout-minutes: 10
     steps:
@@ -162,7 +162,7 @@ jobs:
     #  - We need to set container to null on Windows and Mac as containers are
     #    supported on Linux only
     runs-on: ${{ (matrix.os == 'linux') && 'ubuntu' || matrix.os }}-latest
-    container: ${{ (matrix.os == 'linux') && format('ghcr.io/renaissance-benchmarks/renaissance-buildenv:v15-{0}', matrix.image) || null }}
+    container: ${{ (matrix.os == 'linux') && format('ghcr.io/renaissance-benchmarks/renaissance-buildenv:v16-{0}', matrix.image) || null }}
 
     # We rarely run over 17 minutes but a runaway JMH can loop forever.
     timeout-minutes: 30
@@ -216,7 +216,7 @@ jobs:
   plugins:
     runs-on: ubuntu-latest
     needs: build
-    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v15-openjdk11-with-ant-gcc"
+    container: "ghcr.io/renaissance-benchmarks/renaissance-buildenv:v16-openjdk11-with-ant-gcc"
     # We rarely run over 10 minutes anyway.
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
See https://github.com/renaissance-benchmarks/docker-buildenv/pull/32