### PR TITLE
scala-stm-bench7: fix STMBench7 bugs and add invariant + opacity validation

### DIFF
--- a/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/ScalaStmBench7.scala
+++ b/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/ScalaStmBench7.scala
@@ -5,15 +5,25 @@ import org.renaissance.Benchmark._
 import org.renaissance.BenchmarkContext
 import org.renaissance.BenchmarkResult
 import org.renaissance.BenchmarkResult.Validators
+import org.renaissance.BenchmarkResult.Assert
 import org.renaissance.License
 
 @Name("scala-stm-bench7")
 @Group("scala-stm")
-@Group("scala") // With Scala 3, the primary group goes last.
+@Group("scala")
 @Summary("Runs the stmbench7 benchmark using ScalaSTM.")
 @Licenses(Array(License.BSD3, License.GPL2))
 @Repetitions(60)
-@Parameter(name = "thread_count", defaultValue = "$cpu.count")
+@Parameter(
+  name = "thread_count",
+  defaultValue = "$cpu.count",
+  summary = "Number of worker threads to use"
+)
+@Parameter(
+  name = "operation_count",
+  defaultValue = "20",
+  summary = "Number of operations to perform"
+)
 @Configuration(name = "test")
 @Configuration(name = "jmh")
 final class ScalaStmBench7 extends Benchmark {
@@ -21,36 +31,104 @@ final class ScalaStmBench7 extends Benchmark {
   // TODO: Consolidate benchmark parameters across the suite.
   //  See: https://github.com/renaissance-benchmarks/renaissance/issues/27
 
-  private var stmBenchArgs: Array[String] = _
+  /**
+   * The STMBench7 benchmark instance.
+   * Initialized once in setUpBeforeAll, reused across iterations.
+   */
+  private var stmBench: stmbench7.Benchmark = _
+
+  /** Number of threads to use */
+  private var threadCount: Int = _
+
+  /**
+   * Duration in seconds (unused when operationCount > 0).
+   *
+   * Not used, operationCount preferred.
+   */
+  private var numSeconds: Int = _
+
+  /** Number of operations per thread per iteration */
+  private var operationCount: Int = _
+
+  /** Workload type: "r" (read-dominated), "rw" (read-write), "w" (write-dominated) */
+  private val Workload: String = "rw"
+
+  /** Synchronization type */
+  private val synchType: stmbench7.Parameters.SynchronizationType =
+    stmbench7.Parameters.SynchronizationType.STM
+
+  /** Full class name of STM initializer */
+  private val StmInitializer: String = "stmbench7.scalastm.ScalaSTMInitializer"
+
+  /** Enable long traversal operations */
+  private val LongTraversalsEnabled: Boolean = true
+
+  /** Enable structural modification operations */
+  private val StructureModificationEnabled: Boolean = true
+
+
+  private var SequentialReplayEnabled: Boolean = true
+
+  /** Whether to check opacity after each iteration */
+  private val CheckOpacity: Boolean = true
 
   override def setUpBeforeAll(c: BenchmarkContext): Unit = {
-    val threadCountParam = c.parameter("thread_count").toPositiveInteger
+    // Parse params
+    threadCount = c.parameter("thread_count").toPositiveInteger
+    operationCount = c.parameter("operation_count").toPositiveInteger
 
-    // The following is the description of STMBench7's arguments.
-    // -s -- the initializer class for the STM implementation
-    // -g -- the type of synchronization that the benchmark should use
-    // -w -- the type of the workload (we use the read/write workload)
-    // -c -- the count of operations to execute in the benchmark
-    // -t -- the number of threads to use
-    stmBenchArgs = Array(
-      "-s",
-      "stmbench7.scalastm.ScalaSTMInitializer",
-      "-g",
-      "stm",
-      "-w",
-      "rw",
-      "-c",
-      "20",
-      "-t",
-      threadCountParam.toString
+    // Initialize the random number generator phase
+
+
+    // Create the benchmark instance with all configuration.
+    stmBench = new stmbench7.Benchmark(
+      threadCount,                  // numThreads
+      numSeconds,                   // numSeconds (unused when countOfOperations > 0)
+      operationCount,               // countOfOperations
+      Workload,                     // workload: "r", "rw", or "w"
+      synchType,                    // synchronizationType enum
+      StmInitializer,               // STM initializer class
+      LongTraversalsEnabled,        // longTraversalsEnabled
+      StructureModificationEnabled, // structureModificationEnabled
+      SequentialReplayEnabled       // sequentialReplayEnabled
     )
   }
 
-  override def run(c: BenchmarkContext): BenchmarkResult = {
-    // TODO: Make the benchmark return something useful
-    stmbench7.Benchmark.main(stmBenchArgs)
+  override def setUpBeforeEach(c: BenchmarkContext): Unit = {
+    // Reset thread state for a fresh iteration.
+    // This recreates BenchThread instances with zeroed counters
+    // while reusing the expensive Setup data structure.
+    stmBench.resetForNextIteration()
+    stmBench.setupClone = null
 
-    // TODO: add proper validation
-    Validators.dummy()
+    // Create initial clone
+    // This must be done before start() so we have a copy of the initial state.
+    if (SequentialReplayEnabled && CheckOpacity) {
+      stmBench.createInitialClone()
+    }
+  }
+
+
+
+  override def run(c: BenchmarkContext): BenchmarkResult = {
+
+    stmBench.start()
+
+    () => {
+      val result = stmBench.validateInvariants(false)
+      Assert.assertEquals(true, result.invariantsValid, "invariants valid")
+      Assert.assertEquals(true, result.successfulOperations > 0, "successful_ops > 0")
+
+      if (CheckOpacity) {
+        val opacityResult = stmBench.checkOpacity()
+        Assert.assertEquals(true, opacityResult, "opacity check")
+      }
+    }
+  }
+  
+
+  override def tearDownAfterAll(c: BenchmarkContext): Unit = {
+    // Clean up
+    stmBench = null
   }
 }

--- a/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/ScalaStmBench7.scala
+++ b/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/ScalaStmBench7.scala
@@ -21,10 +21,10 @@ import org.renaissance.License
 )
 @Parameter(
   name = "operation_count",
-  defaultValue = "100",
+  defaultValue = "44",
   summary = "Number of operations to perform"
 )
-@Configuration(name = "test", settings = Array("operation_count = 20"))
+@Configuration(name = "test", settings = Array("operation_count = 5"))
 @Configuration(name = "jmh")
 final class ScalaStmBench7 extends Benchmark {
 
@@ -92,6 +92,13 @@ final class ScalaStmBench7 extends Benchmark {
       StructureModificationEnabled, // structureModificationEnabled
       SequentialReplayEnabled       // sequentialReplayEnabled
     )
+
+    // Clone once, while setup is still pristine. resetForNextIteration()
+    // reuses setup across iterations instead of rebuilding it, and each
+    // checkOpacity() keeps setupClone in sync, so it never needs redoing.
+    if (SequentialReplayEnabled && CheckOpacity) {
+      stmBench.createInitialClone()
+    }
   }
 
   override def setUpBeforeEach(c: BenchmarkContext): Unit = {
@@ -99,13 +106,6 @@ final class ScalaStmBench7 extends Benchmark {
     // This recreates BenchThread instances with zeroed counters
     // while reusing the expensive Setup data structure.
     stmBench.resetForNextIteration()
-    stmBench.setupClone = null
-
-    // Create initial clone
-    // This must be done before start() so we have a copy of the initial state.
-    if (SequentialReplayEnabled && CheckOpacity) {
-      stmBench.createInitialClone()
-    }
   }
 
 

--- a/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/ScalaStmBench7.scala
+++ b/benchmarks/scala-stm/src/main/scala/org/renaissance/scala/stm/ScalaStmBench7.scala
@@ -21,10 +21,10 @@ import org.renaissance.License
 )
 @Parameter(
   name = "operation_count",
-  defaultValue = "20",
+  defaultValue = "100",
   summary = "Number of operations to perform"
 )
-@Configuration(name = "test")
+@Configuration(name = "test", settings = Array("operation_count = 20"))
 @Configuration(name = "jmh")
 final class ScalaStmBench7 extends Benchmark {
 

--- a/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/AtomicPartImpl.scala
+++ b/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/AtomicPartImpl.scala
@@ -19,18 +19,18 @@ class AtomicPartImpl(id0: Int, typ0: String, bd0: Int, x0: Int, y0: Int)
   private val y = Ref(y0)
   private val partOf = Ref(null: CompositePart).single
   private val from = TSet.empty[Connection].single // this is the equivalent of SmallSetImpl
-  private val to = TSet.empty[Connection].single
+  private val to = Ref(List.empty[Connection]).single
 
   override def connectTo(dest: AtomicPart, typ: String, length: Int): Unit = {
     val c = new ConnectionImpl(this, dest, typ, length)
-    to += c
+    to.transform(_ :+ c)
     dest.addConnectionFromOtherPart(c.getReversed)
   }
 
   override def addConnectionFromOtherPart(c: Connection): Unit = { from += c }
   override def setCompositePart(po: CompositePart): Unit = { partOf() = po }
-  override def getNumToConnections: Int = to.size
-  override def getToConnections = new ImmutableSetImpl[Connection](to)
+  override def getNumToConnections: Int = to().size
+  override def getToConnections = new ImmutableSeqImpl[Connection](to())
   override def getFromConnections = new ImmutableSetImpl[Connection](from)
   override def getPartOf: CompositePart = partOf()
 
@@ -46,7 +46,7 @@ class AtomicPartImpl(id0: Int, typ0: String, bd0: Int, x0: Int, y0: Int)
     atomic { implicit t =>
       x() = 0
       y() = 0
-      to.clear()
+      to() = null
       from.clear()
       partOf() = null
     }

--- a/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/BaseAssemblyImpl.scala
+++ b/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/BaseAssemblyImpl.scala
@@ -22,7 +22,7 @@ class BaseAssemblyImpl(
     Ref(List.empty[CompositePart]).single // the original BagImpl was just an ArrayList
 
   override def addComponent(component: CompositePart): Unit = {
-    components.transform(component :: _)
+    components.transform(_ :+ component)
     component.addAssembly(this)
   }
 
@@ -35,6 +35,12 @@ class BaseAssemblyImpl(
   }
 
   override def getComponents = new ImmutableSeqImpl[CompositePart](components())
+
+  override def equals(obj: Any): Boolean = obj match {
+    case d: BaseAssembly => d.getId == id
+    case _ => false
+  }
+  override def hashCode(): Int = id
 
   override def clearPointers(): Unit = {
     super.clearPointers()

--- a/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/ComplexAssemblyImpl.scala
+++ b/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/ComplexAssemblyImpl.scala
@@ -2,7 +2,7 @@
 
 package stmbench7.scalastm
 
-import scala.concurrent.stm.TSet
+import scala.concurrent.stm.Ref
 
 import stmbench7.Parameters
 import stmbench7.core.Assembly
@@ -20,26 +20,36 @@ class ComplexAssemblyImpl(
 ) extends AssemblyImpl(id, typ, buildDate, module, superAssembly)
   with ComplexAssembly {
 
-  private val subAssemblies = TSet.empty[Assembly].single
+  private val subAssemblies = Ref(List.empty[Assembly]).single
 
   private val level =
     if (superAssembly == null) Parameters.NumAssmLevels else superAssembly.getLevel - 1
 
   override def addSubAssembly(assembly: Assembly): Boolean = {
     if (assembly.isInstanceOf[BaseAssembly] && level != 2)
-      throw new RuntimeError("ComplexAssembly.addAssembly: BaseAssembly at wrong level!");
-
-    subAssemblies.add(assembly)
+      throw new RuntimeError("ComplexAssembly.addAssembly: BaseAssembly at wrong level!")
+    subAssemblies.transformIfDefined {
+      case x if !x.contains(assembly) => x :+ assembly
+    }
   }
 
-  override def removeSubAssembly(assembly: Assembly): Boolean = subAssemblies.remove(assembly)
+  override def removeSubAssembly(assembly: Assembly): Boolean =
+    subAssemblies.transformIfDefined {
+      case x if x.contains(assembly) => x.filterNot(_ == assembly)
+    }
 
-  override def getSubAssemblies = new ImmutableSetImpl[Assembly](subAssemblies)
+  override def getSubAssemblies = new ImmutableSeqImpl[Assembly](subAssemblies())
 
   override def getLevel: Short = level.asInstanceOf[Short]
 
+  override def equals(obj: Any): Boolean = obj match {
+    case d: ComplexAssembly => d.getId == id
+    case _ => false
+  }
+  override def hashCode(): Int = id
+
   override def clearPointers(): Unit = {
     super.clearPointers()
-    subAssemblies.clear()
+    subAssemblies() = null
   }
 }

--- a/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/CompositePartImpl.scala
+++ b/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/CompositePartImpl.scala
@@ -22,7 +22,7 @@ class CompositePartImpl(id: Int, typ: String, buildDate: Int, documentation0: Do
 
   documentation0.setPart(this)
 
-  override def addAssembly(assembly: BaseAssembly): Unit = { usedIn.transform(assembly :: _) }
+  override def addAssembly(assembly: BaseAssembly): Unit = { usedIn.transform(_ :+ assembly) }
 
   override def addPart(part: AtomicPart): Boolean = {
     val f = parts().add(part)

--- a/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/DesignObjImpl.scala
+++ b/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/DesignObjImpl.scala
@@ -14,4 +14,10 @@ class DesignObjImpl(id: Int, typ: String, buildDate0: Int) extends DesignObj {
   override def getBuildDate: Int = bd()
   override def updateBuildDate(): Unit = { if (bd() % 2 == 0) bd -= 1 else bd += 1 }
   override def nullOperation(): Unit = {}
+
+  override def equals(obj: Any): Boolean = obj match {
+    case d: DesignObj => d.getId == id
+    case _ => false
+  }
+  override def hashCode(): Int = id
 }

--- a/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/DocumentImpl.scala
+++ b/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/DocumentImpl.scala
@@ -37,4 +37,10 @@ class DocumentImpl(id: Int, title: String, text0: String) extends Document {
   }
 
   override def textBeginsWith(prefix: String): Boolean = text().startsWith(prefix)
+
+  override def equals(obj: Any): Boolean = obj match {
+    case d: Document => d.getDocumentId == id
+    case _ => false
+  }
+  override def hashCode(): Int = id
 }

--- a/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/LargeSetImpl.scala
+++ b/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/LargeSetImpl.scala
@@ -15,5 +15,6 @@ class LargeSetImpl[A <: Comparable[A]] extends LargeSet[A] {
   override def remove(e: A): Boolean = underlying.remove(e).isDefined
   override def contains(e: A): Boolean = underlying.contains(e)
   override def size: Int = underlying.size
-  override def iterator: java.util.Iterator[A] = underlying.keysIterator.asJava
+  override def iterator: java.util.Iterator[A] =
+    underlying.keysIterator.toSeq.sortWith(_.compareTo(_) < 0).iterator.asJava
 }

--- a/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/ScalaSTMInitializer.scala
+++ b/benchmarks/scala-stm/src/main/scala/stmbench7/scalastm/ScalaSTMInitializer.scala
@@ -7,6 +7,9 @@ import scala.annotation.unused
 import scala.concurrent.stm.atomic
 import scala.concurrent.stm.Ref
 
+import stmbench7.core.OperationFailedException
+import stmbench7.ThreadRandom
+
 import stmbench7.OperationExecutor
 import stmbench7.OperationExecutorFactory
 import stmbench7.Parameters
@@ -38,13 +41,37 @@ class ScalaSTMInitializer extends SynchMethodInitializer {
           private var lastTS = 0
 
           def execute(): Int = {
-            atomic { implicit t =>
-              val z = op.performOperation()
-              if (Parameters.sequentialReplayEnabled) {
-                timestamp += 1
-                lastTS = timestamp()
+            // Save state before the transaction so that restoreState() inside
+            // the atomic block has a valid savedState to restore from, both on
+            // the first attempt and on every STM retry.
+            if (Parameters.sequentialReplayEnabled) ThreadRandom.saveState()
+            try {
+              atomic { implicit t =>
+                if (Parameters.sequentialReplayEnabled) {
+                  // On each STM retry restore to the pre-transaction state and
+                  // immediately save it again, so the next retry also restores
+                  // to the same point.  After a successful commit the
+                  // ThreadRandom state reflects exactly one execution of
+                  // performOperation, matching sequential replay.
+                  ThreadRandom.restoreState()
+                  ThreadRandom.saveState()
+                }
+                val z = op.performOperation()
+                if (Parameters.sequentialReplayEnabled) {
+                  timestamp += 1
+                  lastTS = timestamp()
+                }
+                z
               }
-              z
+            } catch {
+              case e: OperationFailedException =>
+                if (Parameters.sequentialReplayEnabled) {
+                  atomic { implicit t =>
+                    timestamp += 1
+                    lastTS = timestamp()
+                  }
+                }
+                throw e
             }
           }
 

--- a/benchmarks/scala-stm/stmbench7/src/main/java/stmbench7/BenchThread.java
+++ b/benchmarks/scala-stm/stmbench7/src/main/java/stmbench7/BenchThread.java
@@ -30,14 +30,16 @@ public class BenchThread implements Runnable {
 		public final int timestamp, result;
 		public final boolean failed;
 		public final int opNum;
+		public final long callCountBefore;  // random call count BEFORE getNextOperationNumber
 
 		public ReplayLogEntry(int timestamp, int result, boolean failed,
-				int opNum) {
+				int opNum, long callCountBefore) {
 			this.threadNum = myThreadNum;
 			this.timestamp = timestamp;
 			this.result = result;
 			this.failed = failed;
 			this.opNum = opNum;
+			this.callCountBefore = callCountBefore;
 		}
 
 		public int compareTo(ReplayLogEntry entry) {
@@ -78,6 +80,7 @@ public class BenchThread implements Runnable {
 		while (!stop && opIndex < countOfOperations) {
 			opIndex++;
 			//if (i++ > 55) continue;
+			long callCountBefore = Parameters.sequentialReplayEnabled ? ThreadRandom.getCallCount() : 0;
 			int operationNumber = getNextOperationNumber(opIndex);
 
 			// OperationType type = OperationId.values()[operationNumber].getType();
@@ -92,6 +95,12 @@ public class BenchThread implements Runnable {
 			OperationExecutor currentExecutor = operations[operationNumber];
 			int result = 0;
 			boolean failed = false;
+
+			// Save ThreadRandom state so that a failed operation can be rolled
+			// back, matching the save/restore behaviour of SequentialReplayThread.
+			if (Parameters.sequentialReplayEnabled) {
+				ThreadRandom.saveState();
+			}
 
 			try {
 				long startTime = System.currentTimeMillis();
@@ -116,12 +125,17 @@ public class BenchThread implements Runnable {
 			} catch (OperationFailedException e) {
 				failedOperations[operationNumber]++;
 				failed = true;
+				// Restore ThreadRandom so the next getNextOperationNumber uses the
+				// same state as if the failed operation never ran.
+				if (Parameters.sequentialReplayEnabled) {
+					ThreadRandom.restoreState();
+				}
 			}
 
 			if (Parameters.sequentialReplayEnabled) {
 				ReplayLogEntry newEntry = new ReplayLogEntry(
 						currentExecutor.getLastOperationTimestamp(), result, failed,
-						operationNumber);
+						operationNumber, callCountBefore);
 				replayLog.add(newEntry);
 				//System.out.println("ts: " + newEntry.timestamp);
 			}
@@ -159,9 +173,13 @@ public class BenchThread implements Runnable {
 		}
 	}
 
+	//TODO
+	/*
+	* random seed
+	* do not do modulo 20
+	* */
 	protected int getNextOperationNumber(int iteration) {
-		// double whichOperation = ThreadRandom.nextDouble();
-		double whichOperation = (iteration % 20) / 20.0;
+		double whichOperation = ThreadRandom.nextDouble();
 		int operationNumber = 0;
 		while (whichOperation >= operationCDF[operationNumber])
 			operationNumber++;

--- a/benchmarks/scala-stm/stmbench7/src/main/java/stmbench7/Benchmark.java
+++ b/benchmarks/scala-stm/stmbench7/src/main/java/stmbench7/Benchmark.java
@@ -1,7 +1,7 @@
 package stmbench7;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Formatter;
 
 import stmbench7.annotations.NonAtomic;
@@ -16,549 +16,785 @@ import stmbench7.impl.NoSynchronizationInitializer;
 import stmbench7.ThreadRandom.Phase;
 
 /**
- * STMBench7 benchmark, the main program. 
+ * STMBench7 benchmark, the main program.
  * Run with argument "-h" or "--help" to see the syntax.
- * 
- * TODO: The class got too large and needs some careful refactoring.
- * TODO: An XML output of the benchmark results would be helpful.
+ *
+ * Modified for Renaissance benchmark suite integration.
  */
 @NonAtomic
 public class Benchmark {
 
 	public static final String VERSION = "1.0(15.02.2011)";
-	
-	class BenchmarkParametersException extends Exception {
+
+	public class BenchmarkParametersException extends Exception {
 		private static final long serialVersionUID = 6341915439489283553L;
 
 		public BenchmarkParametersException(String message, Exception cause) {
 			super(message + ": " + cause.toString());
 		}
-		
+
 		public BenchmarkParametersException(String message) {
 			super(message);
 		}
-		
+
 		public BenchmarkParametersException() {
 			super("");
 		}
 	}
-	
-    public static void main(String[] args) throws InterruptedException {
-    	Benchmark benchmark = null;
-      ThreadRandom.phase = Phase.INIT;
 
-    	try {
-    		benchmark = new Benchmark(args);
-    	}
-    	catch(BenchmarkParametersException e) {
-    		System.err.println(e.getMessage());
-    		System.exit(1);
-    	}
+	/**
+	 * Result container for benchmark execution.
+	 */
+	public static class Result {
+		public final int successfulOperations;
+		public final int failedOperations;
+		public final double elapsedTime;
+		public final boolean invariantsValid;
+		public final String validationError;
 
-    	//benchmark.checkInvariants(true);
-    	benchmark.createInitialClone();
-    	benchmark.start();
-    	//benchmark.checkInvariants(false);
-    	//benchmark.checkOpacity();
-    	benchmark.showTTCHistograms();
-    	benchmark.showStats();
-    }
+		public Result(int successful, int failed, double elapsed) {
+			this(successful, failed, elapsed, true, null);
+		}
 
-    private SynchMethodInitializer synchMethodInitializer;
-    private boolean printTTCHistograms = false;
-    private double[] operationCDF;
-    private BenchThread[] benchThreads;
-    private Thread[] threads;
-    private Setup setup, setupClone;
-    private double elapsedTime;
-    private int countOfOperations;
-
-    private Benchmark(String[] args) throws BenchmarkParametersException, InterruptedException {
-    	printHeader();
-    	
-    	parseCommandLineParameters(args);
-    	printRunTimeParametersInformation();
-    	
-    	generateOperationCDF();
-    	setupStructures();
+		public Result(int successful, int failed, double elapsed, boolean invariantsValid, String validationError) {
+			this.successfulOperations = successful;
+			this.failedOperations = failed;
+			this.elapsedTime = elapsed;
+			this.invariantsValid = invariantsValid;
+			this.validationError = validationError;
+		}
 	}
-    
-    private void printHeader() {
-    	String header =
-	    "The STMBench7 Benchmark (Java version)\n" +
-	    "A benchmark for comparing synchronization techniques\n" +
-	    "Version: " + VERSION + "\n" +
-	    "More information: http://lpd.epfl.ch/site/research/tmeval\n" +
-	    "Copyright (C) 2006-2008 LPD, I&C, EPFL (http://lpd.epfl.ch)\n" +
-	    "Implemented by Michal Kapalka (http://kapalka.eu)\n"+
-	    "Updated by Vincent Gramoli for compliance with the VELOX stack";
-    	
-    	printLine('=');
-    	System.out.println(header);
-    	printLine('=');
-    	System.out.println();
-    }
 
-    @SuppressWarnings("unchecked")
-	private void parseCommandLineParameters(String[] args) throws BenchmarkParametersException {
-    	int argNumber = 0;
-   		String workload = null, synchType = null, stmInitializerClassName = null;
+	// Original main method preserved for standalone usage
+	public static void main(String[] args) throws InterruptedException {
+		Benchmark benchmark = null;
+		ThreadRandom.phase = Phase.INIT;
 
-   		while(argNumber < args.length) {
-    		String currentArg = args[argNumber++];
+		try {
+			benchmark = new Benchmark(args);
+		}
+		catch(BenchmarkParametersException e) {
+			System.err.println(e.getMessage());
+			System.exit(1);
+		}
 
-    		try {
-    			if(currentArg.equals("--help") || currentArg.equals("-h")) {
-    				printSyntax();
-    				throw new BenchmarkParametersException();
-    			}
-    			else if(currentArg.equals("--no-traversals")) Parameters.longTraversalsEnabled = false;
-    			else if(currentArg.equals("--no-sms")) Parameters.structureModificationEnabled = false;
-    			else if(currentArg.equals("--ttc-histograms")) printTTCHistograms = true;
-    			else if(currentArg.equals("--seq-replay")) Parameters.sequentialReplayEnabled = true;
-    			else if(currentArg.equals("--")) {
-    				Parameters.stmCommandLineParameters = new String[args.length - argNumber];
-    				int stmArgNum = 0;
-    				while(argNumber < args.length) 
-    					Parameters.stmCommandLineParameters[stmArgNum++] = args[argNumber++];
-    				break;
-    			}
-    			else {
-    				String optionValue = args[argNumber++];
-    				if(currentArg.equals("-t")) Parameters.numThreads = Integer.parseInt(optionValue);
-    				else if(currentArg.equals("-l")) Parameters.numSeconds = Integer.parseInt(optionValue);
-    				else if(currentArg.equals("-w")) workload = optionValue;
-    				else if(currentArg.equals("-g")) synchType = optionValue;
-    				else if(currentArg.equals("-s")) stmInitializerClassName = optionValue;
-    				else if(currentArg.equals("-c")) countOfOperations = Integer.parseInt(optionValue);
-    				else throw new BenchmarkParametersException("Invalid option: " + currentArg);
-    			}
-    		}
-    		catch(IndexOutOfBoundsException e) {
-    			throw new BenchmarkParametersException("Missing value after option: " + currentArg);
-    		}
-    		catch(NumberFormatException e) {
-    			throw new BenchmarkParametersException("Number expected after option: " + currentArg);
-    		}
-    	}
-    	
-    	if(workload != null) {
-    		if(workload.equals("r")) 
-    			Parameters.workloadType = Parameters.WorkloadType.READ_DOMINATED;
-    		else if(workload.equals("rw")) 
-    			Parameters.workloadType = Parameters.WorkloadType.READ_WRITE;
-    		else if(workload.equals("w")) 
-    			Parameters.workloadType = Parameters.WorkloadType.WRITE_DOMINATED;
-    		else throw new BenchmarkParametersException("Invalid workload type: " + workload);
-    	}
-    	
-    	if(synchType != null) {
-    		if(synchType.equals("coarse")) 
-    			Parameters.synchronizationType = Parameters.SynchronizationType.LOCK_COARSE;
-    		else if(synchType.equals("medium")) 
-    			Parameters.synchronizationType = Parameters.SynchronizationType.LOCK_MEDIUM;
-    		else if(synchType.equals("fine")) 
-    			Parameters.synchronizationType = Parameters.SynchronizationType.LOCK_FINE;
-    		else if(synchType.equals("none")) 
-    			Parameters.synchronizationType = Parameters.SynchronizationType.NONE;
-    		else if(synchType.equals("stm"))
-    			Parameters.synchronizationType = Parameters.SynchronizationType.STM;
-    		else throw new BenchmarkParametersException("Invalid lock granularity: " + synchType);
-    	}
-    	
-    	Class<? extends SynchMethodInitializer> synchMethodInitializerClass = null;
-    	switch(Parameters.synchronizationType) {
-    	case NONE:
-    		synchMethodInitializerClass = ImplParameters.noSynchronizationInitializerClass;
-    		break;
-    	case LOCK_COARSE:
-    		synchMethodInitializerClass = ImplParameters.coarseGrainedLockingInitializerClass;
-    		break;
-    	case LOCK_MEDIUM:
-    		synchMethodInitializerClass = ImplParameters.mediumGrainedLockingInitializerClass;
-    		break;
-    	case LOCK_FINE:
-    		synchMethodInitializerClass = ImplParameters.fineGrainedLockingInitializerClass;
-    		break;
-    	case STM:
-    		if(stmInitializerClassName != null) {
-    			try {
-        			synchMethodInitializerClass =
-        				(Class<? extends SynchMethodInitializer>) 
-        					Class.forName(stmInitializerClassName);    				
-    			}
-    			catch(ClassNotFoundException e) {
-    				throw new BenchmarkParametersException("Error instantiating the STM" +
-    						" initializer class", e);
-    			}
-    		}
-    		else if(ImplParameters.defaultSTMInitializerClass != null) {
-    			synchMethodInitializerClass = ImplParameters.defaultSTMInitializerClass;
-    		}
-    		else throw new BenchmarkParametersException("STM initializer class name not given" +
-    				" and a default class not specified" +
-    				" in ImpParameters.defaultSTMInitializerClass");
-    		break;
-    	}
+		benchmark.createInitialClone();
+		benchmark.start();
+		benchmark.showTTCHistograms();
+		benchmark.showStats();
+	}
+
+	// Made public for external access
+	public SynchMethodInitializer synchMethodInitializer;
+	public boolean printTTCHistograms = false;
+	public double[] operationCDF;
+	public BenchThread[] benchThreads;
+	public Thread[] threads;
+	public Setup setup, setupClone;
+	public double elapsedTime;
+	public int countOfOperations;
+
+	/**
+	 * Original constructor for command-line usage.
+	 */
+	private Benchmark(String[] args) throws BenchmarkParametersException, InterruptedException {
+		printHeader();
+
+		parseCommandLineParameters(args);
+		printRunTimeParametersInformation();
+
+		generateOperationCDF();
+		setupStructures();
+	}
+
+	/**
+	 * API constructor for programmatic usage (e.g., from Renaissance benchmark suite).
+	 *
+	 * @param numThreads Number of threads to use
+	 * @param numSeconds Duration in seconds (used if countOfOperations <= 0)
+	 * @param countOfOperations Number of operations per thread (if > 0, overrides numSeconds)
+	 * @param workload Workload type: "r" (read-dominated), "rw" (read-write), "w" (write-dominated)
+	 * @param synchronizationType Synchronization type enum value
+	 * @param stmInitializerClassName Full class name of STM initializer (required if synchronizationType is STM)
+	 * @param longTraversalsEnabled Enable long traversal operations
+	 * @param structureModificationEnabled Enable structural modification operations
+	 * @param sequentialReplayEnabled Enable sequential replay for opacity checking
+	 */
+	public Benchmark(
+			int numThreads,
+			int numSeconds,
+			int countOfOperations,
+			String workload,
+			Parameters.SynchronizationType synchronizationType,
+			String stmInitializerClassName,
+			boolean longTraversalsEnabled,
+			boolean structureModificationEnabled,
+			boolean sequentialReplayEnabled
+	) throws BenchmarkParametersException, InterruptedException {
+
+		// Set parameters directly
+		Parameters.numThreads = numThreads;
+		Parameters.numSeconds = numSeconds;
+		this.countOfOperations = countOfOperations;
+		Parameters.longTraversalsEnabled = longTraversalsEnabled;
+		Parameters.structureModificationEnabled = structureModificationEnabled;
+		Parameters.sequentialReplayEnabled = sequentialReplayEnabled;
+		Parameters.synchronizationType = synchronizationType;
+
+		// Parse workload type
+		if (workload != null) {
+			if (workload.equals("r"))
+				Parameters.workloadType = Parameters.WorkloadType.READ_DOMINATED;
+			else if (workload.equals("rw"))
+				Parameters.workloadType = Parameters.WorkloadType.READ_WRITE;
+			else if (workload.equals("w"))
+				Parameters.workloadType = Parameters.WorkloadType.WRITE_DOMINATED;
+			else
+				throw new BenchmarkParametersException("Invalid workload type: " + workload);
+		}
+
+		// Initialize synchronization method
+		initializeSynchMethod(stmInitializerClassName);
+
+		// Generate operation probability distribution
+		generateOperationCDF();
+
+		// Setup benchmark data structures
+		setupStructures();
+	}
+
+	/**
+	 * Initialize the synchronization method based on configuration.
+	 */
+	@SuppressWarnings("unchecked")
+	private void initializeSynchMethod(String stmInitializerClassName) throws BenchmarkParametersException {
+		Class<? extends SynchMethodInitializer> synchMethodInitializerClass = null;
+
+		switch(Parameters.synchronizationType) {
+			case NONE:
+				synchMethodInitializerClass = ImplParameters.noSynchronizationInitializerClass;
+				break;
+			case LOCK_COARSE:
+				synchMethodInitializerClass = ImplParameters.coarseGrainedLockingInitializerClass;
+				break;
+			case LOCK_MEDIUM:
+				synchMethodInitializerClass = ImplParameters.mediumGrainedLockingInitializerClass;
+				break;
+			case LOCK_FINE:
+				synchMethodInitializerClass = ImplParameters.fineGrainedLockingInitializerClass;
+				break;
+			case STM:
+				if (stmInitializerClassName != null) {
+					try {
+						synchMethodInitializerClass =
+								(Class<? extends SynchMethodInitializer>)
+										Class.forName(stmInitializerClassName);
+					}
+					catch(ClassNotFoundException e) {
+						throw new BenchmarkParametersException(
+								"Error instantiating the STM initializer class", e);
+					}
+				}
+				else if (ImplParameters.defaultSTMInitializerClass != null) {
+					synchMethodInitializerClass = ImplParameters.defaultSTMInitializerClass;
+				}
+				else {
+					throw new BenchmarkParametersException(
+							"STM initializer class name not given and a default class not specified" +
+									" in ImplParameters.defaultSTMInitializerClass");
+				}
+				break;
+		}
+
 		try {
 			synchMethodInitializer =
-				synchMethodInitializerClass.getDeclaredConstructor().newInstance();
+					synchMethodInitializerClass.getDeclaredConstructor().newInstance();
 		}
 		catch(Exception e) {
 			throw new BenchmarkParametersException("Error instantiating STM initializer class", e);
 		}
-		
+
 		setFactoryInstances(synchMethodInitializer);
 	}
 
-    private void setFactoryInstances(SynchMethodInitializer synchMethodInitializer) {
+	/**
+	 * Reset benchmark state for a new iteration.
+	 * Recreates BenchThread instances with fresh counters while reusing the Setup.
+	 */
+	public void resetForNextIteration() {
+		for (int i = 0; i < benchThreads.length; i++) {
+			benchThreads[i] = new BenchThread(setup, operationCDF, (short) i, countOfOperations);
+			threads[i] = ThreadFactory.instance.createThread(benchThreads[i]);
+		}
+		// Reset operation type statistics
+		for (OperationType type : OperationType.values()) {
+			type.successfulOperations = 0;
+			type.failedOperations = 0;
+			type.maxttc = 0;
+		}
+		ThreadRandom.phase = stmbench7.ThreadRandom.Phase.INIT;
+	}
+
+	/**
+	 * Run the benchmark and return results.
+	 * This is the main execution method for API usage.
+	 */
+	public Result start() throws InterruptedException {
+		System.err.println("\nBenchmark started.");
+		ThreadRandom.startConcurrentPhase();
+
+		long startTime = System.currentTimeMillis();
+
+		for (Thread thread : threads) {
+			thread.start();
+		}
+
+		for (Thread thread : threads) {
+			thread.join();
+		}
+
+		//zrusit meranie casu?
+		long endTime = System.currentTimeMillis();
+		elapsedTime = ((double)(endTime - startTime)) / 1000.0;
+		System.err.println("Benchmark completed.\n");
+
+		return computeResult();
+	}
+
+	/**
+	 * Compute and return the benchmark results.
+	 */
+	public Result computeResult() {
+		int totalSuccessful = 0;
+		int totalFailed = 0;
+
+		OperationId[] operations = OperationId.values();
+		for (OperationId operation : operations) {
+			int opNumber = operation.ordinal();
+			for (BenchThread thread : benchThreads) {
+				totalSuccessful += thread.successfulOperations[opNumber];
+				totalFailed += thread.failedOperations[opNumber];
+			}
+		}
+
+		return new Result(totalSuccessful, totalFailed, elapsedTime);
+	}
+
+	// ==================== Original methods below ====================
+
+	private void printHeader() {
+		String header =
+				"The STMBench7 Benchmark (Java version)\n" +
+						"A benchmark for comparing synchronization techniques\n" +
+						"Version: " + VERSION + "\n" +
+						"More information: http://lpd.epfl.ch/site/research/tmeval\n" +
+						"Copyright (C) 2006-2008 LPD, I&C, EPFL (http://lpd.epfl.ch)\n" +
+						"Implemented by Michal Kapalka (http://kapalka.eu)\n"+
+						"Updated by Vincent Gramoli for compliance with the VELOX stack";
+
+		printLine('=');
+		System.out.println(header);
+		printLine('=');
+		System.out.println();
+	}
+
+	@SuppressWarnings("unchecked")
+	private void parseCommandLineParameters(String[] args) throws BenchmarkParametersException {
+		int argNumber = 0;
+		String workload = null, synchType = null, stmInitializerClassName = null;
+
+		while(argNumber < args.length) {
+			String currentArg = args[argNumber++];
+
+			try {
+				if(currentArg.equals("--help") || currentArg.equals("-h")) {
+					printSyntax();
+					throw new BenchmarkParametersException();
+				}
+				else if(currentArg.equals("--no-traversals")) Parameters.longTraversalsEnabled = false;
+				else if(currentArg.equals("--no-sms")) Parameters.structureModificationEnabled = false;
+				else if(currentArg.equals("--ttc-histograms")) printTTCHistograms = true;
+				else if(currentArg.equals("--seq-replay")) Parameters.sequentialReplayEnabled = true;
+				else if(currentArg.equals("--")) {
+					Parameters.stmCommandLineParameters = new String[args.length - argNumber];
+					int stmArgNum = 0;
+					while(argNumber < args.length)
+						Parameters.stmCommandLineParameters[stmArgNum++] = args[argNumber++];
+					break;
+				}
+				else {
+					String optionValue = args[argNumber++];
+					if(currentArg.equals("-t")) Parameters.numThreads = Integer.parseInt(optionValue);
+					else if(currentArg.equals("-l")) Parameters.numSeconds = Integer.parseInt(optionValue);
+					else if(currentArg.equals("-w")) workload = optionValue;
+					else if(currentArg.equals("-g")) synchType = optionValue;
+					else if(currentArg.equals("-s")) stmInitializerClassName = optionValue;
+					else if(currentArg.equals("-c")) countOfOperations = Integer.parseInt(optionValue);
+					else throw new BenchmarkParametersException("Invalid option: " + currentArg);
+				}
+			}
+			catch(IndexOutOfBoundsException e) {
+				throw new BenchmarkParametersException("Missing value after option: " + currentArg);
+			}
+			catch(NumberFormatException e) {
+				throw new BenchmarkParametersException("Number expected after option: " + currentArg);
+			}
+		}
+
+		if(workload != null) {
+			if(workload.equals("r"))
+				Parameters.workloadType = Parameters.WorkloadType.READ_DOMINATED;
+			else if(workload.equals("rw"))
+				Parameters.workloadType = Parameters.WorkloadType.READ_WRITE;
+			else if(workload.equals("w"))
+				Parameters.workloadType = Parameters.WorkloadType.WRITE_DOMINATED;
+			else throw new BenchmarkParametersException("Invalid workload type: " + workload);
+		}
+
+		if(synchType != null) {
+			if(synchType.equals("coarse"))
+				Parameters.synchronizationType = Parameters.SynchronizationType.LOCK_COARSE;
+			else if(synchType.equals("medium"))
+				Parameters.synchronizationType = Parameters.SynchronizationType.LOCK_MEDIUM;
+			else if(synchType.equals("fine"))
+				Parameters.synchronizationType = Parameters.SynchronizationType.LOCK_FINE;
+			else if(synchType.equals("none"))
+				Parameters.synchronizationType = Parameters.SynchronizationType.NONE;
+			else if(synchType.equals("stm"))
+				Parameters.synchronizationType = Parameters.SynchronizationType.STM;
+			else throw new BenchmarkParametersException("Invalid lock granularity: " + synchType);
+		}
+
+		Class<? extends SynchMethodInitializer> synchMethodInitializerClass = null;
+		switch(Parameters.synchronizationType) {
+			case NONE:
+				synchMethodInitializerClass = ImplParameters.noSynchronizationInitializerClass;
+				break;
+			case LOCK_COARSE:
+				synchMethodInitializerClass = ImplParameters.coarseGrainedLockingInitializerClass;
+				break;
+			case LOCK_MEDIUM:
+				synchMethodInitializerClass = ImplParameters.mediumGrainedLockingInitializerClass;
+				break;
+			case LOCK_FINE:
+				synchMethodInitializerClass = ImplParameters.fineGrainedLockingInitializerClass;
+				break;
+			case STM:
+				if(stmInitializerClassName != null) {
+					try {
+						synchMethodInitializerClass =
+								(Class<? extends SynchMethodInitializer>)
+										Class.forName(stmInitializerClassName);
+					}
+					catch(ClassNotFoundException e) {
+						throw new BenchmarkParametersException("Error instantiating the STM" +
+								" initializer class", e);
+					}
+				}
+				else if(ImplParameters.defaultSTMInitializerClass != null) {
+					synchMethodInitializerClass = ImplParameters.defaultSTMInitializerClass;
+				}
+				else throw new BenchmarkParametersException("STM initializer class name not given" +
+							" and a default class not specified" +
+							" in ImpParameters.defaultSTMInitializerClass");
+				break;
+		}
+		try {
+			synchMethodInitializer =
+					synchMethodInitializerClass.getDeclaredConstructor().newInstance();
+		}
+		catch(Exception e) {
+			throw new BenchmarkParametersException("Error instantiating STM initializer class", e);
+		}
+
+		setFactoryInstances(synchMethodInitializer);
+	}
+
+	public void setFactoryInstances(SynchMethodInitializer synchMethodInitializer) {
 		DesignObjFactory.setInstance(synchMethodInitializer.createDesignObjFactory());
 		BackendFactory.setInstance(synchMethodInitializer.createBackendFactory());
 		OperationExecutorFactory.setInstance(synchMethodInitializer.createOperationExecutorFactory());
-		ThreadFactory.setInstance(synchMethodInitializer.createThreadFactory());    	
-    }
-    
-    private void printRunTimeParametersInformation() {
-    	printSection("Benchmark parameters");
-    	
-    	System.out.println("Number of threads: " + Parameters.numThreads + "\n" +
-    			"Length: " + Parameters.numSeconds + " s\n" +
-    			"Workload: " + Parameters.workloadType + "\n" +
-    			"Synchronization method: " + Parameters.synchronizationType + "\n" +
-    			"Long traversals " + (Parameters.longTraversalsEnabled ? "enabled" : "disabled") + "\n" +
-    			"Structural modification operations " + 
-    				(Parameters.structureModificationEnabled ? "enabled" : "disabled") + "\n" + 
-    			"DesignObjFactory: " + DesignObjFactory.instance.getClass().getName() + "\n" +
-    			"BackendFactory: " + BackendFactory.instance.getClass().getName() + "\n" +
-    			"OperationExecutorFactory: " + 
-    			OperationExecutorFactory.instance.getClass().getName() + "\n" +
-    			"ThreadFactory: " + ThreadFactory.instance.getClass().getName() + "\n" +
-    			"Sequential replay " + (Parameters.sequentialReplayEnabled ? "enabled" : "disabled"));
-    	
-    	System.out.print("STM-specific parameters:");
-    	if(Parameters.stmCommandLineParameters == null) System.out.print(" none");
-    	else for(String parameter : Parameters.stmCommandLineParameters) 
-    		System.out.print(" " + parameter);
-    	System.out.println("\n");	
-    }
-    
-    private void generateOperationCDF() {
-    	double shortTraversalsRatio = (double)Parameters.ShortTraversalsRatio / 100.0, 
-    	operationsRatio = (double)Parameters.OperationsRatio / 100.0;
-    	
-    	double traversalsRatio, structuralModificationsRatio;
-    	if(Parameters.longTraversalsEnabled) traversalsRatio = (double)Parameters.TraversalsRatio / 100.0;
-    	else traversalsRatio = 0;
-    	if(Parameters.structureModificationEnabled)
-    		structuralModificationsRatio = (double)Parameters.StructuralModificationsRatio / 100.0;
-    	else structuralModificationsRatio = 0;
+		ThreadFactory.setInstance(synchMethodInitializer.createThreadFactory());
+	}
 
-    	double readOnlyOperationsRatio = (double)Parameters.workloadType.readOnlyOperationsRatio / 100.0,
-    	updateOperationsRatio = 1.0 - readOnlyOperationsRatio;
+	private void printRunTimeParametersInformation() {
+		printSection("Benchmark parameters");
 
-    	double sumRatios = traversalsRatio + shortTraversalsRatio + operationsRatio + 
-    		structuralModificationsRatio * updateOperationsRatio;
-    	traversalsRatio /= sumRatios;
-    	shortTraversalsRatio /= sumRatios;
-    	operationsRatio /= sumRatios;
-    	structuralModificationsRatio /= sumRatios;
-    	
+		System.out.println("Number of threads: " + Parameters.numThreads + "\n" +
+				"Length: " + Parameters.numSeconds + " s\n" +
+				"Workload: " + Parameters.workloadType + "\n" +
+				"Synchronization method: " + Parameters.synchronizationType + "\n" +
+				"Long traversals " + (Parameters.longTraversalsEnabled ? "enabled" : "disabled") + "\n" +
+				"Structural modification operations " +
+				(Parameters.structureModificationEnabled ? "enabled" : "disabled") + "\n" +
+				"DesignObjFactory: " + DesignObjFactory.instance.getClass().getName() + "\n" +
+				"BackendFactory: " + BackendFactory.instance.getClass().getName() + "\n" +
+				"OperationExecutorFactory: " +
+				OperationExecutorFactory.instance.getClass().getName() + "\n" +
+				"ThreadFactory: " + ThreadFactory.instance.getClass().getName() + "\n" +
+				"Sequential replay " + (Parameters.sequentialReplayEnabled ? "enabled" : "disabled"));
+
+		System.out.print("STM-specific parameters:");
+		if(Parameters.stmCommandLineParameters == null) System.out.print(" none");
+		else for(String parameter : Parameters.stmCommandLineParameters)
+			System.out.print(" " + parameter);
+		System.out.println("\n");
+	}
+
+	private void generateOperationCDF() {
+		double shortTraversalsRatio = (double)Parameters.ShortTraversalsRatio / 100.0,
+				operationsRatio = (double)Parameters.OperationsRatio / 100.0;
+
+		double traversalsRatio, structuralModificationsRatio;
+		if(Parameters.longTraversalsEnabled) traversalsRatio = (double)Parameters.TraversalsRatio / 100.0;
+		else traversalsRatio = 0;
+		if(Parameters.structureModificationEnabled)
+			structuralModificationsRatio = (double)Parameters.StructuralModificationsRatio / 100.0;
+		else structuralModificationsRatio = 0;
+
+		double readOnlyOperationsRatio = (double)Parameters.workloadType.readOnlyOperationsRatio / 100.0,
+				updateOperationsRatio = 1.0 - readOnlyOperationsRatio;
+
+		double sumRatios = traversalsRatio + shortTraversalsRatio + operationsRatio +
+				structuralModificationsRatio * updateOperationsRatio;
+		traversalsRatio /= sumRatios;
+		shortTraversalsRatio /= sumRatios;
+		operationsRatio /= sumRatios;
+		structuralModificationsRatio /= sumRatios;
+
 		for (OperationType type : OperationType.values()) type.count = 0;
-    	OperationId[] operations = OperationId.values();
-    	for(OperationId operation : operations) operation.getType().count++;
-    	
-       	OperationType.TRAVERSAL.probability = 
-       		traversalsRatio * updateOperationsRatio / OperationType.TRAVERSAL.count;
-    	OperationType.TRAVERSAL_RO.probability = 
-    		traversalsRatio * readOnlyOperationsRatio / OperationType.TRAVERSAL_RO.count;
-    	OperationType.SHORT_TRAVERSAL.probability = 
-    		shortTraversalsRatio * updateOperationsRatio / OperationType.SHORT_TRAVERSAL.count;
-    	OperationType.SHORT_TRAVERSAL_RO.probability = 
-    		shortTraversalsRatio * readOnlyOperationsRatio / OperationType.SHORT_TRAVERSAL_RO.count;
-    	OperationType.OPERATION.probability = 
-    		operationsRatio * updateOperationsRatio / OperationType.OPERATION.count;
-    	OperationType.OPERATION_RO.probability = 
-    		operationsRatio * readOnlyOperationsRatio / OperationType.OPERATION_RO.count;
-    	OperationType.STRUCTURAL_MODIFICATION.probability = 
-    		structuralModificationsRatio * updateOperationsRatio / OperationType.STRUCTURAL_MODIFICATION.count;
-    	
-    	System.out.println("Operation ratios [%]:");
-    	for(OperationType type : OperationType.values())
-    		System.out.println(alignText(type.toString(), 23) + ": " + 
-    				formatDouble(type.probability * type.count * 100));
-    	System.out.println();
-    	
-    	double[] operationProbabilities = new double[operations.length];
-    	for(OperationId operation : operations) {
-    		double operationProbability = operation.getType().probability;
-    		operationProbabilities[operation.ordinal()] = operationProbability;
-    	}
-    	
-    	operationCDF = new double[operations.length];
-    	double prevProbValue = 0;
-    	for(int opNum = 0; opNum < operations.length; opNum++) {
-    		operationCDF[opNum] = prevProbValue + operationProbabilities[opNum];
-    		prevProbValue = operationCDF[opNum];
-    	}
-    	operationCDF[operations.length - 1] = 1.0; // to avoid rounding errors
-		// System.out.println(Arrays.stream(operationCDF).boxed().collect(java.util.stream.Collectors.toList()));
-    }
-    
-    private void setupStructures() throws InterruptedException {
-    	System.err.println("Setup start...");
-     	setup = new Setup();    			
-    	
-    	benchThreads = new BenchThread[Parameters.numThreads];
-    	threads = new Thread[Parameters.numThreads];
-    	for(short threadNum = 0; threadNum < Parameters.numThreads; threadNum++) {
-    		benchThreads[threadNum] = 
-    			new BenchThread(setup, operationCDF, threadNum, countOfOperations);
-    		threads[threadNum] = ThreadFactory.instance.createThread(benchThreads[threadNum]);
-    	}
-    	System.err.println("Setup completed.");
-    }
+		OperationId[] operations = OperationId.values();
+		for(OperationId operation : operations) operation.getType().count++;
 
-    private void checkInvariants(boolean initial) throws InterruptedException {
-    	if(initial) System.err.println("Checking invariants (initial data structure):");
-    	else System.err.println("Checking invariants (final data structure):");
+		OperationType.TRAVERSAL.probability =
+				traversalsRatio * updateOperationsRatio / OperationType.TRAVERSAL.count;
+		OperationType.TRAVERSAL_RO.probability =
+				traversalsRatio * readOnlyOperationsRatio / OperationType.TRAVERSAL_RO.count;
+		OperationType.SHORT_TRAVERSAL.probability =
+				shortTraversalsRatio * updateOperationsRatio / OperationType.SHORT_TRAVERSAL.count;
+		OperationType.SHORT_TRAVERSAL_RO.probability =
+				shortTraversalsRatio * readOnlyOperationsRatio / OperationType.SHORT_TRAVERSAL_RO.count;
+		OperationType.OPERATION.probability =
+				operationsRatio * updateOperationsRatio / OperationType.OPERATION.count;
+		OperationType.OPERATION_RO.probability =
+				operationsRatio * readOnlyOperationsRatio / OperationType.OPERATION_RO.count;
+		OperationType.STRUCTURAL_MODIFICATION.probability =
+				structuralModificationsRatio * updateOperationsRatio / OperationType.STRUCTURAL_MODIFICATION.count;
 
-    	Operation checkInvariantsOperation = 
-    		new CheckInvariantsOperation(setup, initial);
+		System.out.println("Operation ratios [%]:");
+		for(OperationType type : OperationType.values())
+			System.out.println(alignText(type.toString(), 23) + ": " +
+					formatDouble(type.probability * type.count * 100));
+		System.out.println();
+
+		double[] operationProbabilities = new double[operations.length];
+		for(OperationId operation : operations) {
+			double operationProbability = operation.getType().probability;
+			operationProbabilities[operation.ordinal()] = operationProbability;
+		}
+
+		operationCDF = new double[operations.length];
+		double prevProbValue = 0;
+		for(int opNum = 0; opNum < operations.length; opNum++) {
+			operationCDF[opNum] = prevProbValue + operationProbabilities[opNum];
+			prevProbValue = operationCDF[opNum];
+		}
+		operationCDF[operations.length - 1] = 1.0; // to avoid rounding errors
+	}
+
+	private void setupStructures() throws InterruptedException {
+		System.err.println("Setup start...");
+		setup = new Setup();
+
+		benchThreads = new BenchThread[Parameters.numThreads];
+		threads = new Thread[Parameters.numThreads];
+		for(short threadNum = 0; threadNum < Parameters.numThreads; threadNum++) {
+			benchThreads[threadNum] =
+					new BenchThread(setup, operationCDF, threadNum, countOfOperations);
+			threads[threadNum] = ThreadFactory.instance.createThread(benchThreads[threadNum]);
+		}
+		System.err.println("Setup completed.");
+	}
+
+	public void checkInvariants(boolean initial) throws InterruptedException {
+		if(initial) System.err.println("Checking invariants (initial data structure):");
+		else System.err.println("Checking invariants (final data structure):");
+
+		Operation checkInvariantsOperation =
+				new CheckInvariantsOperation(setup, initial);
 		OperationExecutorFactory.executeSequentialOperation(checkInvariantsOperation);
-    }
-    
-    private void createInitialClone() throws InterruptedException {
-    	if(! Parameters.sequentialReplayEnabled) return;
-    	
-    	System.err.println("Cloning the initial data structure...");
-    	ThreadRandom.reset();
-    	setFactoryInstances(new NoSynchronizationInitializer());
-   		setupClone = new Setup();
-   		setFactoryInstances(synchMethodInitializer);
-    	System.err.println("Cloning completed.");  
-    	
-    	System.err.println("Checking if the clone is the same as the data structure...");
-    	StructureComparisonOperation structureComparisonOperation = 
-    		new StructureComparisonOperation(setup, setupClone);
-    	OperationExecutorFactory.executeSequentialOperation(structureComparisonOperation);
-    	System.err.println("Check OK.");    	
-    }
-    
-    private void start() throws InterruptedException {
-    	System.err.println("\nBenchmark started.");
-    	ThreadRandom.startConcurrentPhase();
-    	
-    	long startTime = System.currentTimeMillis();
+	}
 
-    	for(Thread thread : threads) thread.start();
+	/**
+	 * Validate invariants and return result with success/failure status.
+	 * This is the preferred method for Renaissance integration.
+	 *
+	 * @param initial true if checking initial state, false for post-benchmark state
+	 * @return Result containing validation status
+	 */
+	public Result validateInvariants(boolean initial) throws InterruptedException {
+		Result currentResult = computeResult();
 
-			// Renaissance: we require the threads to execute the specified number of operations.
-   		// Thread.sleep(Parameters.numSeconds * 1000);
-   		// for(BenchThread thread : benchThreads) thread.stopThread();
+		try {
+			if(initial) System.err.println("Checking invariants (initial data structure):");
+			else System.err.println("Checking invariants (final data structure):");
 
-   		for(Thread thread : threads) thread.join();
+			Operation checkInvariantsOperation =
+					new CheckInvariantsOperation(setup, initial);
+			OperationExecutorFactory.executeSequentialOperation(checkInvariantsOperation);
 
-    	long endTime = System.currentTimeMillis();
-    	elapsedTime = ((double)(endTime - startTime)) / 1000.0;
-    	System.err.println("Benchmark completed.\n");
-    }
+			// Invariants passed
+			return new Result(
+					currentResult.successfulOperations,
+					currentResult.failedOperations,
+					currentResult.elapsedTime,
+					true,
+					null
+			);
+		} catch (Exception e) {
+			// Invariants failed
+			return new Result(
+					currentResult.successfulOperations,
+					currentResult.failedOperations,
+					currentResult.elapsedTime,
+					false,
+					e.getMessage()
+			);
+		}
+	}
 
-    private void checkOpacity() throws InterruptedException {
-    	if(! Parameters.sequentialReplayEnabled) return;
-    	
-    	System.err.println("\nReplaying the execution in a single thread...");
+	public void createInitialClone() throws InterruptedException {
+		if(! Parameters.sequentialReplayEnabled) return;
 
-    	ArrayList<BenchThread.ReplayLogEntry> replayLog = new ArrayList<BenchThread.ReplayLogEntry>();
-    	for(BenchThread thread : benchThreads)
-    		replayLog.addAll(thread.replayLog);
-    	BenchThread.ReplayLogEntry[] replayLogArray = replayLog.toArray(new BenchThread.ReplayLogEntry[0]);
-    	Arrays.sort(replayLogArray);
-    	replayLog = new ArrayList<BenchThread.ReplayLogEntry>();
-    	for(BenchThread.ReplayLogEntry entry : replayLogArray) replayLog.add(entry);
-    	replayLogArray = null;
-    	    	
-    	setFactoryInstances(new NoSynchronizationInitializer());
-    	ThreadRandom.startSequentialReplayPhase();
-    	SequentialReplayThread seqThread = new SequentialReplayThread(setupClone, 
-    			operationCDF, replayLog);
-    	seqThread.run();
-    	setFactoryInstances(synchMethodInitializer);
-    	
-    	StructureComparisonOperation structureComparisonOperation = 
-    		new StructureComparisonOperation(setup, setupClone);
-    	OperationExecutorFactory.executeSequentialOperation(structureComparisonOperation);
-    	System.err.println("\nOpacity ensured.\n");
-    }
-    
-    private void showTTCHistograms() {
-    	if(! printTTCHistograms) return;
-    	
-    	printSection("TTC histograms");
-    	
-    	OperationId[] operations = OperationId.values();
-    	for(OperationId operation : operations) {
-    		System.out.print("TTC histogram for " + operation + ":");
-    		
-    		for(int ttc = 0; ttc <= Parameters.MAX_LOW_TTC; ttc++) {
-        		int count = 0;
-        		for(BenchThread thread : benchThreads) 
-        			count += thread.operationsTTC[operation.ordinal()][ttc];
-        		
-        		System.out.print(" " + ttc + "," + count);
-    		}
-    		
-    		for(int logTtcIndex = 0; logTtcIndex < Parameters.HIGH_TTC_ENTRIES; logTtcIndex++) {
-    			int count = 0;
-    			for(BenchThread thread : benchThreads)
-    				count += thread.operationsHighTTCLog[operation.ordinal()][logTtcIndex];
-    			
-    			int ttc = logTtcIndex2Ttc(logTtcIndex);
-    			System.out.print(" " + ttc + "," + count);
-    		}
-    		
-    		System.out.println();
-    	}
-    	System.out.println();
-    }
-    
-    private int logTtcIndex2Ttc(double logTtcIndex) {
-    	return (int)((Parameters.MAX_LOW_TTC + 1) * Math.pow(Parameters.HIGH_TTC_LOG_BASE, logTtcIndex));
-    }
-    
-    private void showStats() {
-    	printSection("Detailed results");
-    	
-    	OperationId[] operations = OperationId.values();
-    	for(OperationId operation : operations) {
-    		System.out.print("Operation " + alignText(operation.toString(), 4) + ":   ");
-    		
-    		int opNumber = operation.ordinal();
-    		int successful = 0, failed = 0, maxttc = 0;
-    		for(BenchThread thread : benchThreads) {
-    			successful += thread.successfulOperations[opNumber];
-    			failed += thread.failedOperations[opNumber];
-    			maxttc = Math.max(maxttc, computeMaxThreadTTC(thread, opNumber));
-    		}
-    		
-    		System.out.println("successful = " + successful + "\tmaxttc = " + maxttc + "\tfailed = " + failed);
-    		
-    		OperationType operationType = operation.getType();
-    		operationType.successfulOperations += successful;
-    		operationType.failedOperations += failed;
-    		operationType.maxttc = Math.max(operationType.maxttc, maxttc);
-    	}
-    	System.out.println();
+		System.err.println("Cloning the initial data structure...");
+		ThreadRandom.reset();
+		setFactoryInstances(new NoSynchronizationInitializer());
+		setupClone = new Setup();
+		setFactoryInstances(synchMethodInitializer);
+		System.err.println("Cloning completed.");
 
-    	printSection("Sample errors (operation ratios [%])");
+		System.err.println("Checking if the clone is the same as the data structure...");
+		StructureComparisonOperation structureComparisonOperation =
+				new StructureComparisonOperation(setup, setupClone);
+		OperationExecutorFactory.executeSequentialOperation(structureComparisonOperation);
+		System.err.println("Check OK.");
+	}
 
-    	int totalSuccessful = 0, totalFailed = 0;
-    	for(OperationType type : OperationType.values()) {
-    		totalSuccessful += type.successfulOperations;
-    		totalFailed += type.failedOperations;
-    	}
+	private ArrayList<BenchThread.ReplayLogEntry> collectSortedReplayLog() {
+		ArrayList<BenchThread.ReplayLogEntry> replayLog = new ArrayList<>();
+		for (BenchThread thread : benchThreads)
+			replayLog.addAll(thread.replayLog);
+		Collections.sort(replayLog);
+		return replayLog;
+	}
 
-    	double totalError = 0, totalTError = 0;
-    	for(OperationType type : OperationType.values()) {
-    		double expectedRatio = type.probability * type.count * 100.0;
-    		double realRatio = (double)type.successfulOperations / (double)totalSuccessful * 100.0; 
-    		double error = Math.abs(realRatio - expectedRatio);
-    		double tRealRatio = (double)(type.successfulOperations + type.failedOperations) /
-    			(double)(totalSuccessful + totalFailed) * 100.0;
-    		double tError = Math.abs(tRealRatio - expectedRatio);
-    		System.out.println(alignText(type.toString(), 23) + ":  " + 
-    				"expected = " + formatDouble(expectedRatio) +
-    				"\tsuccessful = " + formatDouble(realRatio) +
-    				"\terror = " + formatDouble(error) +
-    				"\t(total = " + formatDouble(tRealRatio) +
-    				"\terror = " + formatDouble(tError) + ")");
-    		totalError += error;
-    		totalTError += tError;
-    	}
-    	System.out.println();
-    	
-    	printSection("Summary results");
-    	
-    	int total = totalSuccessful + totalFailed;
-    	for(OperationType type : OperationType.values()) {
-    		int totalTypeOperations = type.successfulOperations + type.failedOperations;
-    		System.out.println(alignText(type.toString(), 23) + ":  " +
-    				"successful = " + type.successfulOperations + 
-    				"\tmaxttc = " + type.maxttc +
-    				"\tfailed = " + type.failedOperations +
-    				"\ttotal = " + totalTypeOperations);
-    	}
-    	System.out.println();
-    	
-    	System.out.println("Total sample error: " + formatDouble(totalError) + "%" +
-    			" (" + formatDouble(totalTError) + "% including failed)");
-    	System.out.println("Total throughput: " + formatDouble( (double)totalSuccessful / elapsedTime ) + " op/s" +
-    			" (" + formatDouble( (double)total / elapsedTime ) + " op/s including failed)");
-    	System.out.println("Elapsed time: " + formatDouble(elapsedTime) + " s");
-    }
+	/**
+	 * Check opacity by replaying operations sequentially and comparing results.
+	 * Requires sequentialReplayEnabled to be true and createInitialClone() to be called first.
+	 *
+	 * @return true if opacity check passed, false otherwise
+	 */
+	public boolean checkOpacity() throws InterruptedException {
+		if (!Parameters.sequentialReplayEnabled) {
+			System.err.println("Sequential replay not enabled, skipping opacity check.");
+			return true;
+		}
 
-    private int computeMaxThreadTTC(BenchThread thread, int opNumber) {
-    	for(int logTtcIndex = Parameters.HIGH_TTC_ENTRIES - 1; logTtcIndex >= 0; logTtcIndex--) {
-    		if(thread.operationsHighTTCLog[opNumber][logTtcIndex] > 0)
-    			return logTtcIndex2Ttc(logTtcIndex);
-    	}
-    	
-    	for(int ttc = Parameters.MAX_LOW_TTC; ttc >= 0; ttc--) {
-    		if(thread.operationsTTC[opNumber][ttc] > 0) return ttc;
-    	}
-    	
-    	return 0; // operation never completed with success
-    }
-    
-    private void printSyntax() {
-    	String syntax = 
-    		"Syntax:\n" +
-    		"java stmbench7.Benchmark [options] [-- stm-specific options]\n\n" +
-    		"Options:\n" +
-    		"\t-t numThreads -- set the number of threads (default: 1)\n" +
-    		"\t-l length     -- set the length of the benchmark, in seconds (default: 10)\n" +
-    		"\t-c count      -- set the length of the benchmark, in operations\n" +
-    		"\t-w r|rw|w     -- set the workload: r = read-dominated, w = write-dominated\n" +
-    		"\t                                   rw = read-write (default: read-dominated)\n" +
-    		"\t-g coarse|medium|fine|none|stm -- set synchronization method (default: coarse)\n" +
-    		"\t-s stmInitializerClass         -- set STM initializer class (default: none)\n" +
-    		"\t--no-traversals  -- do not use long traversals\n" +
-    		"\t--no-sms         -- do not use structural modification operations\n" +
-    		"\t--seq-replay 	-- replay the execution in a single thread\n" +
-    		"\t                    (checks for opacity violations)\n" +
-    		"\t--ttc-histograms -- print TTC histograms to stdout\n\n" +
-    		"Note: the benchmark needs a lot of lot of memory, so the -Xmx option of Java\n" +
-    		"might be necessary.";
+		if (setupClone == null) {
+			System.err.println("Initial clone not created, cannot check opacity. Call createInitialClone() first.");
+			return false;
+		}
+
+		try {
+			System.err.println("\nReplaying the execution in a single thread...");
+
+			ArrayList<BenchThread.ReplayLogEntry> replayLog = collectSortedReplayLog();
+
+			setFactoryInstances(new NoSynchronizationInitializer());
+			ThreadRandom.startSequentialReplayPhase();
+			SequentialReplayThread seqThread = new SequentialReplayThread(setupClone,
+					operationCDF, replayLog);
+			seqThread.run();
+			setFactoryInstances(synchMethodInitializer);
+
+			StructureComparisonOperation structureComparisonOperation =
+					new StructureComparisonOperation(setup, setupClone);
+			OperationExecutorFactory.executeSequentialOperation(structureComparisonOperation);
+			return true;
+		} catch (Exception e) {
+			System.err.println("\nOpacity check failed: " + e.getMessage());
+			return false;
+		}
+	}
+
+	public void showTTCHistograms() {
+		if(! printTTCHistograms) return;
+
+		printSection("TTC histograms");
+
+		OperationId[] operations = OperationId.values();
+		for(OperationId operation : operations) {
+			System.out.print("TTC histogram for " + operation + ":");
+
+			for(int ttc = 0; ttc <= Parameters.MAX_LOW_TTC; ttc++) {
+				int count = 0;
+				for(BenchThread thread : benchThreads)
+					count += thread.operationsTTC[operation.ordinal()][ttc];
+
+				System.out.print(" " + ttc + "," + count);
+			}
+
+			for(int logTtcIndex = 0; logTtcIndex < Parameters.HIGH_TTC_ENTRIES; logTtcIndex++) {
+				int count = 0;
+				for(BenchThread thread : benchThreads)
+					count += thread.operationsHighTTCLog[operation.ordinal()][logTtcIndex];
+
+				int ttc = logTtcIndex2Ttc(logTtcIndex);
+				System.out.print(" " + ttc + "," + count);
+			}
+
+			System.out.println();
+		}
+		System.out.println();
+	}
+
+	private int logTtcIndex2Ttc(double logTtcIndex) {
+		return (int)((Parameters.MAX_LOW_TTC + 1) * Math.pow(Parameters.HIGH_TTC_LOG_BASE, logTtcIndex));
+	}
+
+	public void showStats() {
+		printSection("Detailed results");
+
+		OperationId[] operations = OperationId.values();
+		for(OperationId operation : operations) {
+			System.out.print("Operation " + alignText(operation.toString(), 4) + ":   ");
+
+			int opNumber = operation.ordinal();
+			int successful = 0, failed = 0, maxttc = 0;
+			for(BenchThread thread : benchThreads) {
+				successful += thread.successfulOperations[opNumber];
+				failed += thread.failedOperations[opNumber];
+				maxttc = Math.max(maxttc, computeMaxThreadTTC(thread, opNumber));
+			}
+
+			System.out.println("successful = " + successful + "\tmaxttc = " + maxttc + "\tfailed = " + failed);
+
+			OperationType operationType = operation.getType();
+			operationType.successfulOperations += successful;
+			operationType.failedOperations += failed;
+			operationType.maxttc = Math.max(operationType.maxttc, maxttc);
+		}
+		System.out.println();
+
+		printSection("Sample errors (operation ratios [%])");
+
+		int totalSuccessful = 0, totalFailed = 0;
+		for(OperationType type : OperationType.values()) {
+			totalSuccessful += type.successfulOperations;
+			totalFailed += type.failedOperations;
+		}
+
+		double totalError = 0, totalTError = 0;
+		for(OperationType type : OperationType.values()) {
+			double expectedRatio = type.probability * type.count * 100.0;
+			double realRatio = (double)type.successfulOperations / (double)totalSuccessful * 100.0;
+			double error = Math.abs(realRatio - expectedRatio);
+			double tRealRatio = (double)(type.successfulOperations + type.failedOperations) /
+					(double)(totalSuccessful + totalFailed) * 100.0;
+			double tError = Math.abs(tRealRatio - expectedRatio);
+			System.out.println(alignText(type.toString(), 23) + ":  " +
+					"expected = " + formatDouble(expectedRatio) +
+					"\tsuccessful = " + formatDouble(realRatio) +
+					"\terror = " + formatDouble(error) +
+					"\t(total = " + formatDouble(tRealRatio) +
+					"\terror = " + formatDouble(tError) + ")");
+			totalError += error;
+			totalTError += tError;
+		}
+		System.out.println();
+
+		printSection("Summary results");
+
+		int total = totalSuccessful + totalFailed;
+		for(OperationType type : OperationType.values()) {
+			int totalTypeOperations = type.successfulOperations + type.failedOperations;
+			System.out.println(alignText(type.toString(), 23) + ":  " +
+					"successful = " + type.successfulOperations +
+					"\tmaxttc = " + type.maxttc +
+					"\tfailed = " + type.failedOperations +
+					"\ttotal = " + totalTypeOperations);
+		}
+		System.out.println();
+
+		System.out.println("Total sample error: " + formatDouble(totalError) + "%" +
+				" (" + formatDouble(totalTError) + "% including failed)");
+		System.out.println("Total throughput: " + formatDouble( (double)totalSuccessful / elapsedTime ) + " op/s" +
+				" (" + formatDouble( (double)total / elapsedTime ) + " op/s including failed)");
+		System.out.println("Elapsed time: " + formatDouble(elapsedTime) + " s");
+	}
+
+	private int computeMaxThreadTTC(BenchThread thread, int opNumber) {
+		for(int logTtcIndex = Parameters.HIGH_TTC_ENTRIES - 1; logTtcIndex >= 0; logTtcIndex--) {
+			if(thread.operationsHighTTCLog[opNumber][logTtcIndex] > 0)
+				return logTtcIndex2Ttc(logTtcIndex);
+		}
+
+		for(int ttc = Parameters.MAX_LOW_TTC; ttc >= 0; ttc--) {
+			if(thread.operationsTTC[opNumber][ttc] > 0) return ttc;
+		}
+
+		return 0; // operation never completed with success
+	}
+
+	private void printSyntax() {
+		String syntax =
+				"Syntax:\n" +
+						"java stmbench7.Benchmark [options] [-- stm-specific options]\n\n" +
+						"Options:\n" +
+						"\t-t numThreads -- set the number of threads (default: 1)\n" +
+						"\t-l length     -- set the length of the benchmark, in seconds (default: 10)\n" +
+						"\t-c count      -- set the length of the benchmark, in operations\n" +
+						"\t-w r|rw|w     -- set the workload: r = read-dominated, w = write-dominated\n" +
+						"\t                                   rw = read-write (default: read-dominated)\n" +
+						"\t-g coarse|medium|fine|none|stm -- set synchronization method (default: coarse)\n" +
+						"\t-s stmInitializerClass         -- set STM initializer class (default: none)\n" +
+						"\t--no-traversals  -- do not use long traversals\n" +
+						"\t--no-sms         -- do not use structural modification operations\n" +
+						"\t--seq-replay     -- replay the execution in a single thread\n" +
+						"\t                    (checks for opacity violations)\n" +
+						"\t--ttc-histograms -- print TTC histograms to stdout\n\n" +
+						"Note: the benchmark needs a lot of lot of memory, so the -Xmx option of Java\n" +
+						"might be necessary.";
 		System.err.println(syntax);
-    }
-    
-    private void printSection(String title) {
-    	printLine('-');
-    	System.out.println(title);
-    	printLine('-');
-    }
-    
-    private void printLine(char ch) {
-    	StringBuffer line = new StringBuffer(79);
-    	for(int i = 0; i < 79; i++) line.append(ch);
-    	System.out.println(line);
-    }
-    
-    private String alignText(String text, int width) {
-    	int textLen = text.length();
-    	int padding = width - textLen;
-    	if(padding < 0) throw new RuntimeError("alignText: width too small!");
-    	
-    	StringBuffer output = new StringBuffer(width);
-    	for(int i = 0; i < padding; i++) output.append(' ');
-    	output.append(text);
-    	
-    	return output.toString();
-    }
-    
-    private String formatDouble(double number) {
-    	Formatter formatter = new Formatter();
-    	formatter.format("%3.2f", number);
-    	return formatter.toString();
-    }
-}
+	}
 
+	private void printSection(String title) {
+		printLine('-');
+		System.out.println(title);
+		printLine('-');
+	}
+
+	private void printLine(char ch) {
+		StringBuffer line = new StringBuffer(79);
+		for(int i = 0; i < 79; i++) line.append(ch);
+		System.out.println(line);
+	}
+
+	private String alignText(String text, int width) {
+		int textLen = text.length();
+		int padding = width - textLen;
+		if(padding < 0) throw new RuntimeError("alignText: width too small!");
+
+		StringBuffer output = new StringBuffer(width);
+		for(int i = 0; i < padding; i++) output.append(' ');
+		output.append(text);
+
+		return output.toString();
+	}
+
+	private String formatDouble(double number) {
+		Formatter formatter = new Formatter();
+		formatter.format("%3.2f", number);
+		return formatter.toString();
+	}
+}

--- a/benchmarks/scala-stm/stmbench7/src/main/java/stmbench7/OperationExecutorFactory.java
+++ b/benchmarks/scala-stm/stmbench7/src/main/java/stmbench7/OperationExecutorFactory.java
@@ -22,9 +22,10 @@ public abstract class OperationExecutorFactory {
 	public abstract OperationExecutor createOperationExecutor(Operation op);
 	
 	public static void executeSequentialOperation(final Operation op) throws InterruptedException {
+		final Throwable[] threadError = new Throwable[1];
 		Thread opThread = ThreadFactory.instance.createThread(new Runnable() {
 			public void run() {
-				OperationExecutor operationExecutor = 
+				OperationExecutor operationExecutor =
 					instance.createOperationExecutor(op);
 				try {
 					operationExecutor.execute();
@@ -32,10 +33,19 @@ public abstract class OperationExecutorFactory {
 				catch(OperationFailedException e) {
 					throw new RuntimeError("Unexpected failure of a sequential operation " + op);
 				}
-				
+			}
+		});
+		opThread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+			public void uncaughtException(Thread t, Throwable e) {
+				threadError[0] = e;
 			}
 		});
 		opThread.start();
 		opThread.join();
+		if (threadError[0] != null) {
+			if (threadError[0] instanceof RuntimeError)
+				throw (RuntimeError) threadError[0];
+			throw new RuntimeError("Sequential operation failed: " + op, threadError[0]);
+		}
 	}
 }

--- a/benchmarks/scala-stm/stmbench7/src/main/java/stmbench7/ThreadRandom.java
+++ b/benchmarks/scala-stm/stmbench7/src/main/java/stmbench7/ThreadRandom.java
@@ -1,7 +1,5 @@
 package stmbench7;
 
-import java.util.Random;
-
 import stmbench7.annotations.Immutable;
 import stmbench7.core.RuntimeError;
 
@@ -22,36 +20,64 @@ public class ThreadRandom {
 		SEQUENTIAL_REPLAY
 	}
 	
-	private static class CloneableRandom extends Random implements Cloneable {
-		public static final long serialVersionUID = 1L;
-		
+	// Custom LCG matching java.util.Random's algorithm. Uses a primitive long
+	// for state so that Object.clone() performs a true value copy - unlike
+	// java.util.Random whose AtomicLong seed is shared across shallow clones,
+	// which would silently prevent restoreState() from working during STM retries.
+	private static class CloneableRandom implements Cloneable {
+		private static final long multiplier = 0x5DEECE66DL;
+		private static final long addend     = 0xBL;
+		private static final long mask       = (1L << 48) - 1;
+
+		private long seed;
+
 		public CloneableRandom(long seed) {
-			super(seed);
+			this.seed = (seed ^ multiplier) & mask;
 		}
-		
+
+		private int next(int bits) {
+			seed = (seed * multiplier + addend) & mask;
+			return (int)(seed >>> (48 - bits));
+		}
+
+		public int nextInt(int n) {
+			if ((n & -n) == n) return (int)((n * (long)next(31)) >> 31);
+			int bits, val;
+			do {
+				bits = next(31);
+				val  = bits % n;
+			} while (bits - val + (n - 1) < 0);
+			return val;
+		}
+
+		public double nextDouble() {
+			return (((long)(next(26)) << 27) + next(27)) / (double)(1L << 53);
+		}
+
 		@Override
 		public CloneableRandom clone() {
 			try {
-				return (CloneableRandom) super.clone();
+				return (CloneableRandom) super.clone(); // seed is a long primitive -> deep copy
 			}
 			catch(CloneNotSupportedException e) {
 				throw new RuntimeException(e);
 			}
-		}		
+		}
 	}
 	
 	private static class RandomState {
 		private CloneableRandom currentState, savedState;
-		
+		public long callCount = 0;
+
 		public RandomState() {
 			currentState = new CloneableRandom(3);
 			savedState = null;
 		}
-		
+
 		public void saveState() {
 			savedState = currentState.clone();
 		}
-		
+
 		public void restoreState() {
 			currentState = savedState;
 		}
@@ -73,17 +99,19 @@ public class ThreadRandom {
 	};
 	
 	public static int nextInt(int n) {
-		int k = getCurrentRandom().currentState.nextInt(n);
-		//if(phase != Phase.INIT) 
-		//	System.out.println("int " + n + " = " + k + " " + getCurrentRandom().currentState);
-		return k;
+		RandomState rs = getCurrentRandom();
+		rs.callCount++;
+		return rs.currentState.nextInt(n);
 	}
-	
+
 	public static double nextDouble() {
-		double k = getCurrentRandom().currentState.nextDouble();
-		//if(phase != Phase.INIT) 
-		//	System.out.println("double = " + k + " " + getCurrentRandom().currentState);
-		return k;
+		RandomState rs = getCurrentRandom();
+		rs.callCount++;
+		return rs.currentState.nextDouble();
+	}
+
+	public static long getCallCount() {
+		return getCurrentRandom().callCount;
 	}
 
 	public static void reset() {

--- a/benchmarks/scala-stm/stmbench7/src/main/java/stmbench7/correctness/opacity/SequentialReplayThread.java
+++ b/benchmarks/scala-stm/stmbench7/src/main/java/stmbench7/correctness/opacity/SequentialReplayThread.java
@@ -22,7 +22,7 @@ public class SequentialReplayThread extends BenchThread {
 
 	public SequentialReplayThread(Setup setup, double[] operationCDF,
 			ArrayList<ReplayLogEntry> replayLog) {
-		super(setup, operationCDF);
+		super(setup, operationCDF, (short) 0, 0);
 		this.replayLog = replayLog;
 	}
 	
@@ -35,15 +35,32 @@ public class SequentialReplayThread extends BenchThread {
 			System.err.print("Operation " + opIndex + " out of " + opCount + "\r");
 			short threadNum = entry.threadNum;
 			ThreadRandom.setVirtualThreadNumber(threadNum);
-			
+
+			long virtualCallCount = ThreadRandom.getCallCount();
+//			if (virtualCallCount != entry.callCountBefore) {
+//				System.err.println("\nCallCount mismatch BEFORE getNextOp at opIndex=" + opIndex +
+//					" thread=" + threadNum +
+//					" virtual=" + virtualCallCount +
+//					" expected=" + entry.callCountBefore +
+//					" diff=" + (virtualCallCount - entry.callCountBefore));
+//			}
+
 			//System.out.println(++i);
 			int operationNumber = getNextOperationNumber(opIndex);
 			opIndex++;
 
 			//System.out.println(entry.threadNum + " -- " + OperationId.values()[entry.opNum] +
 			//	" / " + OperationId.values()[operationNumber]);
-			if(operationNumber != entry.opNum)
+			if(operationNumber != entry.opNum) {
+				System.err.println("\nThreadRandom skew at opIndex=" + (opIndex-1) +
+					" thread=" + threadNum +
+					" expected=" + OperationId.values()[entry.opNum] + "(" + entry.opNum + ")" +
+					" got=" + OperationId.values()[operationNumber] + "(" + operationNumber + ")" +
+					" timestamp=" + entry.timestamp + " failed=" + entry.failed +
+					" callBefore(expected)=" + entry.callCountBefore +
+					" callBefore(actual)=" + virtualCallCount);
 				throw new RuntimeError("ThreadRandom skew");
+			}
 			
 			int result = 0;
 			boolean failed = false;
@@ -56,12 +73,19 @@ public class SequentialReplayThread extends BenchThread {
 				failed = true;
 				ThreadRandom.restoreState();
 			}
-			
+
+			//debug print
+
+//			System.err.println("\nOp " + (opIndex-1) + ": thread=" + threadNum +
+//				" op=" + OperationId.values()[operationNumber] +
+//				" concurrent(result=" + entry.result + ",failed=" + entry.failed + ")" +
+//				" sequential(result=" + result + ",failed=" + failed + ")" +
+//				" callBefore=" + entry.callCountBefore + " ts=" + entry.timestamp);
 			if(result != entry.result || failed != entry.failed) {
 				String opName = OperationId.values()[operationNumber].toString();
 				throw new RuntimeError("Different operation result in the sequential execution (" +
 						"operation " + opName + "): " +
-						"Sequential: result = " + result + ", failed = " + failed + ". " + 
+						"Sequential: result = " + result + ", failed = " + failed + ". " +
 						"Concurrent: result = " + entry.result + ", failed = " + entry.failed + ".");
 			}
 		}

--- a/benchmarks/scala-stm/stmbench7/src/main/java/stmbench7/correctness/opacity/StructureComparisonOperation.java
+++ b/benchmarks/scala-stm/stmbench7/src/main/java/stmbench7/correctness/opacity/StructureComparisonOperation.java
@@ -208,7 +208,9 @@ public class StructureComparisonOperation implements Operation {
 		checkEqual(part1.getY(), part2.getY(), part1, id1, part2, id2, "y");
 		checkReferences(part1.getPartOf(), part2.getPartOf(),
 				part1, id1, part2, id2, "partOf");
-		
+		checkEqual(part1.getPartOf().getId(), part2.getPartOf().getId(),
+				part1, id1, part2, id2, "partOf.id");
+
 		ImmutableCollection<Connection> to1 = part1.getToConnections(),
 			to2 = part2.getToConnections();
 		checkEqual(to1.size(), to2.size(), part1, id1, part2, id2, "to.size()");


### PR DESCRIPTION
## Summary

cc @lbulej

The original `scala-stm-bench7` benchmark invoked STMBench7 via its `main` method, mixing full data-structure initialisation into every measured iteration, and returned `Validators.dummy()`. The STMBench7 codebase contained code paths for structural invariant checking and sequential replay for opacity detection, but five independent bugs made them unreachable or incorrect. This PR fixes all five bugs, switches to a programmatic interface, and enables both validators.

**Problems in the original:**
- `Validators.dummy()` — no result checked whatsoever
- Each call to `run` re-invoked `main`, rebuilding the full assembly hierarchy from scratch and including initialisation cost in the measured time
- **Non-random operation selection:** the random call was commented out and replaced with a deterministic modulo formula, producing a fixed cycling pattern instead of the statistical distribution the spec requires
- **Crashing replay constructor:** `SequentialReplayThread` called a two-argument superclass constructor whose body was a single unconditional `throw` — every instantiation terminated before replay could begin
- **Non-cloneable random state:** the RNG extended `java.util.Random` whose seed is an `AtomicLong`; a shallow clone shared that field between original and copy, so failed transaction retries could not roll back their random consumption, causing the replay sequence to diverge
- **Missing parent identity check:** structural comparison confirmed a non-null parent reference but not that both sides carried the same identifier — two atoms could reference parents with different IDs and the check would pass
- **Swallowed validation exceptions:** the helper thread running invariant checks installed no uncaught exception handler; any `RuntimeError` was consumed by the JVM default handler, the calling thread observed a clean join and continued as if the check had passed

**Redesigned workload:**
- Data structure built once in `setUpBeforeAll` via a dedicated programmatic constructor
- Between iterations a `reset` method recreates thread instances and zeroes per-thread counters while leaving the data structure intact, removing initialisation cost from the timed path
- Random operation selection call restored
- `SequentialReplayThread` constructor fixed to call the correct four-argument superclass constructor
- RNG replaced with a custom linear congruential generator whose state is a primitive `long`; `clone()` produces a genuine independent copy
- Structural comparison extended to verify parent identifier equality
- Helper thread extended with an uncaught exception handler that rethrows any `RuntimeError` in the calling thread after join

**Validation (advanced):**
- **Invariant checking:** after each iteration a sequential traversal verifies structural consistency — every component referenced by an assembly is present, every connection between atomic parts is symmetric, all indices contain exactly the required elements
- **Opacity checking via sequential replay:** before each iteration the data structure is cloned; during the iteration each transactional operation records its identity, result, and an atomically assigned timestamp; after the iteration the per-thread logs are merged, sorted by timestamp, and replayed on the clone — any divergence indicates an opacity violation; the final clone state is also compared structurally against the main structure including parent identifier equality

**Performance comparison (30 independent JVM runs, last 10 steady-state iterations each):**

Measurements were collected on a two-socket Intel Xeon Gold 6230 server (20 cores per socket, 40 physical cores, 48 logical CPUs online, 2.10 GHz base clock). 30 independent JVM invocations were run, each with a 6-minute time budget. The last 10 iterations of each run were taken as steady-state samples, yielding 300 measurements in total.

| | Original | After validation |
|---|---|---|
| Median iteration time | 1 092 ms | 2 056 ms |
| Change | — | ~1.9× slower |

Removing data-structure reinitialisation from the timed path (previously repeated every iteration) made the per-iteration cost initially collapse to a small fraction of the original. However, opacity checking replays every logged operation single-threadedly and performs a full structural comparison after each iteration; that overhead scales with total operations across all threads rather than per-thread work, and does not shrink linearly with `operation_count`. `operation_count` was tuned back up to produce a measured workload comparable to the original, and is still being refined toward full parity.

<img width="1050" height="900" alt="scala_stm_bench7_distribution" src="https://github.com/user-attachments/assets/08b53f83-5778-436b-bd55-331210a41dda" />
<img width="1500" height="750" alt="scala_stm_bench7_histogram" src="https://github.com/user-attachments/assets/ded251ba-46eb-4d22-8e8f-941efdbf9f74" />
<img width="1800" height="750" alt="scala_stm_bench7_median_per_run" src="https://github.com/user-attachments/assets/3d0945f1-d96f-4124-8200-c967719bb611" />
<img width="1800" height="750" alt="scala_stm_bench7_variability" src="https://github.com/user-attachments/assets/b7b69626-e2c9-46be-ae89-e106b4474878" />
