### PR TITLE
Trigger early loading of the UserGroupInformation.RealUser class to avoid crash on exit

### DIFF
--- a/renaissance-core/src/main/java/org/renaissance/core/ModuleLoader.java
+++ b/renaissance-core/src/main/java/org/renaissance/core/ModuleLoader.java
@@ -265,7 +265,8 @@ public final class ModuleLoader {
 
   private static URL makeUrl(String spec) {
     try {
-      return new URL(spec);
+      // Avoid URL constructor deprecated since Java 20.
+      return URI.create(spec).toURL();
     } catch (MalformedURLException e) {
       logger.warning(String.format("Failed to convert '%s' to URL", spec));
       return null;


### PR DESCRIPTION
One of Hadoop shutdown hooks apparently accesses the class, but at that time, the class loader providing access to the benchmark's dependency JARs is already closed and the files deleted, resulting in a class loading exception in the shutdown handler. Loading the class early ensures that the class will be available to the late shutdown hook.

If this turns out to be too fragile, there are some options concerning the Hadoop `ShutdownHookManager` class, but integrating them into Renaissance would be more difficult:
- Making the `executeShutdown()` method public to allow triggering the Hadoop shutdown hooks in Renaissance on benchmark shutdown. This will would also need making the `shutdownInProgress` field public so that we can prevent the system-wide shutdown hook from executing the Hadoop shutdown hooks again. This is also doable through reflection, but probably not preferred.
- Alternatively, the class could be modified to avoid registering a system wide shutdown hook in the class initializer and instead expose that hook for Renaissance to call directly on benchmark shutdown. 

Closes #471 