### PR TITLE
Disable remote reporting in Chronicle Analytics

### DIFF
--- a/benchmarks/database/src/main/scala/org/renaissance/database/DbShootout.scala
+++ b/benchmarks/database/src/main/scala/org/renaissance/database/DbShootout.scala
@@ -80,6 +80,9 @@ final class DbShootout extends Benchmark {
     mapDbReader.setup(tempDirPath.toFile, readWriteEntryCountParam)
     mapDbWriter.setup(tempDirPath.toFile, readWriteEntryCountParam)
 
+    // Disable online data collection in Chronicle Analytics.
+    System.setProperty("chronicle.analytics.disable", "true")
+
     //
     // Chronicle needs the 'java.class.path' property to contain certain jars because
     // it is using the Java compiler to compile generated source code and expects the


### PR DESCRIPTION
The Chronicle Analytics library is reporting some usage data to a remote server. Clients are identified using a uuid stored in `.chronicle.analytics.client.id` in the home directory, with some sort of event counter in `.chronicle.analytics.last` probably to limit the frequency of sending events upstream.

Even though the authors mentioned it in the release notes when it was introduced, it is not something we want in a benchmark suite. This disables the reporting based on information from https://github.com/OpenHFT/Chronicle-Analytics/blob/master/src/main/java/net/openhft/chronicle/analytics/Analytics.java.


