### PR TITLE
Add http4k benchmark (see #451)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ The following is the complete list of benchmarks, separated into groups.
   \
   Default repetitions: 12; APACHE2 license, MIT distribution; Supported JVM: 11 and later
 
+- `http4k` - Sends concurrent HTTP requests to an http4k server with an Undertow backend.
+  \
+  Default repetitions: 20; APACHE2 license, MIT distribution; Supported JVM: 11 and later
+
 
 
 The suite also contains a group of benchmarks intended solely for testing

--- a/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/Http4kBenchmark.kt
+++ b/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/Http4kBenchmark.kt
@@ -1,0 +1,122 @@
+package org.renaissance.http4k
+
+import kotlinx.coroutines.runBlocking
+import org.http4k.client.OkHttp
+import org.renaissance.Benchmark
+import org.renaissance.Benchmark.Configuration
+import org.renaissance.Benchmark.Group
+import org.renaissance.Benchmark.Licenses
+import org.renaissance.Benchmark.Name
+import org.renaissance.Benchmark.Parameter
+import org.renaissance.Benchmark.Repetitions
+import org.renaissance.Benchmark.Summary
+import org.renaissance.BenchmarkContext
+import org.renaissance.BenchmarkResult
+import org.renaissance.BenchmarkResult.Validators
+import org.renaissance.License
+import org.renaissance.http4k.workload.WorkloadClient
+import org.renaissance.http4k.workload.WorkloadConfiguration
+import org.renaissance.http4k.workload.WorkloadServer
+
+@Name("http4k")
+@Group("web")
+@Group("http4k")
+@Summary("Sends concurrent HTTP requests to an http4k server with an Undertow backend.")
+@Licenses(License.APACHE2)
+@Repetitions(20)
+@Parameter(
+    name = "host",
+    defaultValue = "127.0.0.1",
+    summary = "Host of the server."
+)
+@Parameter(
+    name = "port",
+    defaultValue = "0",
+    summary = "Port of the server (0 for auto-allocation)."
+)
+@Parameter(
+    name = "server_threads",
+    defaultValue = "\$cpu.count",
+    summary = "Number of Undertow worker threads."
+)
+@Parameter(
+    name = "max_threads",
+    defaultValue = "\$cpu.count",
+    summary = "Maximum number of client coroutine threads."
+)
+@Parameter(
+    name = "workload_count",
+    defaultValue = "450",
+    summary = "Number of workloads to generate."
+)
+@Parameter(
+    name = "read_workload_repeat_count",
+    defaultValue = "5",
+    summary = "Number of read requests per workload."
+)
+@Parameter(
+    name = "write_workload_repeat_count",
+    defaultValue = "5",
+    summary = "Number of write requests per workload."
+)
+@Parameter(
+    name = "ddos_workload_repeat_count",
+    defaultValue = "5",
+    summary = "Number of ddos requests per workload."
+)
+@Parameter(
+    name = "mixed_workload_repeat_count",
+    defaultValue = "5",
+    summary = "Number of mixed requests per workload."
+)
+@Parameter(
+    name = "workload_selection_seed",
+    defaultValue = "42",
+    summary = "Seed used to generate random workloads."
+)
+@Configuration(
+    name = "test",
+    settings = [
+        "server_threads = 2",
+        "max_threads = 2",
+        "workload_count = 100"
+    ]
+)
+@Configuration(name = "jmh")
+class Http4kBenchmark : Benchmark {
+    private lateinit var server: WorkloadServer
+    private lateinit var client: WorkloadClient
+    private lateinit var configuration: WorkloadConfiguration
+
+    override fun run(context: BenchmarkContext): BenchmarkResult = runBlocking {
+        val workloadSummary = client.workload()
+        Validators.simple("Workload count", configuration.workloadCount.toLong(), workloadSummary.workloadCount)
+    }
+
+    override fun setUpBeforeEach(context: BenchmarkContext) {
+        configuration = context.toWorkloadConfiguration()
+        server = WorkloadServer(configuration.port, configuration.serverThreads)
+        server.start()
+
+        // If port value is 0, server allocates a free port which has to be saved for client requests.
+        configuration = configuration.copy(port = server.port())
+        client = WorkloadClient(OkHttp(), configuration)
+    }
+
+    override fun tearDownAfterEach(context: BenchmarkContext) {
+        server.stop()
+    }
+
+    private fun BenchmarkContext.toWorkloadConfiguration(): WorkloadConfiguration = WorkloadConfiguration(
+        host = parameter("host").value(),
+        port = parameter("port").value().toInt(),
+        serverThreads = parameter("server_threads").value().toInt(),
+        readWorkloadRepeatCount = parameter("read_workload_repeat_count").value().toInt(),
+        writeWorkloadRepeatCount = parameter("write_workload_repeat_count").value().toInt(),
+        ddosWorkloadRepeatCount = parameter("ddos_workload_repeat_count").value().toInt(),
+        mixedWorkloadRepeatCount = parameter("mixed_workload_repeat_count").value().toInt(),
+        workloadCount = parameter("workload_count").value().toInt(),
+        maxThreads = parameter("max_threads").value().toInt(),
+        workloadSelectionSeed = parameter("workload_selection_seed").value().toLong()
+    )
+}

--- a/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/model/Product.kt
+++ b/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/model/Product.kt
@@ -1,0 +1,11 @@
+package org.renaissance.http4k.model
+
+import org.http4k.core.Body
+import org.http4k.format.Moshi.auto
+
+internal data class Product(val id: String, val name: String) {
+    internal companion object {
+        internal val productLens = Body.auto<Product>().toLens()
+        internal val productsLens = Body.auto<Array<Product>>().toLens()
+    }
+}

--- a/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/workload/BoundedUndertow.kt
+++ b/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/workload/BoundedUndertow.kt
@@ -1,0 +1,49 @@
+package org.renaissance.http4k.workload
+
+import io.undertow.Undertow
+import io.undertow.server.handlers.BlockingHandler
+import org.http4k.core.HttpHandler
+import org.http4k.server.Http4kServer
+import org.http4k.server.Http4kUndertowHttpHandler
+import org.http4k.server.ServerConfig
+import org.http4k.server.ServerConfig.StopMode
+import org.http4k.server.ServerConfig.StopMode.Immediate
+import java.net.InetSocketAddress
+
+/**
+ * Custom Undertow server configuration with a bounded number of worker threads.
+ *
+ * The default http4k [org.http4k.server.Undertow] uses 32 * availableProcessors()
+ * worker threads, which prevents the server from becoming CPU-bound on large machines.
+ * This wrapper allows controlling the worker thread count for more predictable
+ * benchmark behavior.
+ *
+ * @param port Server port (0 for auto-allocation).
+ * @param workerThreads Number of Undertow worker threads.
+ */
+internal class BoundedUndertow(
+    private val port: Int = 0,
+    private val workerThreads: Int = Runtime.getRuntime().availableProcessors()
+) : ServerConfig {
+    override val stopMode: StopMode = Immediate
+
+    override fun toServer(http: HttpHandler): Http4kServer {
+        val httpHandler = Http4kUndertowHttpHandler(http).let(::BlockingHandler)
+
+        return object : Http4kServer {
+            val server: Undertow = Undertow.builder()
+                .addHttpListener(port, "0.0.0.0")
+                .setWorkerThreads(workerThreads)
+                .setHandler(httpHandler)
+                .build()
+
+            override fun start() = apply { server.start() }
+            override fun stop() = apply { server.stop() }
+
+            override fun port(): Int = when {
+                port > 0 -> port
+                else -> (server.listenerInfo[0].address as InetSocketAddress).port
+            }
+        }
+    }
+}

--- a/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/workload/WorkloadClient.kt
+++ b/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/workload/WorkloadClient.kt
@@ -1,0 +1,137 @@
+package org.renaissance.http4k.workload
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import org.http4k.core.HttpHandler
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.renaissance.http4k.model.Product
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.random.Random
+
+/**
+ * Client used to generate workloads for the http4k server.
+ * The client sends requests to the server based on the workload type.
+ * @param client HttpHandler used to send requests to the server.
+ * @param configuration WorkloadConfiguration used to generate the workload.
+ */
+internal class WorkloadClient(
+    private val client: HttpHandler, private val configuration: WorkloadConfiguration
+) {
+    private val getProductsCounter = AtomicLong(0)
+    private val getProductCounter = AtomicLong(0)
+    private val postProductCounter = AtomicLong(0)
+
+    private val readCounter = AtomicLong(0)
+    private val writeCounter = AtomicLong(0)
+    private val ddosCounter = AtomicLong(0)
+    private val mixedCounter = AtomicLong(0)
+
+    private val workloadCounter = AtomicLong(0)
+
+    private val dispatcher = Dispatchers.IO.limitedParallelism(configuration.maxThreads, "Workload")
+
+    /**
+     * Starts the workload on the server based on [configuration].
+     * Each workload consists of read, write, ddos and mixed requests.
+     * The number of workloads is determined by [WorkloadConfiguration.workloadCount].
+     * The number of requests for each workload type is determined by the corresponding configuration value.
+     * Random workload is generated for each iteration based on the seed in [WorkloadConfiguration.workloadSelectionSeed].
+     * @return WorkloadSummary containing number of requests per type used for validation.
+     */
+    suspend fun workload(): WorkloadSummary = coroutineScope {
+        val random = Random(configuration.workloadSelectionSeed)
+        withContext(dispatcher) {
+            range(configuration.workloadCount).flatMap {
+                when (random.nextWorkload()) {
+                    WorkloadType.READ -> range(configuration.readWorkloadRepeatCount).map { async { client.readWorkload() } }
+                    WorkloadType.WRITE -> range(configuration.writeWorkloadRepeatCount).map { async { client.writeWorkload() } }
+                    WorkloadType.DDOS -> range(configuration.ddosWorkloadRepeatCount).map { async { client.ddosWorkload() } }
+                    WorkloadType.MIXED -> range(configuration.mixedWorkloadRepeatCount).map { async { client.mixedWorkload() } }
+                }.also { workloadCounter.incrementAndGet() }
+            }.awaitAll()
+
+            WorkloadSummary(
+                getProductsCount = getProductsCounter.get(),
+                getProductCount = getProductCounter.get(),
+                postProductCount = postProductCounter.get(),
+                readCount = readCounter.get(),
+                writeCount = writeCounter.get(),
+                ddosCount = ddosCounter.get(),
+                mixedCount = mixedCounter.get(),
+                workloadCount = workloadCounter.get()
+            )
+        }
+    }
+
+    /**
+     * Read workload gets all products and then iterates over each one and gets the specific product.
+     */
+    private fun HttpHandler.readWorkload() {
+        val products = getProducts()
+        products.forEach { product ->
+            getProduct(product.id)
+        }
+        readCounter.incrementAndGet()
+    }
+
+    /**
+     * Write workload creates a new product.
+     */
+    private fun HttpHandler.writeWorkload() {
+        val product = generateProduct()
+        postProduct(product)
+        writeCounter.incrementAndGet()
+    }
+
+    /**
+     * DDOS workload reads all products 10 times in a row.
+     */
+    private fun HttpHandler.ddosWorkload() {
+        repeat(10) {
+            getProducts()
+        }
+        ddosCounter.incrementAndGet()
+    }
+
+    /**
+     * Mixed workload reads all products, then creates a new product and fetches it afterward.
+     */
+    private fun HttpHandler.mixedWorkload() {
+        getProducts()
+        val product = generateProduct()
+        postProduct(product)
+        getProduct(product.id)
+        mixedCounter.incrementAndGet()
+    }
+
+    private fun HttpHandler.getProducts(): List<Product> =
+        Product.productsLens(this(Request(Method.GET, configuration.url("product")))).toList()
+            .also { getProductsCounter.incrementAndGet() }
+
+    private fun HttpHandler.getProduct(id: String) =
+        this(Request(Method.GET, configuration.url("product/$id"))).also { getProductCounter.incrementAndGet() }
+
+    private fun HttpHandler.postProduct(product: Product) = this(
+        Product.productLens(
+            product,
+            Request(Method.POST, configuration.url("product"))
+        )
+    ).also { postProductCounter.incrementAndGet() }
+
+    private fun WorkloadConfiguration.url(endpoint: String) = "http://$host:$port/$endpoint"
+
+    private fun Random.nextWorkload() = WorkloadType.entries[nextInt(WorkloadType.entries.size)]
+
+    private fun generateProduct(): Product {
+        val id = UUID.randomUUID().toString()
+        val name = "Product $id"
+        return Product(id, name)
+    }
+
+    private fun range(end: Int) = (1..end)
+}

--- a/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/workload/WorkloadConfiguration.kt
+++ b/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/workload/WorkloadConfiguration.kt
@@ -1,0 +1,14 @@
+package org.renaissance.http4k.workload
+
+internal data class WorkloadConfiguration(
+    val host: String,
+    val port: Int,
+    val serverThreads: Int,
+    val readWorkloadRepeatCount: Int,
+    val writeWorkloadRepeatCount: Int,
+    val ddosWorkloadRepeatCount: Int,
+    val mixedWorkloadRepeatCount: Int,
+    val workloadCount: Int,
+    val maxThreads: Int,
+    val workloadSelectionSeed: Long
+)

--- a/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/workload/WorkloadServer.kt
+++ b/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/workload/WorkloadServer.kt
@@ -1,0 +1,50 @@
+package org.renaissance.http4k.workload
+
+import org.http4k.core.HttpHandler
+import org.http4k.core.Method
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.routing.bind
+import org.http4k.routing.path
+import org.http4k.routing.routes
+import org.http4k.server.Http4kServer
+import org.http4k.server.asServer
+import org.renaissance.http4k.model.Product
+import java.util.concurrent.ConcurrentHashMap
+
+internal class WorkloadServer(port: Int, workerThreads: Int) : Http4kServer {
+    private val server = app().asServer(BoundedUndertow(port, workerThreads))
+    private val products: MutableMap<String, Product> = ConcurrentHashMap<String, Product>()
+
+    private fun app(): HttpHandler = routes(
+        "/product" bind Method.GET to { Product.productsLens(products.values.toTypedArray(), Response(Status.OK)) },
+        "/product/{id}" bind Method.GET to {
+            when (val id = it.path("id")) {
+                null -> Response(Status.BAD_REQUEST)
+                !in products -> Response(Status.NOT_FOUND)
+                else -> {
+                    val product = products[id] ?: error("Invariant error: Product $it should be present")
+                    Product.productLens(product, Response(Status.OK))
+                }
+            }
+        },
+        "/product" bind Method.POST to {
+            val product = Product.productLens(it)
+            products[product.id] = product
+            Response(Status.CREATED)
+        }
+    )
+
+    override fun port(): Int = server.port()
+
+    override fun start(): Http4kServer {
+        server.start()
+        return this
+    }
+
+    override fun stop(): Http4kServer {
+        server.stop()
+        products.clear()
+        return this
+    }
+}

--- a/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/workload/WorkloadSummary.kt
+++ b/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/workload/WorkloadSummary.kt
@@ -1,0 +1,12 @@
+package org.renaissance.http4k.workload
+
+internal data class WorkloadSummary(
+    val getProductsCount: Long,
+    val getProductCount: Long,
+    val postProductCount: Long,
+    val readCount: Long,
+    val writeCount: Long,
+    val ddosCount: Long,
+    val mixedCount: Long,
+    val workloadCount: Long
+)

--- a/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/workload/WorkloadType.kt
+++ b/benchmarks/http4k/src/main/kotlin/org/renaissance/http4k/workload/WorkloadType.kt
@@ -1,0 +1,8 @@
+package org.renaissance.http4k.workload
+
+internal enum class WorkloadType {
+    READ,
+    WRITE,
+    DDOS,
+    MIXED
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import kotlin.Keys.{kotlinVersion, kotlincJvmTarget}
 import org.renaissance.License
 import sbt.Def
 import sbt.Package
@@ -180,6 +181,7 @@ val commonsMath3Version = "3.6.1"
 val commonsTextVersion = "1.12.0"
 val eclipseCollectionsVersion = "11.1.0"
 val guavaVersion = "33.3.1-jre"
+val http4kVersion = "5.47.0.0"
 val jacksonVersion = "2.18.1"
 val jakartaXmlBindVersion = "2.3.3"
 val jerseyVersion = "2.45"
@@ -492,6 +494,23 @@ lazy val jdkStreamsBenchmarks = (project in file("benchmarks/jdk-streams"))
   )
   .dependsOn(renaissanceCore % "provided")
 
+lazy val http4kBenchmarks = (project in file("benchmarks/http4k"))
+  .enablePlugins(KotlinPlugin)
+  .settings(
+    name := "http4k",
+    commonSettingsNoScala,
+    kotlinVersion := "2.1.20",
+    kotlincJvmTarget := javaRelease,
+    libraryDependencies ++= Seq(
+      "org.http4k" % "http4k-core" % http4kVersion,
+      "org.http4k" % "http4k-server-undertow" % http4kVersion,
+      "org.http4k" % "http4k-client-okhttp" % http4kVersion,
+      "org.http4k" % "http4k-format-moshi" % http4kVersion,
+      "org.jetbrains.kotlinx" % "kotlinx-coroutines-core" % "1.9.0"
+    )
+  )
+  .dependsOn(renaissanceCore % "provided")
+
 val grpcVersion = "1.68.1"
 
 lazy val neo4jBenchmarks = (project in file("benchmarks/neo4j"))
@@ -622,6 +641,7 @@ lazy val scalaStmBenchmarks = (project in file("benchmarks/scala-stm"))
 val finagleVersion = "24.2.0"
 
 lazy val twitterFinagleBenchmarks = (project in file("benchmarks/twitter-finagle"))
+  .disablePlugins(KotlinPlugin)
   .settings(
     name := "twitter-finagle",
     commonSettingsScala213,
@@ -669,6 +689,7 @@ val renaissanceBenchmarks: Seq[Project] = Seq(
   actorsReactorsBenchmarks,
   apacheSparkBenchmarks,
   databaseBenchmarks,
+  http4kBenchmarks,
   jdkConcurrentBenchmarks,
   jdkStreamsBenchmarks,
   neo4jBenchmarks,
@@ -1137,6 +1158,7 @@ def mapJarContentsToAssemblyTask(classpath: Classpath) =
  * compiled wrappers are used by the [[renaissanceJmh]] project below.
  */
 lazy val renaissanceJmhWrappers = (project in file("renaissance-jmh/wrappers"))
+  .disablePlugins(KotlinPlugin)
   .settings(
     name := "renaissance-jmh-wrappers",
     commonSettingsNoScala,
@@ -1156,6 +1178,7 @@ lazy val renaissanceJmhWrappers = (project in file("renaissance-jmh/wrappers"))
  * its dependencies), along with the benchmark dependencies as JAR files.
  */
 lazy val renaissanceJmh = (project in file("renaissance-jmh"))
+  .disablePlugins(KotlinPlugin)
   .settings(
     name := "renaissance-jmh",
     commonSettingsNoScala,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.4")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.2")
+addSbtPlugin("org.jetbrains.scala" % "sbt-kotlin-plugin" % "3.1.5")


### PR DESCRIPTION
Continues the work from #451 by @kristian-petras.

## Summary

Adds a Kotlin-based HTTP benchmark using the [http4k](https://www.http4k.org/) framework with an Undertow server backend. The benchmark creates a product management REST API and exercises it with concurrent client requests using Kotlin coroutines.

This also introduces Kotlin compilation support into the build system via `sbt-kotlin-plugin`.

## Changes addressing review feedback from #451

- **CPU utilization fix**: Added `BoundedUndertow` — a custom `ServerConfig` wrapper that controls Undertow worker thread count via a new `server_threads` parameter (default `$cpu.count`). The default http4k `Undertow` uses `32 * availableProcessors()` worker threads, which prevented the server from becoming CPU-bound on large machines ([discussion](https://github.com/renaissance-benchmarks/renaissance/pull/451#issuecomment-2363428701)).
- **kotlincJvmTarget**: Set to `javaRelease` (currently `"11"`) to match the project-wide bytecode target.
- **Port**: Uses `0` for auto-allocation to avoid conflicts, with `127.0.0.1` as default host to avoid IPv6 issues in CI.
- **Group**: `@Group("web")` consistent with `finagle-http`.
- **Versions**: http4k 5.47.0.0 (last v5, Java 11 compatible), Kotlin 2.1.20, sbt-kotlin-plugin 3.1.5.
- **Build**: `KotlinPlugin` disabled on incompatible projects (`twitter-finagle`, JMH wrappers).

## Test results

- `test` config (`server_threads=2, max_threads=2, workload_count=100`): ~1 sec/iteration
- `default` config (`server_threads=$cpu.count, workload_count=450`): ~4.5 sec/iteration
- JMH package builds successfully
- All pre-push checks pass (encoding, formatting, README)